### PR TITLE
[WIP] Updated Chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,118 @@
 [![Travis Status][trav_img]][trav_site]
 
+##TODO: write an actual README!
+
+These are the props
+```
+style: React.PropTypes.node,
+  data: React.PropTypes.oneOfType([ // maybe this should just be "node"
+    React.PropTypes.arrayOf(
+      React.PropTypes.shape({
+        x: React.PropTypes.any,
+        y: React.PropTypes.any
+      })
+    ),
+    React.PropTypes.arrayOf(
+      React.PropTypes.arrayOf(
+        React.PropTypes.shape({
+          x: React.PropTypes.any,
+          y: React.PropTypes.any
+        })
+      )
+    )
+  ]),
+  dataAttributes: React.PropTypes.oneOfType([
+    React.PropTypes.object,
+    React.PropTypes.arrayOf(React.PropTypes.object)
+  ]),
+  x: React.PropTypes.array,
+  y: React.PropTypes.oneOfType([
+    React.PropTypes.array,
+    React.PropTypes.func
+  ]),
+  yAttributes: React.PropTypes.oneOfType([
+    React.PropTypes.object,
+    React.PropTypes.arrayOf(React.PropTypes.object)
+  ]),
+  domain: React.PropTypes.oneOfType([
+    React.PropTypes.array,
+    React.PropTypes.shape({
+      x: React.PropTypes.array,
+      y: React.PropTypes.array
+    })
+  ]),
+  range: React.PropTypes.oneOfType([
+    React.PropTypes.array,
+    React.PropTypes.shape({
+      x: React.PropTypes.arrayOf(React.PropTypes.number),
+      y: React.PropTypes.arrayOf(React.PropTypes.number)
+    })
+  ]),
+  scale: React.PropTypes.oneOfType([
+    React.PropTypes.func,
+    React.PropTypes.shape({
+      x: React.PropTypes.func,
+      y: React.PropTypes.func
+    })
+  ]),
+  samples: React.PropTypes.number,
+  interpolation: React.PropTypes.oneOf([
+    "linear",
+    "linear-closed",
+    "step",
+    "step-before",
+    "step-after",
+    "basis",
+    "basis-open",
+    "basis-closed",
+    "bundle",
+    "cardinal",
+    "cardinal-open",
+    "cardinal-closed",
+    "monotone"
+  ]),
+  axisOrientation: React.PropTypes.shape({
+    x: React.PropTypes.oneOf(["top", "bottom"]),
+    y: React.PropTypes.oneOf(["left", "right"])
+  }),
+  showGridLines: React.PropTypes.shape({
+    x: React.PropTypes.bool,
+    y: React.PropTypes.bool
+  }),
+  tickValues: React.PropTypes.shape({
+    x: React.PropTypes.arrayOf(React.PropTypes.any),
+    y: React.PropTypes.arrayOf(React.PropTypes.any)
+  }),
+  tickFormat: React.PropTypes.shape({
+    x: React.PropTypes.func,
+    y: React.PropTypes.func
+  }),
+  tickCount: React.PropTypes.shape({
+    x: React.PropTypes.number,
+    y: React.PropTypes.number
+  }),
+  axisStyle: React.PropTypes.shape({
+    x: React.PropTypes.node,
+    y: React.PropTypes.node
+  }),
+  tickStyle: React.PropTypes.shape({
+    x: React.PropTypes.node,
+    y: React.PropTypes.node
+  }),
+  gridStyle: React.PropTypes.shape({
+    x: React.PropTypes.node,
+    y: React.PropTypes.node
+  }),
+  animate: React.PropTypes.oneOfType([
+    React.PropTypes.bool,
+    React.PropTypes.shape({
+      line: React.PropTypes.bool,
+      scatter: React.PropTypes.bool,
+      axis: React.PropTypes.bool
+    })
+  ]),
+  containerElement: React.PropTypes.oneOf(["svg", "g"])
+```
 
 Victory Chart
 =============

--- a/demo/app.jsx
+++ b/demo/app.jsx
@@ -20,11 +20,16 @@ class App extends React.Component {
             y={(x) => x}/>
           <VictoryChart
             y={(x) => 3 * x + 0.5}
-            domain={[0, 10]}/>
+            yAttributes={{stroke: "red"}}/>
           <VictoryChart y={[
             (x) => 3 * x + 0.5,
             (x) => 4 * x + 0.5,
             (x) => Math.sin(x)
+          ]}
+          yAttributes={[
+            {stroke: "red"},
+            {stroke: "green"},
+            {stroke: "blue"}
           ]}/>
 
         </p>

--- a/demo/app.jsx
+++ b/demo/app.jsx
@@ -18,7 +18,9 @@ class App extends React.Component {
           <VictoryChart
             data={[{x: 1, y: 5}, {x: 2, y: 3}, {x: 3, y: 4}]}
             y={(x) => x}/>
-          <VictoryChart y={(x) => 3 * x + 0.5}/>
+          <VictoryChart
+            y={(x) => 3 * x + 0.5}
+            domain={[0, 10]}/>
           <VictoryChart y={[
             (x) => 3 * x + 0.5,
             (x) => 4 * x + 0.5,

--- a/demo/app.jsx
+++ b/demo/app.jsx
@@ -17,6 +17,7 @@ class App extends React.Component {
             ]}/>
           <VictoryChart
             data={[{x: 1, y: 5}, {x: 2, y: 3}, {x: 3, y: 4}]}
+            dataAttributes={{type: "scatter", color: "blue"}}
             y={(x) => x}/>
           <VictoryChart
             y={(x) => 3 * x + 0.5}
@@ -27,9 +28,9 @@ class App extends React.Component {
             (x) => Math.sin(x)
           ]}
           yAttributes={[
-            {stroke: "red"},
-            {stroke: "green"},
-            {stroke: "blue"}
+            {name: "line-one", type: "line", stroke: "red", strokeWidth: 5},
+            {name: "line-two", type: "line", stroke: "green"},
+            {name: "line-3", type: "line", stroke: "blue"}
           ]}/>
 
         </p>

--- a/demo/app.jsx
+++ b/demo/app.jsx
@@ -71,7 +71,7 @@ class App extends React.Component {
           <VictoryChart {...this.state}
             data={this.state.lineData}
             showGridLines={{x: false, y: true}}
-            animate={{line: true}}/>
+            animate={true}/>
 
           <VictoryChart interpolation="linear"
             scale={{
@@ -105,7 +105,7 @@ class App extends React.Component {
 
           <VictoryChart
             data={this.state.scatterData}
-            animate={{scatter: true}}
+            animate={{scatter: true, axis: false, line: false}}
             dataAttributes={{type: "scatter"}}
             y={(x) => x}/>
 

--- a/demo/app.jsx
+++ b/demo/app.jsx
@@ -12,25 +12,46 @@ class App extends React.Component {
           <VictoryChart />
           <VictoryChart interpolation="linear"
             data={[
-              [{x: 0, y: 0}, {x: 1, y: 2}, {x: 2, y: 3}, {x: 3, y: 4}],
-              [{x: 0, y: 0}, {x: 1, y: 5}, {x: 4, y: 8}, {x: 5, y: 10}]
+              [{x: -3, y: -2}, {x: 1, y: -1.5}, {x: 2, y: 3}, {x: 3, y: 4}],
+              [{x: 0, y: 0}, {x: 1, y: 5}, {x: 4, y: 8}, {x: 5, y: 6}]
             ]}/>
           <VictoryChart
-            data={[{x: 1, y: 5}, {x: 2, y: 3}, {x: 3, y: 4}]}
-            dataAttributes={{type: "scatter", color: "blue"}}
+          showGridLines={{x: true, y: true}}
+            data={[
+              {x: 1, y: 4, size: 3, symbol: "circle", color: "red"},
+              {x: 2, y: 3, size: 5, symbol: "triangleUp", color: "green"},
+              {x: 4, y: 4, size: 7, symbol: "star"}
+            ]}
+            dataAttributes={{type: "scatter"}}
             y={(x) => x}/>
           <VictoryChart
-            y={(x) => 3 * x + 0.5}
-            yAttributes={{stroke: "red"}}/>
-          <VictoryChart y={[
-            (x) => 3 * x + 0.5,
-            (x) => 4 * x + 0.5,
-            (x) => Math.sin(x)
+          showGridLines={{x: true, y: true}}
+            axisOrientation={{x: "top", y: "right"}}
+            y={[
+              (x) => 0.5 * x + 0.5,
+              (x) => x * x
+            ]}
+            yAttributes={[
+              {stroke: "red"},
+              {type: "scatter"}
+            ]}/>
+          <VictoryChart
+            showGridLines={{x: true, y: true}}
+            axisLabels={{x: "x axis", y: "y axis"}}
+            x={[
+              [1, 2, 3, 4],
+              [-2, -1, 0, 1, 3, 4],
+              [3, 4, 6]
+            ]}
+            y={[
+            [1, 2, 10, 4],
+            (x) => x * x,
+            [-5, -4, -3, -2, 2, 3]
           ]}
           yAttributes={[
-            {name: "line-one", type: "line", stroke: "red", strokeWidth: 5},
+            {name: "line-one", type: "scatter", color: "red", symbol: "triangleUp"},
             {name: "line-two", type: "line", stroke: "green"},
-            {name: "line-3", type: "line", stroke: "blue"}
+            {name: "line-3", type: "scatter", color: "blue"}
           ]}/>
 
         </p>

--- a/demo/app.jsx
+++ b/demo/app.jsx
@@ -1,31 +1,117 @@
-/*global document:false*/
+/*global document:false */
+/*global window:false */
 import React from "react";
+import d3 from "d3";
+import _ from "lodash";
 import {VictoryChart} from "../src/index";
 
 
 class App extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      scatterData: this.getScatterData(),
+      lineData: this.getData(),
+      dataAttributes: {
+        stroke: "blue",
+        strokeWidth: 2
+      }
+    };
+  }
+
+  getData() {
+    return _.map(_.range(20), (i) => {
+      return {
+        x: i,
+        y: Math.random()
+      };
+    });
+  }
+
+  getScatterData() {
+    const colors =
+      ["violet", "cornflowerblue", "gold", "orange", "turquoise", "tomato", "greenyellow"];
+    const symbols = ["circle", "star", "square", "triangleUp", "triangleDown", "diamond", "plus"];
+    // symbol: symbols[scaledIndex],
+    return _.map(_.range(20), (index) => {
+      const scaledIndex = _.floor(index % 7);
+      return {
+        x: _.random(20),
+        y: _.random(20),
+        size: _.random(8) + 3,
+        symbol: symbols[scaledIndex],
+        color: colors[_.random(0, 6)],
+        opacity: _.random(0.3, 1)
+      };
+    });
+  }
+
+  getStyles() {
+    const colors = ["red", "orange", "cyan", "green", "blue", "purple"];
+    return {
+      stroke: colors[_.random(0, 5)],
+      strokeWidth: [_.random(1, 3)]
+    };
+  }
+
+  componentWillMount() {
+    window.setInterval(() => {
+      this.setState({
+        scatterData: this.getScatterData(),
+        lineData: this.getData(),
+        dataAttributes: this.getStyles()
+      });
+    }, 4000);
+  }
 
   render() {
     return (
       <div className="demo">
         <p>
-          <VictoryChart />
+          <VictoryChart {...this.state}
+            data={this.state.lineData}
+            showGridLines={{x: false, y: true}}
+            animate={{line: true}}/>
+
           <VictoryChart interpolation="linear"
+            scale={{
+              x: () => d3.time.scale(),
+              y: () => d3.scale.linear()
+            }}
+            tickValues={{
+              x: [
+                new Date(1980, 1, 1),
+                new Date(1990, 1, 1),
+                new Date(2000, 1, 1),
+                new Date(2010, 1, 1),
+                new Date(2020, 1, 1)
+              ],
+              y: [100, 200, 300, 400, 500]
+            }}
+            tickFormat={{
+              x: () => d3.time.format("%Y"),
+              y: () => d3.scale.linear().tickFormat()
+            }}
             data={[
-              [{x: -3, y: -2}, {x: 1, y: -1.5}, {x: 2, y: 3}, {x: 3, y: 4}],
-              [{x: 0, y: 0}, {x: 1, y: 5}, {x: 4, y: 8}, {x: 5, y: 6}]
+              {x: new Date(1982, 1, 1), y: 125},
+              {x: new Date(1987, 1, 1), y: 257},
+              {x: new Date(1993, 1, 1), y: 345},
+              {x: new Date(1997, 1, 1), y: 515},
+              {x: new Date(2001, 1, 1), y: 132},
+              {x: new Date(2005, 1, 1), y: 305},
+              {x: new Date(2011, 1, 1), y: 270},
+              {x: new Date(2015, 1, 1), y: 470}
             ]}/>
+
           <VictoryChart
-          showGridLines={{x: true, y: true}}
-            data={[
-              {x: 1, y: 4, size: 3, symbol: "circle", color: "red"},
-              {x: 2, y: 3, size: 5, symbol: "triangleUp", color: "green"},
-              {x: 4, y: 4, size: 7, symbol: "star"}
-            ]}
+            data={this.state.scatterData}
+            animate={{scatter: true}}
             dataAttributes={{type: "scatter"}}
             y={(x) => x}/>
+
           <VictoryChart
-          showGridLines={{x: true, y: true}}
+            showGridLines={{x: true, y: true}}
+            samples={20}
             axisOrientation={{x: "top", y: "right"}}
             y={[
               (x) => 0.5 * x + 0.5,
@@ -35,12 +121,13 @@ class App extends React.Component {
               {stroke: "red"},
               {type: "scatter"}
             ]}/>
+
           <VictoryChart
             showGridLines={{x: true, y: true}}
             axisLabels={{x: "x axis", y: "y axis"}}
             x={[
               [1, 2, 3, 4],
-              [-2, -1, 0, 1, 3, 4],
+              [-2, -1, 0, 1, 3],
               [3, 4, 6]
             ]}
             y={[

--- a/demo/app.jsx
+++ b/demo/app.jsx
@@ -3,16 +3,6 @@ import React from "react";
 import {VictoryChart} from "../src/index";
 import _ from "lodash";
 
-const twoLinesData = [
-  _.range(0, 100, 1).map((x) => { return {x, y: Math.sin(x)}; }),
-  _.range(0, 100, 1).map((x) => { return {x, y: Math.sin(x + 5)}; })
-];
-
-const namedData = {
-  lineOne: _.range(0, 100, 1).map((x) => { return {x, y: Math.sin(x)}; }),
-  lineTwo: _.range(0, 100, 1).map((x) => { return {x, y: Math.sin(x + 5)}; }),
-  lineThree: _.range(0, 100, 1).map((x) => { return {x, y: Math.sin(x + 10)}; })
-};
 
 class App extends React.Component {
 
@@ -21,32 +11,21 @@ class App extends React.Component {
       <div className="demo">
         <p>
           <VictoryChart />
-          <VictoryChart y={(x) => Math.sin(x)}/>
-          <VictoryChart
-            y={[
-              (x) => Math.sin(x),
-              (x) => Math.sin(x + 5),
-              (x) => Math.sin(x + 10)
-            ]}
-            sample={25}
-            lineStyles={[
-              {"stroke": "blue"},
-              {"stroke": "red"},
-              {"stroke": "orange"}
+          <VictoryChart interpolation="linear"
+            data={[
+              [{x: 0, y: 0}, {x: 1, y: 2}, {x: 2, y: 3}, {x: 3, y: 4}],
+              [{x: 0, y: 0}, {x: 1, y: 5}, {x: 4, y: 8}, {x: 5, y: 10}]
             ]}/>
           <VictoryChart
-            data={twoLinesData}
-            lineStyles={[
-              {"stroke": "green"},
-              {"stroke": "blue"}
-            ]}/>
-          <VictoryChart
-            data={namedData}
-            lineStyles={{
-              lineOne: {"stroke": "orange"},
-              lineThree: {stroke: "lightblue"},
-              lineTwo: {"stroke": "red"}
-            }}/>
+            data={[{x: 1, y: 5}, {x: 2, y: 3}, {x: 3, y: 4}]}
+            y={(x) => x}/>
+          <VictoryChart y={(x) => 3 * x + 0.5}/>
+          <VictoryChart y={[
+            (x) => 3 * x + 0.5,
+            (x) => 4 * x + 0.5,
+            (x) => Math.sin(x)
+          ]}/>
+
         </p>
       </div>
     );

--- a/demo/app.jsx
+++ b/demo/app.jsx
@@ -1,7 +1,6 @@
 /*global document:false*/
 import React from "react";
 import {VictoryChart} from "../src/index";
-import _ from "lodash";
 
 
 class App extends React.Component {

--- a/package.json
+++ b/package.json
@@ -59,9 +59,9 @@
     "rimraf": "^2.4.0",
     "style-loader": "~0.8.0",
     "url-loader": "~0.5.5",
-    "victory-axis": "0.0.3",
-    "victory-line": "0.0.5",
-    "victory-scatter": "0.0.1",
+    "victory-axis": "^0.0.3",
+    "victory-line": "^0.0.5",
+    "victory-scatter": "^0.0.2",
     "webpack": "^1.10.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "url-loader": "~0.5.5",
     "victory-axis": "0.0.3",
     "victory-line": "0.0.5",
+    "victory-scatter": "0.0.1",
     "webpack": "^1.10.0"
   },
   "devDependencies": {

--- a/src/components/victory-chart.jsx
+++ b/src/components/victory-chart.jsx
@@ -28,7 +28,7 @@ class VictoryChart extends React.Component {
   }
 
   consolidateData() {
-    let datasets = [];
+    const datasets = [];
     // if y is given, construct data for all y, and add it to this.state.data
     if (this.state.y) {
       const xArray = this.returnOrGenerateX(); // returns an array
@@ -53,7 +53,7 @@ class VictoryChart extends React.Component {
       if (_.isArray(this.props.data[0])) {
         _.each(this.props.data, (data) => {
           datasets.push(data);
-        })
+        });
       } else {
         datasets.push(this.props.data);
       }
@@ -151,8 +151,8 @@ class VictoryChart extends React.Component {
     const data = _.map(this.state.data, (dataset) => {
       return dataset.data;
     });
-    let min = [];
-    let max = [];
+    const min = [];
+    const max = [];
     _.each(data, (datum) => {
       min.push(_.min(_.pluck(datum, type)));
       max.push(_.max(_.pluck(datum, type)));
@@ -320,7 +320,7 @@ VictoryChart.propTypes = {
       x: React.PropTypes.number,
       y: React.PropTypes.number
     })
-  ),
+  )
 };
 
 VictoryChart.defaultProps = {

--- a/src/components/victory-chart.jsx
+++ b/src/components/victory-chart.jsx
@@ -206,10 +206,6 @@ class VictoryChart extends React.Component {
 }
 
 VictoryChart.propTypes = {
-  color: React.PropTypes.string
-};
-
-VictoryChart.propTypes = {
   style: React.PropTypes.node,
   data: React.PropTypes.oneOfType([ // maybe this should just be "node"
     React.PropTypes.arrayOf(

--- a/src/components/victory-chart.jsx
+++ b/src/components/victory-chart.jsx
@@ -177,11 +177,11 @@ class VictoryChart extends React.Component {
       return (
         <VictoryLine
           {...this.props}
-          data={data.data}
+          data={data.data} // TODO: ugh
           style={styles}
-          domain={{x: this.getDomain("x"), y: this.getDomain("y")}}
-          range={{x: this.getRange("x"), y: this.getRange("y")}}
-          ref={_.isString(_.keys(data)) ? _.keys(data) : "data-" + _.keys(data)}
+          domain={{x: this.getDomain("x"), y: this.getDomain("y")}} // maybe unnecessary
+          range={{x: this.getRange("x"), y: this.getRange("y")}} // maybe unnecessary
+          ref={data.name}
           key={index}/>
       );
     });
@@ -190,12 +190,14 @@ class VictoryChart extends React.Component {
         {lines}
         <VictoryAxis
           {...this.props}
-          domain={this.getDomain("x")}
+          domain={this.getDomain("x")} // maybe unnecessary
+          range={this.getRange("x")} // maybe unnecessary
           orientation="bottom"
           style={styles}/>
         <VictoryAxis
           {...this.props}
-          domain={this.getDomain("y")}
+          domain={this.getDomain("y")} // maybe unnecessary
+          range={this.getRange("y")} // maybe unnecessary
           orientation="left"
           style={styles}/>
       </svg>
@@ -209,7 +211,7 @@ VictoryChart.propTypes = {
 
 VictoryChart.propTypes = {
   style: React.PropTypes.node,
-  data: React.PropTypes.oneOfType([
+  data: React.PropTypes.oneOfType([ // maybe this should just be "node"
     React.PropTypes.arrayOf(
       React.PropTypes.shape({
         x: React.PropTypes.number,
@@ -230,18 +232,24 @@ VictoryChart.propTypes = {
     React.PropTypes.array,
     React.PropTypes.func
   ]),
-  domain: React.PropTypes.objectOf(
-    React.PropTypes.shape({
-      x: React.PropTypes.arrayOf(React.PropTypes.number),
-      y: React.PropTypes.arrayOf(React.PropTypes.number)
-    })
-  ),
-  range: React.PropTypes.objectOf(
-    React.PropTypes.shape({
-      x: React.PropTypes.arrayOf(React.PropTypes.number),
-      y: React.PropTypes.arrayOf(React.PropTypes.number)
-    })
-  ),
+  domain: React.PropTypes.oneOfType([
+    React.PropTypes.array,
+    React.PropTypes.objectOf(
+      React.PropTypes.shape({
+        x: React.PropTypes.arrayOf(React.PropTypes.number),
+        y: React.PropTypes.arrayOf(React.PropTypes.number)
+      })
+    )
+  ]),
+  range: React.PropTypes.oneOfType([
+    React.PropTypes.array,
+    React.PropTypes.objectOf(
+      React.PropTypes.shape({
+        x: React.PropTypes.arrayOf(React.PropTypes.number),
+        y: React.PropTypes.arrayOf(React.PropTypes.number)
+      })
+    )
+  ]),
   scale: React.PropTypes.oneOfType([
     React.PropTypes.func,
     React.PropTypes.objectOf(

--- a/src/components/victory-chart.jsx
+++ b/src/components/victory-chart.jsx
@@ -9,27 +9,28 @@ import {VictoryAxis} from "victory-axis";
 class VictoryChart extends React.Component {
   constructor(props) {
     super(props);
-
     // Initialize state
     this.state = {};
-
-    // Either we get data, or we get X/Y.
-    // `y` will either be none, a function, an array of numbers,
-    // or an array of functions.
+    this.state.data = [];
+    // if data is given in props, add it to this.state.data
     if (this.props.data) {
-      this.state.data = this.props.data;
-    } else {
-      this.state = {};
-      this.state.x = this.returnOrGenerateX();
-      this.state.y = this.returnOrGenerateY();
+      this.state.data.push(this.props.data);
+    }
+    // if y is given in props, construct data for all y, and add it to this.state.data
+    if (this.props.y) {
+      const xArray = this.returnOrGenerateX(); // returns an array
+      const yArray = this.returnOrGenerateY(); // returns an array of arrays
+      let n;
+      // create a dataset from x and y with n points
+      const datasets = _.map(yArray, (y) => {
+        n = _.min([xArray.length, y.length]);
+        return _.zip(_.take(xArray, n), _.take(y, n));
+      });
 
-      const inter = _.map(this.state.y, (y) => _.zip(this.state.x, y));
-
-      // Create a map {line-number: dataForLine}
-      const objs = _.chain(inter)
+      const objs = _.chain(datasets)
         .map((objArray, idx) => {
           return [
-            "line-" + idx,
+            "data-" + idx,
             _.map(
               objArray,
               (obj) => {
@@ -40,28 +41,47 @@ class VictoryChart extends React.Component {
         })
         .object()
         .value();
-
-      this.state.data = objs;
+      this.state.data.push(objs);
     }
   }
 
   returnOrGenerateX() {
-    const step = Math.round(this.props.xMax / this.props.sample, 4);
-    return this.props.x
-     ? this.props.x
-     : _.range(this.props.xMin, this.props.xMax, step);
+    if (this.props.x) {
+      return this.props.x;
+    }
+    // if x is not given in props, create an array of values evenly
+    // spaced across the x domain
+    const domainFromProps = (this.props.domain && this.props.domain.x) ?
+      this.props.domain.x : this.props.domain;
+    // note: scale will never be undefined thanks to default props
+    const domainFromScale = this.props.scale.x ?
+      this.props.scale.x().domain() : this.props.scale().domain();
+    // use this.props.domain if specified
+    const domain = domainFromProps || domainFromScale;
+    const samples = this._getSampleNumber();
+    const step = _.max(domain) / samples;
+    return _.range(_.min(domain), _.max(domain), step);
+  }
+
+  // helper for returnOrGenerateX
+  _getSampleNumber() {
+    if (_.isArray(this.props.y) && _.isNumber(this.props.y[0])) {
+      return this.props.y.length;
+    }
+    return this.props.samples;
   }
 
   returnOrGenerateY() {
     // Always return an array of arrays.
     const y = this.props.y;
+    const x = this.returnOrGenerateX();
 
     if (_.isFunction(y)) {
-      return [_.map(this.state.x, (x) => y(x))];
-    } else if (_.isObject(y)) {
+      return [_.map(x, (datum) => y(datum))];
+    } else if (_.isArray(y)) {
       // y is an array of functions
       if (_.isFunction(y[0])) {
-        return _.map(y, (yFn) => _.map(this.state.x, (x) => yFn(x)));
+        return _.map(y, (yFn) => _.map(x, (datum) => yFn(datum)));
       } else {
         return [y];
       }
@@ -73,52 +93,81 @@ class VictoryChart extends React.Component {
 
   getStyles() {
     return _.merge({
-      base: {
-        color: "#000",
-        fontSize: 12,
-        textDecoration: "underline"
-      },
-      svg: {
-        "border": "2px solid black",
-        "margin": "20",
-        "width": "500",
-        "height": "200"
-      }
+      color: "#000",
+      fontSize: 12,
+      margin: 50,
+      width: 500,
+      height: 300
     }, this.props.style);
   }
 
+  getDomain(type) {
+    if (this.props.domain) {
+      return this._getDomainFromProps(type);
+    }
+    return this._getDomainFromData(type);
+  }
+
+  // helper method for getDomain
+  _getDomainFromProps(type) {
+    if (this.props.domain[type]) {
+      // if the domain for this type is given, return it
+      return this.props.domain[type];
+    }
+    // if the domain is given without the type specified, return the domain (reversed for y)
+    return type === "x" ? this.props.domain : this.props.domain.concat().reverse();
+  }
+
+  // helper method for getDomain
+  _getDomainFromData(type) {
+    const data = _.map(this.state.data, (dataset) => {
+      return _.flatten(_.values(dataset));
+    });
+    let min = [];
+    let max = [];
+    _.each(data, (datum) => {
+      min.push(_.min(_.pluck(datum, type)));
+      max.push(_.max(_.pluck(datum, type)));
+    });
+    return type === "x" ? [_.min(min), _.max(max)] : [_.max(max), _.min(min)];
+  }
+
+  getRange(type) {
+    if (this.props.range) {
+      return this.props.range[type] ? this.props.range[type] : this.props.range;
+    }
+    // if the range is not given in props, calculate it from width, height and margin
+    const style = this.getStyles();
+    const dimension = type === "x" ? "width" : "height";
+    return [style.margin, style[dimension] - style.margin];
+  }
+
+
   render() {
-
     const styles = this.getStyles();
+    const lines = _.map(this.state.data, (data, index) => {
 
-    // Lines need 2x + a lil' margin to line up nicely.
-    const lineStyleBase = _.merge(
-      styles,
-      {
-        svg: {
-          margin: (styles.svg.margin * 2) + 2
-        }
-      }
-    );
-
-    const lines = _.map(this.state.data, (data, key) => {
-      // Make sure we aren't mutating base styles.
-      const lineStyle = _.clone(lineStyleBase);
-
-      lineStyle.path = this.props.lineStyles[key];
       return (
-        <VictoryLine {...this.props}
-          data={data}
-          style={lineStyle}
-          ref={key ? _.isString(key) : "line-" + key}
-          key={Math.random()}/>
+        <VictoryLine
+          data={_.values(data)[0]}
+          style={styles}
+          domain={{x: this.getDomain("x"), y: this.getDomain("y")}}
+          range={{x: this.getRange("x"), y: this.getRange("y")}}
+          ref={_.isString(_.keys(data)) ? _.keys(data) : "data-" + _.keys(data)}
+          key={index}/>
       );
     });
-
     return (
-      <svg style={styles.svg}>
+      <svg style={{width: styles.width, height: styles.height}}>
         {lines}
-        <VictoryAxis {...this.props} style={styles}/>
+        <VictoryAxis
+          domain={this.getDomain("x")}
+          orientation="bottom"
+          style={styles}/>
+        <VictoryAxis
+          domain={this.getDomain("y")}
+          orientation="left"
+          style={styles}/>
       </svg>
     );
   }
@@ -129,14 +178,40 @@ VictoryChart.propTypes = {
 };
 
 VictoryChart.propTypes = {
+  style: React.PropTypes.node,
   data: React.PropTypes.arrayOf(
-    React.PropTypes.arrayOf(
+    React.PropTypes.shape({
+      x: React.PropTypes.number,
+      y: React.PropTypes.number
+    })
+  ),
+  x: React.PropTypes.array,
+  y: React.PropTypes.oneOfType([
+    React.PropTypes.array,
+    React.PropTypes.func
+  ]),
+  domain: React.PropTypes.objectOf(
+    React.PropTypes.shape({
+      x: React.PropTypes.arrayOf(React.PropTypes.number),
+      y: React.PropTypes.arrayOf(React.PropTypes.number)
+    })
+  ),
+  range: React.PropTypes.objectOf(
+    React.PropTypes.shape({
+      x: React.PropTypes.arrayOf(React.PropTypes.number),
+      y: React.PropTypes.arrayOf(React.PropTypes.number)
+    })
+  ),
+  scale: React.PropTypes.oneOfType([
+    React.PropTypes.func,
+    React.PropTypes.objectOf(
       React.PropTypes.shape({
-        x: React.PropTypes.number,
-        y: React.PropTypes.number
+        x: React.PropTypes.func,
+        y: React.PropTypes.func
       })
     )
-  ),
+  ]),
+  samples: React.PropTypes.number,
   interpolation: React.PropTypes.oneOf([
     "linear",
     "linear-closed",
@@ -152,43 +227,71 @@ VictoryChart.propTypes = {
     "cardinal-closed",
     "monotone"
   ]),
-  lineStyles: React.PropTypes.oneOfType([
-    React.PropTypes.arrayOf(
-      React.PropTypes.shape({
-        "stroke": React.PropTypes.string,
-        "strokeWidth": React.PropTypes.string
-      })
-    ),
-    React.PropTypes.objectOf(
-      React.PropTypes.shape({
-        "stroke": React.PropTypes.string,
-        "strokeWidth": React.PropTypes.string
-      })
-    )
-  ]),
-  sample: React.PropTypes.number,
-  scale: React.PropTypes.func,
-  style: React.PropTypes.node,
-  x: React.PropTypes.array,
-  xDomain: React.PropTypes.array,
-  yDomain: React.PropTypes.array,
-  y: React.PropTypes.oneOfType([
-    React.PropTypes.array,
-    React.PropTypes.func,
-    React.PropTypes.arrayOf(React.PropTypes.func)
-  ])
+  axisOrientation: React.PropTypes.objectOf(
+    React.PropTypes.shape({
+      x: React.PropTypes.string,
+      y: React.PropTypes.string
+    })
+  ),
+  axisLabels: React.PropTypes.objectOf(
+    React.PropTypes.shape({
+      x: React.PropTypes.string,
+      y: React.PropTypes.string
+    })
+  ),
+  labelPadding: React.PropTypes.objectOf(
+    React.PropTypes.shape({
+      x: React.PropTypes.number,
+      y: React.PropTypes.number
+    })
+  ),
+  gridLines: React.PropTypes.objectOf(
+    React.PropTypes.shape({
+      x: React.PropTypes.bool,
+      y: React.PropTypes.bool
+    })
+  ),
+  tickValues: React.PropTypes.objectOf(
+    React.PropTypes.shape({
+      x: React.PropTypes.arrayOf(React.PropTypes.number),
+      y: React.PropTypes.arrayOf(React.PropTypes.number)
+    })
+  ),
+  tickFormat: React.PropTypes.objectOf(
+    React.PropTypes.shape({
+      x: React.PropTypes.func,
+      y: React.PropTypes.func
+    })
+  ),
+  tickCount: React.PropTypes.objectOf(
+    React.PropTypes.shape({
+      x: React.PropTypes.number,
+      y: React.PropTypes.number
+    })
+  ),
+  tickSize: React.PropTypes.objectOf(
+    React.PropTypes.shape({
+      x: React.PropTypes.number,
+      y: React.PropTypes.number
+    })
+  ),
+  tickPadding: React.PropTypes.objectOf(
+    React.PropTypes.shape({
+      x: React.PropTypes.number,
+      y: React.PropTypes.number
+    })
+  ),
 };
 
 VictoryChart.defaultProps = {
-  data: null,
   interpolation: "basis",
-  lineStyles: [{}],
-  sample: 100,
+  samples: 100,
   scale: () => d3.scale.linear(),
-  x: null,
-  xDomain: [0, 100],
-  y: () => Math.random(),
-  yDomain: [0, 100]
+  y: (x) => (x * x),
+  axisOrientation: {
+    x: "bottom",
+    y: "left"
+  }
 };
 
 export default VictoryChart;

--- a/src/components/victory-chart.jsx
+++ b/src/components/victory-chart.jsx
@@ -170,10 +170,8 @@ VictoryChart.propTypes = {
   scale: React.PropTypes.func,
   style: React.PropTypes.node,
   x: React.PropTypes.array,
-  xMax: React.PropTypes.number,
-  xMin: React.PropTypes.number,
-  yMax: React.PropTypes.number,
-  yMin: React.PropTypes.number,
+  xDomain: React.PropTypes.array,
+  yDomain: React.PropTypes.array,
   y: React.PropTypes.oneOfType([
     React.PropTypes.array,
     React.PropTypes.func,
@@ -186,13 +184,11 @@ VictoryChart.defaultProps = {
   interpolation: "basis",
   lineStyles: [{}],
   sample: 100,
-  scale: (min, max) => d3.scale.linear().range([min, max]),
+  scale: () => d3.scale.linear(),
   x: null,
-  xMax: 100,
-  xMin: 0,
+  xDomain: [0, 100],
   y: () => Math.random(),
-  yMax: 100,
-  yMin: 0
+  yDomain: [0, 100]
 };
 
 export default VictoryChart;

--- a/src/components/victory-chart.jsx
+++ b/src/components/victory-chart.jsx
@@ -267,11 +267,13 @@ class VictoryChart extends React.Component {
 
   drawLine(dataset, index) {
     const style = this.getStyles();
-    const {name, ...attrs} = dataset.attrs;
+    const {type, name, ...attrs} = dataset.attrs;
+    const animate = (this.props.animate.line !== undefined) ?
+      this.props.animate.line : this.props.animate;
     return (
       <VictoryLine
         {...this.props}
-        animate={this.props.animate.line || this.props.animate}
+        animate={animate}
         containerElement="g"
         data={dataset.data}
         style={_.merge(style, attrs)}
@@ -284,11 +286,13 @@ class VictoryChart extends React.Component {
 
   drawScatter(dataset, index) {
     const style = this.getStyles();
-    const {name, symbol, size, ...attrs} = dataset.attrs;
+    const {type, name, symbol, size, ...attrs} = dataset.attrs;
+    const animate = (this.props.animate.scatter !== undefined) ?
+      this.props.animate.scatter : this.props.animate;
     return (
       <VictoryScatter
         {...this.props}
-        animate={this.props.animate.scatter || this.props.animate}
+        animate={animate}
         containerElement="g"
         data={dataset.data}
         size={size || 3}
@@ -317,10 +321,15 @@ class VictoryChart extends React.Component {
     const style = this.getStyles();
     const offsetY = axis === "y" ? undefined : this.getAxisOffset().y;
     const offsetX = axis === "x" ? undefined : this.getAxisOffset().x;
+    const axisStyle = this.props.axisStyle ? axisStyle[axis] : undefined;
+    const tickStyle = this.props.tickStyle ? tickStyle[axis] : undefined;
+    const gridStyle = this.props.gridStyle ? gridStyle[axis] : undefined;
+    const animate = (this.props.animate.axis !== undefined) ?
+      this.props.animate.axis : this.props.animate;
     return (
       <VictoryAxis
         {...this.props}
-        animate={this.props.animate.axis || this.props.animate}
+        animate={animate}
         containerElement="g"
         offsetY={offsetY}
         offsetX={offsetX}
@@ -331,10 +340,11 @@ class VictoryChart extends React.Component {
         orientation={this.props.axisOrientation[axis]}
         showGridLines={this.props.showGridLines[axis]}
         tickCount={this.props.tickCount[axis]}
-        tickSize={this.props.tickSize[axis]}
-        tickPadding={this.props.tickPadding[axis]}
         tickValues={this.getTickValues(axis)}
         tickFormat={this.props.tickFormat[axis]}
+        axisStyle={axisStyle}
+        gridStyle={gridStyle}
+        tickStyle={tickStyle}
         style={style}/>
     );
   }
@@ -366,15 +376,15 @@ VictoryChart.propTypes = {
   data: React.PropTypes.oneOfType([ // maybe this should just be "node"
     React.PropTypes.arrayOf(
       React.PropTypes.shape({
-        x: React.PropTypes.number,
-        y: React.PropTypes.number
+        x: React.PropTypes.any,
+        y: React.PropTypes.any
       })
     ),
     React.PropTypes.arrayOf(
       React.PropTypes.arrayOf(
         React.PropTypes.shape({
-          x: React.PropTypes.number,
-          y: React.PropTypes.number
+          x: React.PropTypes.any,
+          y: React.PropTypes.any
         })
       )
     )
@@ -395,8 +405,8 @@ VictoryChart.propTypes = {
   domain: React.PropTypes.oneOfType([
     React.PropTypes.array,
     React.PropTypes.shape({
-      x: React.PropTypes.arrayOf(React.PropTypes.number),
-      y: React.PropTypes.arrayOf(React.PropTypes.number)
+      x: React.PropTypes.array,
+      y: React.PropTypes.array
     })
   ]),
   range: React.PropTypes.oneOfType([
@@ -438,8 +448,8 @@ VictoryChart.propTypes = {
     y: React.PropTypes.bool
   }),
   tickValues: React.PropTypes.shape({
-    x: React.PropTypes.arrayOf(React.PropTypes.number),
-    y: React.PropTypes.arrayOf(React.PropTypes.number)
+    x: React.PropTypes.arrayOf(React.PropTypes.any),
+    y: React.PropTypes.arrayOf(React.PropTypes.any)
   }),
   tickFormat: React.PropTypes.shape({
     x: React.PropTypes.func,
@@ -449,13 +459,17 @@ VictoryChart.propTypes = {
     x: React.PropTypes.number,
     y: React.PropTypes.number
   }),
-  tickSize: React.PropTypes.shape({
-    x: React.PropTypes.number,
-    y: React.PropTypes.number
+  axisStyle: React.PropTypes.shape({
+    x: React.PropTypes.node,
+    y: React.PropTypes.node
   }),
-  tickPadding: React.PropTypes.shape({
-    x: React.PropTypes.number,
-    y: React.PropTypes.number
+  tickStyle: React.PropTypes.shape({
+    x: React.PropTypes.node,
+    y: React.PropTypes.node
+  }),
+  gridStyle: React.PropTypes.shape({
+    x: React.PropTypes.node,
+    y: React.PropTypes.node
   }),
   animate: React.PropTypes.oneOfType([
     React.PropTypes.bool,
@@ -483,14 +497,6 @@ VictoryChart.defaultProps = {
   tickCount: {
     x: 7,
     y: 5
-  },
-  tickSize: {
-    x: 4,
-    y: 4
-  },
-  tickPadding: {
-    x: 3,
-    y: 3
   },
   tickFormat: {
     x: () => d3.scale.linear().tickFormat(),

--- a/src/components/victory-chart.jsx
+++ b/src/components/victory-chart.jsx
@@ -42,30 +42,46 @@ class VictoryChart extends React.Component {
 
       // for each dataArray create an array of data points and add it to
       // the consolidated datasets
-      _.each(dataArrays, (dataArray) => {
-        datasets.push(_.map(dataArray, (datum) => {
-          return {x: datum[0], y: datum[1]};
-        }));
+      _.each(dataArrays, (dataArray, index) => {
+        const attributes = this.props.yAttributes && this.props.yAttributes[index] ?
+            this.props.yAttributes[index] : this.props.yAttributes;
+        datasets.push({
+          attrs: attributes,
+          name: attributes && attributes.name ? attributes.name : "y-data-" + index,
+          data: _.map(dataArray, (datum) => {
+            return {
+              x: datum[0],
+              y: datum[1],
+            };
+          })
+        });
       });
     }
     // if data is given in this.props.data, add it to the cosolidated datasets
     if (this.props.data) {
+
       if (_.isArray(this.props.data[0])) {
-        _.each(this.props.data, (data) => {
-          datasets.push(data);
+        _.each(this.props.data, (data, index) => {
+          const attributes = this.props.dataAttributes && this.props.dataAttributes[index] ?
+            this.props.dataAttributes[index] : this.props.dataAttributes;
+          datasets.push({
+            attrs: attributes,
+            data: data,
+            name: attributes && attributes.name ? attributes.name : "data-" + index
+          });
         });
       } else {
-        datasets.push(this.props.data);
+        const attributes = this.props.dataAttributes && this.props.dataAttributes[0] ?
+            this.props.dataAttributes[0] : this.props.dataAttributes;
+        datasets.push({
+          attrs: attributes,
+          data: this.props.data,
+          name: attributes && attributes.name ? attributes.name : "data-0"
+        });
       }
     }
 
-    // return an object containing each dataset with a unique name
-    return _.map(datasets, (dataset, index) => {
-      return {
-        name: "data-" + index,
-        data: dataset
-      };
-    });
+    return datasets;
   }
 
   returnOrGenerateX() {
@@ -178,7 +194,7 @@ class VictoryChart extends React.Component {
         <VictoryLine
           {...this.props}
           data={data.data} // TODO: ugh
-          style={styles}
+          style={data.attrs}
           domain={{x: this.getDomain("x"), y: this.getDomain("y")}} // maybe unnecessary
           range={{x: this.getRange("x"), y: this.getRange("y")}} // maybe unnecessary
           ref={data.name}
@@ -223,10 +239,18 @@ VictoryChart.propTypes = {
       )
     )
   ]),
+  dataAttributes: React.PropTypes.oneOfType([
+    React.PropTypes.object,
+    React.PropTypes.arrayOf(React.PropTypes.object)
+  ]),
   x: React.PropTypes.array,
   y: React.PropTypes.oneOfType([
     React.PropTypes.array,
     React.PropTypes.func
+  ]),
+  yAttributes: React.PropTypes.oneOfType([
+    React.PropTypes.object,
+    React.PropTypes.arrayOf(React.PropTypes.object)
   ]),
   domain: React.PropTypes.oneOfType([
     React.PropTypes.array,

--- a/src/log.js
+++ b/src/log.js
@@ -1,0 +1,10 @@
+/* eslint-disable*/
+module.exports = {
+  warn: function (message) {
+    if (process.env.NODE_ENV !== "production") {
+      if (console && console.warn) {
+        console.warn(message);
+      }
+    }
+  }
+};


### PR DESCRIPTION
This branch works with `victory-axis` on branch `refactor-for-chart` and `victory-line` on branch `refactor-for-new-chart` (sorry about the inconsistent naming).  You will have to fetch and `npm link` these branches to see this PR in action

This makes a ton of changes to the chart api, including:
- supporting independent domains, ranges, and scales for x and y
- auto-calculating range based on height / width / margin
- auto-calculating domain based on data
- support for plotting data and functions on the same chart

Still working on: 
- [x] figuring out how to independently style each data series whether passed as data or a function
- [ ] figuring out how to add styles / labels to individual points
- [ ] plotting scatters at all
- [ ] plotting scatters and lines on the same chart, and figuring out how to flag each data series
- [x] figuring out how to name each data series
- [ ] support for crossing axes
- [ ] BUG: line will extend outside of axes into the svg margin if the domain is manually set without considering data
