### PR TITLE
Refactor bar chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,121 +1,270 @@
 [![Travis Status][trav_img]][trav_site]
 
-##TODO: write an actual README!
-
-These are the props
-```
-style: React.PropTypes.node,
-  data: React.PropTypes.oneOfType([ // maybe this should just be "node"
-    React.PropTypes.arrayOf(
-      React.PropTypes.shape({
-        x: React.PropTypes.any,
-        y: React.PropTypes.any
-      })
-    ),
-    React.PropTypes.arrayOf(
-      React.PropTypes.arrayOf(
-        React.PropTypes.shape({
-          x: React.PropTypes.any,
-          y: React.PropTypes.any
-        })
-      )
-    )
-  ]),
-  dataAttributes: React.PropTypes.oneOfType([
-    React.PropTypes.object,
-    React.PropTypes.arrayOf(React.PropTypes.object)
-  ]),
-  x: React.PropTypes.array,
-  y: React.PropTypes.oneOfType([
-    React.PropTypes.array,
-    React.PropTypes.func
-  ]),
-  yAttributes: React.PropTypes.oneOfType([
-    React.PropTypes.object,
-    React.PropTypes.arrayOf(React.PropTypes.object)
-  ]),
-  domain: React.PropTypes.oneOfType([
-    React.PropTypes.array,
-    React.PropTypes.shape({
-      x: React.PropTypes.array,
-      y: React.PropTypes.array
-    })
-  ]),
-  range: React.PropTypes.oneOfType([
-    React.PropTypes.array,
-    React.PropTypes.shape({
-      x: React.PropTypes.arrayOf(React.PropTypes.number),
-      y: React.PropTypes.arrayOf(React.PropTypes.number)
-    })
-  ]),
-  scale: React.PropTypes.oneOfType([
-    React.PropTypes.func,
-    React.PropTypes.shape({
-      x: React.PropTypes.func,
-      y: React.PropTypes.func
-    })
-  ]),
-  samples: React.PropTypes.number,
-  interpolation: React.PropTypes.oneOf([
-    "linear",
-    "linear-closed",
-    "step",
-    "step-before",
-    "step-after",
-    "basis",
-    "basis-open",
-    "basis-closed",
-    "bundle",
-    "cardinal",
-    "cardinal-open",
-    "cardinal-closed",
-    "monotone"
-  ]),
-  axisOrientation: React.PropTypes.shape({
-    x: React.PropTypes.oneOf(["top", "bottom"]),
-    y: React.PropTypes.oneOf(["left", "right"])
-  }),
-  showGridLines: React.PropTypes.shape({
-    x: React.PropTypes.bool,
-    y: React.PropTypes.bool
-  }),
-  tickValues: React.PropTypes.shape({
-    x: React.PropTypes.arrayOf(React.PropTypes.any),
-    y: React.PropTypes.arrayOf(React.PropTypes.any)
-  }),
-  tickFormat: React.PropTypes.shape({
-    x: React.PropTypes.func,
-    y: React.PropTypes.func
-  }),
-  tickCount: React.PropTypes.shape({
-    x: React.PropTypes.number,
-    y: React.PropTypes.number
-  }),
-  axisStyle: React.PropTypes.shape({
-    x: React.PropTypes.node,
-    y: React.PropTypes.node
-  }),
-  tickStyle: React.PropTypes.shape({
-    x: React.PropTypes.node,
-    y: React.PropTypes.node
-  }),
-  gridStyle: React.PropTypes.shape({
-    x: React.PropTypes.node,
-    y: React.PropTypes.node
-  }),
-  animate: React.PropTypes.oneOfType([
-    React.PropTypes.bool,
-    React.PropTypes.shape({
-      line: React.PropTypes.bool,
-      scatter: React.PropTypes.bool,
-      axis: React.PropTypes.bool
-    })
-  ]),
-  containerElement: React.PropTypes.oneOf(["svg", "g"])
-```
-
-Victory Chart
+VictoryChart
 =============
+
+VictoryChart is an intelligent, flexible charting component for React. VictoryChart makes it easy to plot several datasets on the same chart, plot pure math functions, and overlay several types of charts. It relies on d3 for some of the math, but leaves all of the rendering to React. This component is built from several other components on the Victory ecosystem, including [VictoryAxis](http://github.com/formidablelabs/victory-axis), [VictoryLine](http://github.com/formidablelabs/victory-line), [VictoryScatter](http://github.com/formidablelabs/victory-scatter), and [VictoryBar](http://github.com/formidablelabs/victory-bar).  More chart types coming soon!
+
+## API
+
+There are several configuration options for Victory Scatter, but if only the `data` is prop is provided, a sensible scatter will still be rendered.
+
+### Props
+
+All props are optional, but you wont get very far without passing in some data.
+
+### chartType
+
+This prop specifies how data should be plotted. Currently supported types are 
+"line", "scatter", "bar", and "stackedBar".  This "global" chart type can be overridden by passing a different type in with the `dataAttributes` or `yAttributes` props
+
+#### data
+
+The data prop specifies the data to be plotted. Data should be in the form of an array of data points, or an array of arrays of data points for multiple datasets. Each data point should be an object with x and y properties. Other properties may be added to the data point object, such as label, color, size, symbol or opacity. These properties will be interpreted and applied to the individual data point in chart types that support them.
+
+examples:
+
+```
+data={[
+  {x: new Date(1982, 1, 1), y: 125, color: "red", symbol: "plus"},
+  {x: new Date(1987, 1, 1), y: 257, color: "blue", symbol: "star"},
+  {x: new Date(1993, 1, 1), y: 345, color: "green", symbol: "circle"},
+]}
+
+data={[
+  [{x: 5, y: 3}, {x: 4, y: 2}, {x: 3, y: 1}],
+  [{x: 1, y: 2}, {x: 2, y: 3}, {x: 3, y: 4}],
+  [{x: 1, y: 2}, {x: 2, y: 2}, {x: 3, y: 2}]
+]}
+```
+
+### dataAttributes
+
+The dataAttributes prop describes how a data set should be plotted and styled.
+This prop can be given as an object, or an array of objects. If this prop is
+given as an array of objects, the properties of each object in the array will
+be applied to the data points in the corresponding array of the data prop.
+
+examples:
+
+```
+dataAttributes={{type: "scatter", symbol: "square", color: "blue"}}
+
+dataAttributes={[
+  {type: "line", stroke: "green", width: 3}, 
+  {type: "bar", color: "orange"}
+]}
+
+```
+
+### x
+
+The x prop provides another way to supply data for chart to plot. This prop can be given as an array of values or an array of arrays, and it will be plotted against whatever y prop is provided. If no props are provided for y, the values in x will be plotted as the identity function (x) => x.
+
+examples: 
+
+```
+x={["apples", "oranges", "bananas"]} 
+
+x={[
+  [1, 2, 3], 
+  [2, 3, 4], 
+  [4, 5, 6]
+]}
+```
+
+### y
+
+The y prop provides another way to supply data for chart to plot. This prop can be given as a function of x, or an array of values, or an array of functions and / or values. If x props are given, they will be used in plotting (x, y) data points. If x props are not provided, a set of x values evenly spaced across the x domain will be calculated, and used for plotting data points.
+
+examples:
+
+```
+y={(x) => x + 5} 
+
+y={[1, 2, 3]}
+
+y={[
+  (x) => x, 
+  [2, 3, 4], 
+  (x) => Math.sin(x)
+]}
+```
+
+### yAttributes
+The yAttributes prop describes how a data set should be plotted and styled.
+This prop behaves identically to the dataAttributes prop, but is applied to
+any data provided via the y prop
+
+examples:
+
+```
+yAttributes={{type: "scatter", symbol: "square", color: "blue"}}
+
+yAttributes={[
+  {type: "line", stroke: "green", width: 3}, 
+  {type: "bar", color: "orange"}
+]}
+```
+
+### samples
+
+The samples prop specifies how many individual points to plot when plotting
+y as a function of x. Samples is ignored if x props are provided instead.
+
+### interpolation
+
+The interpolation prop determines how data points should be connected when plotting a line. Supported options are: "linear", "linear-closed", "step", "step-before", "step-after", "basis", "basis-open", "basis-closed", "bundle", "cardinal", "cardinal-open", "cardinal-closed", and "monotone"
+ 
+### scale
+
+The scale prop determines which scales your chart should use. This prop can be
+given as a function, or as an object that specifies separate functions for x and y. Supported scales are d3 linear scales, time scales, power scales, and log scales. d3 ordinal scales are not supported, but non-numeric data is automatically handled and range band like behavior is supported via the `categories` prop.
+
+examples:
+
+```
+scale={() => d3.time.scale()}
+
+scale={{x: () => d3.scale.linear(), y: () => d3.scale.log()}}
+```
+
+### domain
+
+The domain prop describes the range of values your chart will include. This prop can be given as a array of the minimum and maximum expected values for your chart, or as an object that specifies separate arrays for x and y.
+If this prop is not provided, a domain will be calculated from data, or other available information.
+
+examples:
+
+```
+domain={[-1, 1]}
+
+domain={{x: [0, 100], y: [0, 1]}}
+```
+
+### range
+
+The range prop describes the range of pixels your chart will cover. This prop can begiven as a array of the minimum and maximum expected values for your chart, or as an object that specifies separate arrays for x and y.
+If this prop is not provided, a range will be calculated based on the height,
+width, and margin provided in the style prop, or in default styles. It is usually a good idea to let the chart component calculate its own range.
+
+examples:
+
+```
+range={[0, 500]} 
+
+range={{x: [0, 500], y: [500, 300]}}
+```
+
+### containerElement
+
+The containerElement prop specifies which element the compnent will render.
+For standalone charts, the containerElement prop should be "svg". If you need to compose a chart with some other svg element, the containerElement prop should be "g", and will need to be rendered within an svg tag.
+
+### style
+
+The style prop specifies styles for your chart. Victory Chart relies on Radium,
+so valid Radium style objects should work for this prop, however height, width, and margin are used to calculate range, and need to be expressed as a number of pixels
+
+example:
+
+```
+style={{fontSize: 15, fontFamily: "helvetica", width: 500, height: 300}}
+```
+
+### axisLabels
+
+The axisLabels prop specifies the labels for your axes. It should be given as
+an object with x and y properties.
+
+example: `{x: "years", y: "cats"}`
+
+### axisOrentation
+
+The axisOrientation prop specifies the layout of your axes. It should be given asan object with x and y properties. Currently, Victory Chart only suppotys vertical y axes and horizontal x axes
+
+example: `{x: "bottom", y: "right"}`
+
+### showGridLines
+
+The showGridLines prop specifies whether or not to draw grid lines for a particular axis. It should be given as an object with x and y properties.
+Note: grid lines for a particular axis extend perpendicularly from that axis.
+
+example: `{x: false, y: true}`
+
+### tickValues
+
+The tickValues prop explicity specifies which ticks values to draw on each axis. This prop should be given as an object with arrays specified for x and y
+
+example: `{x: ["apples", "bananas", "oranges"] y: [2, 4, 6, 8]}`
+
+### tickFormat
+
+The tickFormat prop specifies how tick values should be expressed visually.
+This prop should be given as an object with functions specified for x and y
+
+example: `{x: () => d3.time.format("%Y"), y: (x) => x.toPrecision(2)}`
+
+### tickCount
+
+The tickCount prop specifies how many ticks should be drawn on each axis if
+ticksValues are not explicitly provided. This prop shouls be given as an object
+with numbers specified for x and y
+
+@example `{x: 7, y: 5}`
+
+### axisStyle
+
+The axisStyle prop specifies styles scoped only to the axis lines. Victory Chart relies on Radium, so valid Radium style objects should work for this prop.
+
+example: `{strokeWidth: 2, stroke: "black"}`
+
+### tickStyle
+
+The tickStyle prop specifies styles scoped only to the axis ticks. Victory Chart relies on Radium, so valid Radium style objects should work for this prop.
+
+example: `{fontSize: 15, fontFamily: "helvetica"}``
+
+### gridStyle
+
+The gridStyle prop specifies styles scoped only to the grid lines. Victory Chart relies on Radium, so valid Radium style objects should work for this prop.
+example: `{strokeWidth: 1, stroke: "#c9c5bb"}`
+
+### barWidth
+
+The barWidth prop specifies the width in number of pixels for bars rendered in a bar chart.
+
+### barPadding
+
+The barPadding prop specifies the padding in number of pixels between bars
+rendered in a bar chart.
+
+### domainPadding
+
+The domainPadding prop specifies a number of pixels of padding to add to the beginning and end of a domain. This prop is useful for explicitly spacing ticks farther from the origin to prevent crowding. This prop should be given as an object with numbers specified for x and y.
+
+example: `{x: 20, y: 0}`
+
+### categories
+
+The barCategories prop specifies the categories for a bar chart. This prop should be given as an array of string values, numeric values, or arrays. When this prop is given as an array of arrays, the minimum and maximum values of the arrays define range bands, allowing numeric data to be grouped into segments.
+
+examples:
+
+```
+categories={["dogs", "cats", "mice"]}
+
+categories={[
+  [0, 5], 
+  [5, 10], 
+  [10, 15]
+]}
+```
+
+### animate
+The animate prop determines whether the chart should animate with changing data. This prop can be given as a boolean, or an object with boolean values specified for each supported chart type.
+
+example: `{line: true, scatter: true, axis: false, bar: true}`
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ example: `{x: 20, y: 0}`
 
 ### categories
 
-The barCategories prop specifies the categories for a bar chart. This prop should be given as an array of string values, numeric values, or arrays. When this prop is given as an array of arrays, the minimum and maximum values of the arrays define range bands, allowing numeric data to be grouped into segments.
+The categories prop specifies the categories for a bar chart. This prop should be given as an array of string values, numeric values, or arrays. When this prop is given as an array of arrays, the minimum and maximum values of the arrays define range bands, allowing numeric data to be grouped into segments.
 
 examples:
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ VictoryChart is an intelligent, flexible charting component for React. VictoryCh
 
 ## API
 
-There are several configuration options for Victory Scatter, but if only the `data` is prop is provided, a sensible scatter will still be rendered.
+There are several configuration options for VictoryChart, but if only the `data` is prop is provided, a sensible chart will still be rendered.
 
 ### Props
 

--- a/demo/app.jsx
+++ b/demo/app.jsx
@@ -1,32 +1,10 @@
 /*global document:false */
+/*global window:false */
 import React from "react";
-// import d3 from "d3";
+import d3 from "d3";
 import _ from "lodash";
 import {VictoryChart} from "../src/index";
 
-const showSnapshotShows = 17;
-
-function generateShowSnapshotBarChartData(shows) {
-  const arr = [];
-  for (let i = 1; i < shows; i++) {
-    arr.push({
-      label: 'S02 E' + i,
-      'L+3': Math.floor(Math.random() * 100 * 50),
-      'Beyond L+3': Math.floor(Math.random() * 1000),
-    });
-  }
-  return arr;
-}
-
-function generateShowSnapshotXAxisCategories(shows) {
-  let arr = [];
-  for (let i = 1; i < shows; i++) {
-    arr.push("E" + i)
-  }
-  return arr;
-}
-
-console.log(generateShowSnapshotXAxisCategories(showSnapshotShows))
 
 class App extends React.Component {
   constructor(props) {
@@ -76,20 +54,55 @@ class App extends React.Component {
     };
   }
 
-  // componentWillMount() {
-  //   window.setInterval(() => {
-  //     this.setState({
-  //       scatterData: this.getScatterData(),
-  //       lineData: this.getData(),
-  //       dataAttributes: this.getStyles()
-  //     });
-  //   }, 4000);
-  // }
+  componentWillMount() {
+    window.setInterval(() => {
+      this.setState({
+        scatterData: this.getScatterData(),
+        lineData: this.getData(),
+        dataAttributes: this.getStyles()
+      });
+    }, 4000);
+  }
 
   render() {
     return (
       <div className="demo">
         <p>
+          <VictoryChart {...this.state}
+            data={this.state.lineData}
+            showGridLines={{x: false, y: true}}
+            animate={true}/>
+
+          <VictoryChart interpolation="linear"
+            scale={{
+              x: () => d3.time.scale(),
+              y: () => d3.scale.linear()
+            }}
+            tickValues={{
+              x: [
+                new Date(1980, 1, 1),
+                new Date(1990, 1, 1),
+                new Date(2000, 1, 1),
+                new Date(2010, 1, 1),
+                new Date(2020, 1, 1)
+              ],
+              y: [100, 200, 300, 400, 500]
+            }}
+            tickFormat={{
+              x: () => d3.time.format("%Y"),
+              y: () => d3.scale.linear().tickFormat()
+            }}
+            data={[
+              {x: new Date(1982, 1, 1), y: 125},
+              {x: new Date(1987, 1, 1), y: 257},
+              {x: new Date(1993, 1, 1), y: 345},
+              {x: new Date(1997, 1, 1), y: 515},
+              {x: new Date(2001, 1, 1), y: 132},
+              {x: new Date(2005, 1, 1), y: 305},
+              {x: new Date(2011, 1, 1), y: 270},
+              {x: new Date(2015, 1, 1), y: 470}
+            ]}/>
+
           <VictoryChart
             data={this.state.scatterData}
             animate={{scatter: true, axis: false, line: false}}
@@ -109,14 +122,9 @@ class App extends React.Component {
               {type: "scatter"}
             ]}/>
 
-          <VictoryChart {...this.state}
-            data={this.state.lineData}
-            showGridLines={{x: false, y: true}}
-            animate={true}/>
-
           <VictoryChart
             showGridLines={{x: true, y: true}}
-            axisLabels={{ x: "x axis", y: "y axis", labelPadding: 20 }}
+            axisLabels={{x: "x axis", y: "y axis"}}
             x={[
               [1, 2, 3, 4],
               [-2, -1, 0, 1, 3],
@@ -132,50 +140,24 @@ class App extends React.Component {
             {name: "line-two", type: "line", stroke: "green"},
             {name: "line-3", type: "scatter", color: "blue"}
           ]}/>
-           <VictoryChart
-              dataAttributes={{ type: 'bar' }}
-              barColors={['#07458B', '#50ADD7']}
-              axisLabels={{ y: 'Minutes Viewed (Millions)' }}
-              scale={{
-                x: () => d3.scale.ordinal(),
-                y: () => d3.scale.linear(),
-              }}
-              domain={{
-                y: [0, 8000],
-              }}
-              showGridLines={{ y: true }}
-              style={{
-                fill: "black",
-                fontFamily: 'Montserrat, sans-serif',
-                fontSize: 12,
-                width: 600,
-                height: 350,
-              }}
-              axisStyle={{
-                x: {
-                  stroke: 'none',
-                  fill: 'none',
-                },
-                y: {
-                  stroke: 'none',
-                  fill: 'none',
-                },
-              }}
-              tickValues={{
-                y: [1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000],
-                x: generateShowSnapshotXAxisCategories(showSnapshotShows)
-              }}
-              tickStyle={{
-                x: {
-                  stroke: 'none',
-                  fill: 'none',
-                },
-                y: {
-                  stroke: 'none',
-                  fill: 'none',
-                },
-              }}
-              barData={generateShowSnapshotBarChartData(showSnapshotShows)}/>
+          <VictoryChart
+            data={[
+              {x: "red", y: 2},
+              {x: "green", y: 4},
+              {x: "green", y: 1},
+              {x: "green", y: 2},
+              {x: "blue", y: 5},
+              {x: "blue", y: 3},
+            ]}
+            dataAttributes={[
+              {name: "nameData", type: "scatter", color: "red"}
+            ]}
+            animate={false}
+            y={(x) => x}
+            yAttributes={[
+              {name: "line-two", type: "line", stroke: "green"}
+            ]}/>
+
         </p>
       </div>
     );
@@ -185,33 +167,3 @@ class App extends React.Component {
 const content = document.getElementById("content");
 
 React.render(<App/>, content);
-
-// <VictoryChart interpolation="linear"
-//   scale={{
-//     x: () => d3.time.scale(),
-//     y: () => d3.scale.linear()
-//   }}
-//   tickValues={{
-//     x: [
-//       new Date(1980, 1, 1),
-//       new Date(1990, 1, 1),
-//       new Date(2000, 1, 1),
-//       new Date(2010, 1, 1),
-//       new Date(2020, 1, 1)
-//     ],
-//     y: [100, 200, 300, 400, 500]
-//   }}
-//   tickFormat={{
-//     x: () => d3.time.format("%Y"),
-//     y: () => d3.scale.linear().tickFormat()
-//   }}
-//   data={[
-//     {x: new Date(1982, 1, 1), y: 125},
-//     {x: new Date(1987, 1, 1), y: 257},
-//     {x: new Date(1993, 1, 1), y: 345},
-//     {x: new Date(1997, 1, 1), y: 515},
-//     {x: new Date(2001, 1, 1), y: 132},
-//     {x: new Date(2005, 1, 1), y: 305},
-//     {x: new Date(2011, 1, 1), y: 270},
-//     {x: new Date(2015, 1, 1), y: 470}
-//   ]}/>

--- a/demo/app.jsx
+++ b/demo/app.jsx
@@ -52,15 +52,15 @@ class App extends React.Component {
     return _.map(_.range(5), () => {
       return [
         {
-          x: "first",
+          x: "apples",
           y: _.random(1, 5)
         },
         {
-          x: "second",
+          x: "oranges",
           y: _.random(1, 10)
         },
         {
-          x: "third",
+          x: "bananas",
           y: _.random(1, 15)
         }
       ];
@@ -190,9 +190,10 @@ class App extends React.Component {
               {type: "bar", color: "gold"},
               {type: "bar", color: "tomato"}
             ]}
+            axisOrientation={{x: "top", y: "right"}}
             barCategories={[[1, 3], [4, 7], [9, 11]]}
             domainOffset={{
-              x: 0.2,
+              x: 20,
               y: 0
             }}
             animate={true}/>
@@ -207,7 +208,7 @@ class App extends React.Component {
               {type: "stackedBar", color: "tomato"}
             ]}
             domainOffset={{
-              x: 0.2,
+              x: 100,
               y: 0
             }}
             animate={true}/>

--- a/demo/app.jsx
+++ b/demo/app.jsx
@@ -145,15 +145,15 @@ class App extends React.Component {
               [
                 {x: "red", y: 2},
                 {x: "green", y: 4},
-                {x: "blue", y: 2},
+                {x: "blue", y: 2}
               ], [
                 {x: "red", y: 1},
                 {x: "green", y: 2},
-                {x: "blue", y: 3},
+                {x: "blue", y: 3}
               ], [
                 {x: "red", y: 4},
                 {x: "green", y: 1},
-                {x: "blue", y: 2},
+                {x: "blue", y: 2}
               ]
             ]}
             dataAttributes={[
@@ -161,7 +161,7 @@ class App extends React.Component {
               {name: "series2", type: "bar", color: "green"},
               {name: "series2", type: "bar", color: "red"}
             ]}
-            y={[1, 2, 1]}
+            y={[[1, 2, 1], [2, 3, 3]]}
             yAttributes={{name: "line1", type: "line", stroke: "blue"}}
             domainOffset={{
               x: 0.2,

--- a/demo/app.jsx
+++ b/demo/app.jsx
@@ -192,7 +192,7 @@ class App extends React.Component {
             ]}
             axisOrientation={{x: "top", y: "right"}}
             barCategories={[[1, 3], [4, 7], [9, 11]]}
-            domainOffset={{
+            domainPadding={{
               x: 20,
               y: 0
             }}
@@ -207,7 +207,7 @@ class App extends React.Component {
               {type: "stackedBar", color: "gold"},
               {type: "stackedBar", color: "tomato"}
             ]}
-            domainOffset={{
+            domainPadding={{
               x: 100,
               y: 0
             }}

--- a/demo/app.jsx
+++ b/demo/app.jsx
@@ -191,7 +191,7 @@ class App extends React.Component {
               {type: "bar", color: "tomato"}
             ]}
             axisOrientation={{x: "top", y: "right"}}
-            barCategories={[[1, 3], [4, 7], [9, 11]]}
+            categories={[[1, 3], [4, 7], [9, 11]]}
             domainPadding={{
               x: 20,
               y: 0

--- a/demo/app.jsx
+++ b/demo/app.jsx
@@ -61,7 +61,7 @@ class App extends React.Component {
         lineData: this.getData(),
         dataAttributes: this.getStyles()
       });
-    }, 4000);
+    }, 20000);
   }
 
   render() {
@@ -142,21 +142,36 @@ class App extends React.Component {
           ]}/>
           <VictoryChart
             data={[
-              {x: "red", y: 2},
-              {x: "green", y: 4},
-              {x: "green", y: 1},
-              {x: "green", y: 2},
-              {x: "blue", y: 5},
-              {x: "blue", y: 3},
+              [
+                {x: "red", y: 2},
+                {x: "green", y: 4},
+                {x: "blue", y: 2},
+              ], [
+                {x: "red", y: 1},
+                {x: "green", y: 2},
+                {x: "blue", y: 3},
+              ], [
+                {x: "red", y: 4},
+                {x: "green", y: 1},
+                {x: "blue", y: 2},
+              ]
             ]}
             dataAttributes={[
-              {name: "nameData", type: "scatter", color: "red"}
+              {name: "series1", type: "bar", color: "blue"},
+              {name: "series2", type: "bar", color: "green"},
+              {name: "series2", type: "bar", color: "red"}
             ]}
-            animate={false}
-            y={(x) => x}
-            yAttributes={[
-              {name: "line-two", type: "line", stroke: "green"}
-            ]}/>
+            y={[1, 2, 1]}
+            yAttributes={{name: "line1", type: "line", stroke: "blue"}}
+            domainOffset={{
+              x: 0.2,
+              y: 0.1
+            }}
+            axisOrientation={{
+              x: "top",
+              y: "left"
+            }}
+            animate={false}/>
 
         </p>
       </div>

--- a/demo/app.jsx
+++ b/demo/app.jsx
@@ -12,6 +12,7 @@ class App extends React.Component {
     this.state = {
       scatterData: this.getScatterData(),
       lineData: this.getData(),
+      barData: this.getBarData(),
       dataAttributes: {
         stroke: "blue",
         strokeWidth: 2
@@ -28,11 +29,30 @@ class App extends React.Component {
     });
   }
 
+  getBarData() {
+    const categories = ["red", "green", "blue"];
+    return _.map(_.range(5), (index) => {
+      return [
+        {
+          x: "red",
+          y: _.random(1, 5)
+        },
+        {
+          x: "green",
+          y: _.random(1, 10)
+        },
+        {
+          x: "blue",
+          y: _.random(1, 15)
+        }
+      ];
+    });
+  }
+
   getScatterData() {
     const colors =
       ["violet", "cornflowerblue", "gold", "orange", "turquoise", "tomato", "greenyellow"];
     const symbols = ["circle", "star", "square", "triangleUp", "triangleDown", "diamond", "plus"];
-    // symbol: symbols[scaledIndex],
     return _.map(_.range(20), (index) => {
       const scaledIndex = _.floor(index % 7);
       return {
@@ -59,9 +79,10 @@ class App extends React.Component {
       this.setState({
         scatterData: this.getScatterData(),
         lineData: this.getData(),
+        barData: this.getBarData(),
         dataAttributes: this.getStyles()
       });
-    }, 20000);
+    }, 4000);
   }
 
   render() {
@@ -105,7 +126,7 @@ class App extends React.Component {
 
           <VictoryChart
             data={this.state.scatterData}
-            animate={{scatter: true, axis: false, line: false}}
+            animate={true}
             dataAttributes={{type: "scatter"}}
             y={(x) => x}/>
 
@@ -141,37 +162,19 @@ class App extends React.Component {
             {name: "line-3", type: "scatter", color: "blue"}
           ]}/>
           <VictoryChart
-            data={[
-              [
-                {x: "red", y: 2},
-                {x: "green", y: 4},
-                {x: "blue", y: 2}
-              ], [
-                {x: "red", y: 1},
-                {x: "green", y: 2},
-                {x: "blue", y: 3}
-              ], [
-                {x: "red", y: 4},
-                {x: "green", y: 1},
-                {x: "blue", y: 2}
-              ]
-            ]}
+            data={this.state.barData}
             dataAttributes={[
-              {name: "series1", type: "bar", color: "blue"},
-              {name: "series2", type: "bar", color: "green"},
-              {name: "series2", type: "bar", color: "red"}
+              {type: "stackedBar", color: "cornflowerblue"},
+              {type: "stackedBar", color: "orange"},
+              {type: "stackedBar", color: "greenyellow"},
+              {type: "stackedBar", color: "gold"},
+              {type: "stackedBar", color: "tomato"}
             ]}
-            y={[[1, 2, 1], [2, 3, 3]]}
-            yAttributes={{name: "line1", type: "line", stroke: "blue"}}
             domainOffset={{
               x: 0.2,
-              y: 0.1
+              y: 0
             }}
-            axisOrientation={{
-              x: "top",
-              y: "left"
-            }}
-            animate={false}/>
+            animate={true}/>
 
         </p>
       </div>

--- a/demo/app.jsx
+++ b/demo/app.jsx
@@ -12,6 +12,7 @@ class App extends React.Component {
     this.state = {
       scatterData: this.getScatterData(),
       lineData: this.getData(),
+      numericBarData: this.getNumericBarData(),
       barData: this.getBarData(),
       dataAttributes: {
         stroke: "blue",
@@ -29,20 +30,38 @@ class App extends React.Component {
     });
   }
 
-  getBarData() {
-    const categories = ["red", "green", "blue"];
-    return _.map(_.range(5), (index) => {
+  getNumericBarData() {
+    return _.map(_.range(5), () => {
       return [
         {
-          x: "red",
+          x: _.random(1, 3),
           y: _.random(1, 5)
         },
         {
-          x: "green",
+          x: _.random(4, 7),
           y: _.random(1, 10)
         },
         {
-          x: "blue",
+          x: _.random(9, 11),
+          y: _.random(1, 15)
+        }
+      ];
+    });
+  }
+
+  getBarData() {
+    return _.map(_.range(5), () => {
+      return [
+        {
+          x: "first",
+          y: _.random(1, 5)
+        },
+        {
+          x: "second",
+          y: _.random(1, 10)
+        },
+        {
+          x: "third",
           y: _.random(1, 15)
         }
       ];
@@ -80,6 +99,7 @@ class App extends React.Component {
         scatterData: this.getScatterData(),
         lineData: this.getData(),
         barData: this.getBarData(),
+        numericBarData: this.getNumericBarData(),
         dataAttributes: this.getStyles()
       });
     }, 4000);
@@ -126,7 +146,7 @@ class App extends React.Component {
 
           <VictoryChart
             data={this.state.scatterData}
-            animate={true}
+            animate={{scatter: true, axis: false, line: false}}
             dataAttributes={{type: "scatter"}}
             y={(x) => x}/>
 
@@ -161,7 +181,24 @@ class App extends React.Component {
             {name: "line-two", type: "line", stroke: "green"},
             {name: "line-3", type: "scatter", color: "blue"}
           ]}/>
+
           <VictoryChart
+            data={this.state.numericBarData}
+            dataAttributes={[
+              {type: "bar", color: "cornflowerblue"},
+              {type: "bar", color: "orange"},
+              {type: "bar", color: "greenyellow"},
+              {type: "bar", color: "gold"},
+              {type: "bar", color: "tomato"}
+            ]}
+            barCategories={[[1, 3], [4, 7], [9, 11]]}
+            domainOffset={{
+              x: 0.2,
+              y: 0
+            }}
+            animate={true}/>
+
+            <VictoryChart
             data={this.state.barData}
             dataAttributes={[
               {type: "stackedBar", color: "cornflowerblue"},
@@ -175,7 +212,6 @@ class App extends React.Component {
               y: 0
             }}
             animate={true}/>
-
         </p>
       </div>
     );

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "style-loader": "~0.8.0",
     "url-loader": "~0.5.5",
     "victory-bar": "^1.0.3",
-    "victory-axis": "FormidableLabs/victory-axis",
+    "victory-axis": "^1.0.2",
     "victory-line": "^0.0.6",
     "victory-scatter": "^0.0.3",
     "webpack": "^1.10.0"

--- a/src/components/victory-chart.jsx
+++ b/src/components/victory-chart.jsx
@@ -102,8 +102,8 @@ class VictoryChart extends React.Component {
     }
 
     // if categories exist and are strings, create a map from those strings
-    if (props.barCategories && Util.containsStrings(props.barCategories)) {
-      return _.zipObject(_.map(props.barCategories, (category, index) => {
+    if (props.categories && Util.containsStrings(props.categories)) {
+      return _.zipObject(_.map(props.categories, (category, index) => {
         return ["" + category, index + 1];
       }));
     }
@@ -330,7 +330,7 @@ class VictoryChart extends React.Component {
       domain = props.domain[axis] || props.domain;
     } else if (props.tickValues) {
       domain = this._getDomainFromTickValues(props, axis);
-    } else if (props.barCategories && axis === "x") {
+    } else if (props.categories && axis === "x") {
       domain = this._getDomainFromCategories(props);
     } else {
       domain = this._getDomainFromData(axis);
@@ -373,7 +373,7 @@ class VictoryChart extends React.Component {
   }
 
   _getDomainFromCategories(props) {
-    const categories = _.flatten(props.barCategories);
+    const categories = _.flatten(props.categories);
     if (Util.containsStrings(categories)) {
       return undefined;
     }
@@ -446,7 +446,6 @@ class VictoryChart extends React.Component {
   }
 
   getTickValues(props, axis) {
-    const categories = props.barCategories;
     // if tickValues are defined in props, and dont contain strings, just return them
     if (props.tickValues && !Util.containsStrings(props.tickValues[axis])) {
       return props.tickValues[axis];
@@ -455,10 +454,10 @@ class VictoryChart extends React.Component {
       return props.tickValues ?
         _.map(this.props.tickValues[axis], (tick) => this.stringMap[axis][tick]) :
         _.values(this.stringMap[axis]);
-    } else if (axis === "x" && categories && !Util.containsStrings(categories)) {
-      // return tick values based on the bar categories
-      return _.isArray(categories[0]) ?
-        _.map(categories, (arr) => (_.sum(arr) / arr.length)) : categories;
+    } else if (axis === "x" && props.categories && !Util.containsStrings(props.categories)) {
+      // return tick values based on the categories
+      return _.isArray(props.categories[0]) ?
+        _.map(props.categories, (arr) => (_.sum(arr) / arr.length)) : props.categories;
     } else {
       // let axis determine it's own ticks
       return undefined;
@@ -539,7 +538,7 @@ class VictoryChart extends React.Component {
         style={this.style}
         domain={{x: this.domain.x, y: this.domain.y}}
         range={{x: this.range.x, y: this.range.y}}
-        categories={this.props.barCategories || categories}
+        categories={this.props.categories || categories}
         categoryOffset={offset}
         key={"bar"}/>
     );
@@ -679,7 +678,7 @@ VictoryChart.propTypes = {
     React.PropTypes.arrayOf(React.PropTypes.object)
   ]),
   /**
-   * The x props provides another way to supply data for chart to plot. This prop can be given
+   * The x prop provides another way to supply data for chart to plot. This prop can be given
    * as an array of values or an array of arrays, and it will be plotted against whatever
    * y prop is provided. If no props are provided for y, the values in x will be plotted
    * as the identity function (x) => x.
@@ -687,7 +686,7 @@ VictoryChart.propTypes = {
    */
   x: React.PropTypes.array,
   /**
-   * The y props provides another way to supply data for chart to plot. This prop can be given
+   * The y prop provides another way to supply data for chart to plot. This prop can be given
    * as a function of x, or an array of values, or an array of functions and / or values.
    * if x props are given, they will be used in plotting (x, y) data points. If x props are not
    * provided, a set of x values evenly spaced across the x domain will be calculated, and used
@@ -891,13 +890,13 @@ VictoryChart.propTypes = {
     y: React.PropTypes.number
   }),
   /**
-   * The barCategories prop specifies the categories for a bar chart. This prop should
+   * The categories prop specifies the categories for a bar chart. This prop should
    * be given as an array of string values, numeric values, or arrays. When this prop is
    * given as an array of arrays, the minimum and maximum values of the arrays define range bands,
    * allowing numeric data to be grouped into segments.
    * @example ["dogs", "cats", "mice"], [[0, 5], [5, 10], [10, 15]]
    */
-  barCategories: React.PropTypes.array,
+  categories: React.PropTypes.array,
   /**
    * The animate prop determines whether the chart should animate with changing data.
    * This prop can be given as a boolean, or an object with boolean values specified for each

--- a/src/components/victory-chart.jsx
+++ b/src/components/victory-chart.jsx
@@ -455,7 +455,7 @@ class VictoryChart extends React.Component {
         _.map(this.props.tickValues[axis], (tick) => this.stringMap[axis][tick]) :
         _.values(this.stringMap[axis]);
     } else if (axis === "x" && props.categories && !Util.containsStrings(props.categories)) {
-      // return tick values based on the categories
+      // return tick values based on the bar categories
       return _.isArray(props.categories[0]) ?
         _.map(props.categories, (arr) => (_.sum(arr) / arr.length)) : props.categories;
     } else {
@@ -678,7 +678,7 @@ VictoryChart.propTypes = {
     React.PropTypes.arrayOf(React.PropTypes.object)
   ]),
   /**
-   * The x prop provides another way to supply data for chart to plot. This prop can be given
+   * The x props provides another way to supply data for chart to plot. This prop can be given
    * as an array of values or an array of arrays, and it will be plotted against whatever
    * y prop is provided. If no props are provided for y, the values in x will be plotted
    * as the identity function (x) => x.
@@ -686,7 +686,7 @@ VictoryChart.propTypes = {
    */
   x: React.PropTypes.array,
   /**
-   * The y prop provides another way to supply data for chart to plot. This prop can be given
+   * The y props provides another way to supply data for chart to plot. This prop can be given
    * as a function of x, or an array of values, or an array of functions and / or values.
    * if x props are given, they will be used in plotting (x, y) data points. If x props are not
    * provided, a set of x values evenly spaced across the x domain will be calculated, and used

--- a/src/components/victory-chart.jsx
+++ b/src/components/victory-chart.jsx
@@ -78,8 +78,8 @@ class VictoryChart extends React.Component {
       y: this.getDomain("y")
     };
     this.scale = {
-      x: this.getScale("x"),
-      y: this.getScale("y")
+      x: this.getScale(props, "x"),
+      y: this.getScale(props, "y")
     };
   }
 
@@ -403,9 +403,9 @@ class VictoryChart extends React.Component {
       [style.height - style.margin, style.margin];
   }
 
-  getScale(axis) {
-    const scale = this.props.scale[axis] ? this.props.scale[axis]().copy() :
-      this.props.scale().copy();
+  getScale(props, axis) {
+    const scale = props.scale[axis] ? props.scale[axis]().copy() :
+      props.scale().copy();
     const range = this.range[axis];
     const domain = this.getDomain(axis);
     scale.range(range);
@@ -424,10 +424,6 @@ class VictoryChart extends React.Component {
   getAxisOffset() {
     // make the axes line up, and cross when appropriate
     const style = this.getStyles();
-    const scale = {
-      x: this.getScale("x"),
-      y: this.getScale("y")
-    };
     const origin = {
       x: _.max([_.min(this.getDomain("x")), 0]),
       y: _.max([_.min(this.getDomain("y")), 0])
@@ -437,8 +433,8 @@ class VictoryChart extends React.Component {
       y: this.props.axisOrientation.x === "bottom" ? style.height : 0
     };
     return {
-      x: Math.abs(orientationOffset.x - scale.x.call(this, origin.x)),
-      y: Math.abs(orientationOffset.y - scale.y.call(this, origin.y))
+      x: Math.abs(orientationOffset.x - this.scale.x.call(this, origin.x)),
+      y: Math.abs(orientationOffset.y - this.scale.y.call(this, origin.y))
     };
   }
 
@@ -463,7 +459,6 @@ class VictoryChart extends React.Component {
   }
 
   getTickFormat(axis) {
-    const scale = this.getScale(axis);
     if (this.props.tickFormat) {
       return this.props.tickFormat[axis]();
     } else if (this.props.tickValues && !Util.containsStrings(this.props.tickValues[axis])) {
@@ -474,7 +469,7 @@ class VictoryChart extends React.Component {
       const dataTicks = ["", ...dataNames, ""];
       return (x) => dataTicks[x];
     } else {
-      return scale.tickFormat();
+      return this.scale[axis].tickFormat();
     }
   }
 

--- a/src/util.js
+++ b/src/util.js
@@ -1,15 +1,16 @@
+/* eslint-disable*/
 var _ = require("lodash");
 
 module.exports = {
   containsStrings: function (collection) {
     return _.some(collection, function (item) {
       return _.isString(item);
-    })
+    });
   },
 
   containsOnlyStrings: function (collection) {
     return _.every(collection, function (item) {
       return _.isString(item);
-    })
+    });
   }
 };

--- a/src/util.js
+++ b/src/util.js
@@ -1,0 +1,9 @@
+var _ = require("lodash");
+
+module.exports = {
+  containsStrings: function (collection) {
+    return _.some(collection, function (item) {
+      return _.isString(item);
+    })
+  }
+};

--- a/src/util.js
+++ b/src/util.js
@@ -5,5 +5,11 @@ module.exports = {
     return _.some(collection, function (item) {
       return _.isString(item);
     })
+  },
+
+  containsOnlyStrings: function (collection) {
+    return _.every(collection, function (item) {
+      return _.isString(item);
+    })
   }
 };


### PR DESCRIPTION
cc/ @colinmegill 

Chart needed a *big* refactor for non-numeric data! This definitely needs a seconds set of eyes.

This PR adds:
chartType prop (so you dont have to specify the type in each object in the dataAttributes array)
bar and stacked bar chart types
support for string data via a generated string map from data rather than d3 ordinal scales
support for bar categories as an array (string and numeric arrays act basically like tick values, arrays of arrays act like range bands)
optional domain offset prop (useful for bar charts if you dont want the data to overlap the origin)

TODOS
- [ ] continue extracting stuff into Util, and maybe make it it's own repo
- [ ] automatically color data
- [x]  docs! docs! docs!