### PR TITLE
fix tick formatting for string tickValue arrays

### DIFF
--- a/demo/app.jsx
+++ b/demo/app.jsx
@@ -230,11 +230,7 @@ class App extends React.Component {
               {x: 13, y: 1}
             ]}
             tickValues={{
-              x: _.range(1, 14)
-            }}
-            tickFormat={{
-              x: (x) => x,
-              y: () => ""
+              x: ["12", "13", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11"]
             }}
             axisStyle={{
               x: {stroke: "transparent", fill: "none"},
@@ -242,7 +238,7 @@ class App extends React.Component {
             }}
             tickStyle={{
               x: {stroke: "transparent", fill: "none"},
-              y: {stroke: "transparent", fill: "none"}
+              y: {stroke: "transparent", fill: "none", padding: 20}
             }}
             domainPadding={{
               x: 20,


### PR DESCRIPTION
cc/ @zachhale 

I recently started supporting passing in just one property for the tickValues prop like so `tickValues={{x: ["13", "1", "2"]}}, so that was making an issue. I was also returning the unordered values from the stringMap.  This fixes both issues.