### PR TITLE
Remove render method duplication, use createElement

### DIFF
--- a/src/components/victory-chart.jsx
+++ b/src/components/victory-chart.jsx
@@ -686,8 +686,8 @@ class VictoryChart extends React.Component {
 
   render() {
     const style = this.style.base;
-    const props = this.props.containerElement === 'svg' ? {
-      style: { width: style.width, height: style.height, overflow: 'visible' }
+    const props = this.props.containerElement === "svg" ? {
+      style: { width: style.width, height: style.height, overflow: "visible" }
     } : {};
     return React.createElement(
       this.props.containerElement, props,

--- a/src/components/victory-chart.jsx
+++ b/src/components/victory-chart.jsx
@@ -685,24 +685,16 @@ class VictoryChart extends React.Component {
   }
 
   render() {
-    if (this.props.containerElement === "svg") {
-      const style = this.style.base;
-      return (
-        <svg style={{ width: style.width, height: style.height, overflow: "visible" }}>
-          {this.drawAxis("x")}
-          {this.drawAxis("y")}
-          {this.drawData()}
-        </svg>
-      );
-    } else {
-      return (
-        <g>
-          {this.drawAxis("x")}
-          {this.drawAxis("y")}
-          {this.drawData()}
-        </g>
-      );
-    }
+    const style = this.style.base;
+    const props = this.props.containerElement === 'svg' ? {
+      style: { width: style.width, height: style.height, overflow: 'visible' }
+    } : {};
+    return React.createElement(
+      this.props.containerElement, props,
+      this.drawAxis("x"),
+      this.drawAxis("y"),
+      this.drawData()
+    );
   }
 }
 


### PR DESCRIPTION
When passing in a component name/class to use, like our `containerElement` prop, we can pass that value directly to `React.createElement` to have it create the requested type for us. This lets us get rid of the extra conditional branch and duplication.

/cc @boygirl