### PR TITLE
default samples prop

### DIFF
--- a/src/components/victory-chart.jsx
+++ b/src/components/victory-chart.jsx
@@ -375,7 +375,8 @@ export default class VictoryChart extends React.Component {
       x: 7,
       y: 5
     },
-    standalone: true
+    standalone: true,
+    samples: 50
   };
 
   constructor(props) {


### PR DESCRIPTION
cc/ @exogen 

somehow this got lost in the fray. defaultProp samples is needed so that functions plot several points when no other props are passed. If this prop is not set, functions will always plot straight lines, as they will only ever plot 2 points. The number of samples is pretty arbitrary.