### PR TITLE
Omit null/undefined children from looping children

### DIFF
--- a/src/components/victory-chart.jsx
+++ b/src/components/victory-chart.jsx
@@ -205,6 +205,7 @@ export default class VictoryChart extends React.Component {
     // loop through children, and add each child to the childComponents array
     // unless the limit for that child type has already been reached.
     React.Children.forEach(props.children, (child) => {
+      if (!child || !child.type) { return; }
       const type = child.type.displayName;
       if (count.limitReached(child)) {
         const msg = type === "VictoryAxis" ?


### PR DESCRIPTION
/cc @boygirl I'm not sure how to test this properly, but this solves a problem where if I have conditional code in my `<VictoryChart>{condition ? <VictoryBar/> : null}</VictoryChart>` block now VictoryChart shouldn't crash.