### PR TITLE
If padding is passed in as an object, deafult all non-specified padding attributes to 0

### DIFF
--- a/src/components/victory-chart.jsx
+++ b/src/components/victory-chart.jsx
@@ -13,8 +13,6 @@ const defaultAxes = {
 
 const defaultData = <VictoryLine domain={{x: [0, 1], y: [0, 1]}}/>;
 
-const defaultPadding = 30;
-
 @Radium
 export default class VictoryChart extends React.Component {
   static propTypes = {
@@ -172,12 +170,13 @@ export default class VictoryChart extends React.Component {
   }
 
   getPadding(props) {
-    const padding = _.isNumber(props.padding) ? props.padding : defaultPadding;
+    const padding = _.isNumber(props.padding) ? props.padding : 0;
+    const paddingObj = _.isObject(props.padding) ? props.padding : {};
     return {
-      top: props.padding.top || padding,
-      bottom: props.padding.bottom || padding,
-      left: props.padding.left || padding,
-      right: props.padding.right || padding
+      top: paddingObj.top || padding,
+      bottom: paddingObj.bottom || padding,
+      left: paddingObj.left || padding,
+      right: paddingObj.right || padding
     };
   }
 


### PR DESCRIPTION
Related to #44.

The deafult behavior has not changed. If you don't specify `padding`, it'll still be 30px around the chart. Now, though, if you specify an object for padding like `padding={{left: 100}}` it will default all non-specified edges to 0, so in this case `padding={{left: 100}}` actually means `padding={{left: 100, top: 0, right: 0, bottom: 0}}`.

I verified on the demo page that default behavior has not changed.

/cc @boygirl 