### PR TITLE
fix double axis rendering bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "d3": "^3.5.6",
     "lodash": "^3.9.3",
     "radium": "^0.14.3",
-    "victory-axis": "1.5.3",
+    "victory-axis": "1.5.4",
     "victory-bar": "2.4.6",
     "victory-line": "0.5.5",
     "victory-scatter": "0.5.3",

--- a/src/components/victory-chart.jsx
+++ b/src/components/victory-chart.jsx
@@ -106,17 +106,6 @@ export default class VictoryChart extends React.Component {
     standalone: true
   };
 
-  constructor(props) {
-    super(props);
-    this.getComponents(props);
-    this.getCalculatedValues(props);
-  }
-
-  componentWillReceiveProps(nextProps) {
-    this.getComponents(nextProps);
-    this.getCalculatedValues(nextProps);
-  }
-
   getComponents(props) {
     this.groupedDataTypes = ["bar"];
     this.childComponents = this.getChildComponents(props);
@@ -186,7 +175,7 @@ export default class VictoryChart extends React.Component {
   }
 
   getAxisType(child) {
-    if (child.type !== VictoryAxis) {
+    if (!child.type || child.type.role !== "axis") {
       return undefined;
     }
     return child.props.dependentAxis ? "dependent" : "independent";
@@ -737,6 +726,8 @@ export default class VictoryChart extends React.Component {
   }
 
   render() {
+    this.getComponents(this.props);
+    this.getCalculatedValues(this.props);
     const style = this.style.parent;
     const group = (
       <g style={style}>


### PR DESCRIPTION
cc/ @zachhale cc/ @coopy 

This PR fixes the double axis rendering bug you were seeing. The problem was with the `getAxisType` method. I also moved all of the value calculation into render to match other repos. 