### PR TITLE
move deps to devDeps, basic test coverage, d3-modules

### DIFF
--- a/demo/app.jsx
+++ b/demo/app.jsx
@@ -2,7 +2,7 @@
 /*global window:false */
 import React from "react";
 import ReactDOM from "react-dom";
-import d3 from "d3";
+import d3Scale from "d3-scale";
 import _ from "lodash";
 import {VictoryChart} from "../src/index";
 import {VictoryAxis} from "victory-axis";
@@ -151,8 +151,8 @@ class App extends React.Component {
 
           <VictoryChart style={chartStyle}
             scale={{
-              x: d3.time.scale(),
-              y: d3.scale.linear()
+              x: d3Scale.time(),
+              y: d3Scale.linear()
             }}
           >
             <VictoryAxis
@@ -164,7 +164,7 @@ class App extends React.Component {
                 new Date(2010, 1, 1),
                 new Date(2020, 1, 1)
               ]}
-              tickFormat={d3.time.format("%Y")}
+              tickFormat={(x) => x.getFullYear()}
             />
             <VictoryLine
               data={[

--- a/package.json
+++ b/package.json
@@ -22,21 +22,21 @@
   "dependencies": {
     "builder": "~2.2.2",
     "builder-victory-component": "~0.0.5",
-    "d3": "^3.5.6",
     "victory-axis": "1.5.4",
-    "victory-bar": "2.4.6",
     "victory-line": "0.5.5",
-    "victory-scatter": "0.5.3",
     "victory-util": "^2.0.2"
   },
   "devDependencies": {
     "builder-victory-component-dev": "~0.0.5",
     "chai": "^3.2.0",
+    "d3-scale": "^0.2.0",
     "mocha": "^2.3.3",
     "react": "^0.14.3",
     "react-addons-test-utils": "^0.14.3",
     "react-dom": "^0.14.3",
     "sinon": "^1.17.2",
-    "sinon-chai": "^2.8.0"
+    "sinon-chai": "^2.8.0",
+    "victory-bar": "2.4.6",
+    "victory-scatter": "0.5.3"
   }
 }

--- a/src/components/victory-chart.jsx
+++ b/src/components/victory-chart.jsx
@@ -1,6 +1,6 @@
+import _ from "lodash";
 import React from "react";
 import Radium from "radium";
-import _ from "lodash";
 import {Collection, Log, PropTypes} from "victory-util";
 import {VictoryAxis} from "victory-axis";
 import {VictoryLine} from "victory-line";

--- a/test/client/spec/components/victory-chart.spec.jsx
+++ b/test/client/spec/components/victory-chart.spec.jsx
@@ -1,24 +1,33 @@
 /**
  * Client tests
  */
-import React from "react/addons";
-import Component from "src/components/victory-chart";
-
+import React from "react";
+import ReactDOM from "react-dom";
+import VictoryChart from "src/components/victory-chart";
 // Use `TestUtils` to inject into DOM, simulate events, etc.
 // See: https://facebook.github.io/react/docs/test-utils.html
 import TestUtils from "react-addons-test-utils";
 
+const getElement = function (output, tagName) {
+  return ReactDOM.findDOMNode(
+    TestUtils.findRenderedDOMComponentWithTag(output, tagName)
+  );
+};
+
+let renderedComponent;
+
 describe("components/victory-chart", () => {
+  describe("default component rendering", () => {
+    before(() => {
+      renderedComponent = TestUtils.renderIntoDocument(<VictoryChart/>);
+    });
 
-  it("has expected content with shallow render", () => {
-    // This is a "shallow" render that renders only the current component
-    // without using the actual DOM.
-    //
-    // https://facebook.github.io/react/docs/test-utils.html#shallow-rendering
-    const renderer = TestUtils.createRenderer();
-    renderer.render(<Component />);
-    const output = renderer.getRenderOutput();
+    it("renders an svg with the correct width and height", () => {
 
-    expect(output.type).to.equal("svg");
+      const svg = getElement(renderedComponent, "svg");
+      // default width and height
+      expect(svg.style.width).to.equal(`${VictoryChart.defaultProps.width}px`);
+      expect(svg.style.height).to.equal(`${VictoryChart.defaultProps.height}px`);
+    });
   });
 });


### PR DESCRIPTION
cc/ @coopy 

this biggest change in this PR is that it moves things like `victory-bar` to `devDependencies`.  `victory-axis` and `victory-line` are the only components that are real deps as they are used for sensible defaults. 