### PR TITLE
hotfix for date inconsistency

### DIFF
--- a/src/components/victory-chart.jsx
+++ b/src/components/victory-chart.jsx
@@ -549,8 +549,9 @@ export default class VictoryChart extends React.Component {
     const percentPadding = domainPadding ? domainPadding / rangeExtent : 0.01;
     const padding = extent * percentPadding;
     // don't make the axes cross if they aren't already
-    const adjustedMin = (min >= 0 && (min - padding) <= 0) ? 0 : min - padding;
-    const adjustedMax = (max <= 0 && (max + padding) >= 0) ? 0 : max + padding;
+    // valueOf creates a consistent date format for browsers
+    const adjustedMin = (min >= 0 && (min - padding) <= 0) ? 0 : min.valueOf - padding;
+    const adjustedMax = (max <= 0 && (max + padding) >= 0) ? 0 : max.valueOf + padding;
     return _.isDate(min) || _.isDate(max) ?
       [new Date(adjustedMin), new Date(adjustedMax)] : [adjustedMin, adjustedMax];
   }


### PR DESCRIPTION
Firefox doesn't seem to perform Date + number as intended. The fix is to create the primitive value and then perform addition.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/valueOf