### PR TITLE
Date inconsistency 

### DIFF
--- a/src/components/victory-chart.jsx
+++ b/src/components/victory-chart.jsx
@@ -550,8 +550,8 @@ export default class VictoryChart extends React.Component {
     const padding = extent * percentPadding;
     // don't make the axes cross if they aren't already
     // valueOf creates a consistent date format for browsers
-    const adjustedMin = (min >= 0 && (min - padding) <= 0) ? 0 : min.valueOf - padding;
-    const adjustedMax = (max <= 0 && (max + padding) >= 0) ? 0 : max.valueOf + padding;
+    const adjustedMin = (min >= 0 && (min - padding) <= 0) ? 0 : min.valueOf() - padding;
+    const adjustedMax = (max <= 0 && (max + padding) >= 0) ? 0 : max.valueOf() + padding;
     return _.isDate(min) || _.isDate(max) ?
       [new Date(adjustedMin), new Date(adjustedMax)] : [adjustedMin, adjustedMax];
   }

--- a/src/components/victory-chart.jsx
+++ b/src/components/victory-chart.jsx
@@ -549,8 +549,9 @@ export default class VictoryChart extends React.Component {
     const percentPadding = domainPadding ? domainPadding / rangeExtent : 0.01;
     const padding = extent * percentPadding;
     // don't make the axes cross if they aren't already
-    const adjustedMin = (min >= 0 && (min - padding) <= 0) ? 0 : min - padding;
-    const adjustedMax = (max <= 0 && (max + padding) >= 0) ? 0 : max + padding;
+    // valueOf creates a consistent date format for browsers
+    const adjustedMin = (min >= 0 && (min - padding) <= 0) ? 0 : min.valueOf - padding;
+    const adjustedMax = (max <= 0 && (max + padding) >= 0) ? 0 : max.valueOf + padding;
     return _.isDate(min) || _.isDate(max) ?
       [new Date(adjustedMin), new Date(adjustedMax)] : [adjustedMin, adjustedMax];
   }


### PR DESCRIPTION
Some browsers might not pick up on the date format inconsistency when adding a Date and a number. 

Therefore use the primitive value of the date (or number if not padding a date) for adjusted max/min

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/valueOf
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/valueOf