### PR TITLE
Documentation for victory-chart's labelComponent properties

### DIFF
--- a/src/components/victory-bar/victory-bar.jsx
+++ b/src/components/victory-bar/victory-bar.jsx
@@ -142,9 +142,20 @@ export default class VictoryBar extends React.Component {
      */
     labels: PropTypes.array,
     /**
-     * The labelComponents prop takes in an array of entire, HTML-complete label components
-     * which will be used to create labels for individual bars, stacked bars, or groups of
-     * bars as appropriate.
+     * The labelComponents prop defines labels - as entire, HTML-complete label
+     * components - that will appear above each bar or group of bars in your
+     * bar chart. This prop should be given as an array of elements. The number
+     * of elements in the labelComponents array should be equal to the number
+     * of elements in the categories array, or, if categories is not defined,
+     * to the number of unique x values in your data. Use this prop to add
+     * labels to individual bars, stacked bars, and groups of bars. The new
+     * element created from each element of the labelComponents array will have
+     * children preserved, or provided as the label from the bar's datum;
+     * property data provided by the bar's datum; properties x, y, textAnchor,
+     * and verticalAnchor preserved or default values provided by the bar; and
+     * styles filled out with defaults provided by the bar. If you do not
+     * provide enough elements in the labelComponents array, a new
+     * VictoryLabel will be created with props and styles from the bar.
      */
     labelComponents: PropTypes.array,
     /**

--- a/src/components/victory-line/line-label.jsx
+++ b/src/components/victory-line/line-label.jsx
@@ -8,7 +8,6 @@ import { Helpers } from "victory-util";
 export default class LineLabel extends React.Component {
   static propTypes = {
     data: PropTypes.array,
-    labelComponent: PropTypes.any,
     position: PropTypes.object,
     style: PropTypes.object
   };

--- a/src/components/victory-scatter/victory-scatter.jsx
+++ b/src/components/victory-scatter/victory-scatter.jsx
@@ -73,7 +73,12 @@ export default class VictoryScatter extends React.Component {
     height: CustomPropTypes.nonNegative,
     /**
      * The labelComponent prop takes in an entire, HTML-complete label component
-     * which will be used to create labels for scatter to use
+     * which will be used to create labels for each point in the scatter plot. The new element
+     * created from the passed labelComponent will have children preserved, or provided as the label
+     * property from the point's datum; property data provided by the point's datum; properties x,
+     * y, dy, textAnchor, and verticalAnchor preserved or default values provided by the point; and
+     * styles overwritten by the styles from the scatter. If labelComponent is omitted, a new
+     * VictoryLabel will be created with props and styles from the point.
      */
     labelComponent: PropTypes.element,
     /**


### PR DESCRIPTION
While working on https://github.com/FormidableLabs/victory/issues/111 @boygirl suggested that I reconcile my proposed ```BarLabel``` and ```SliceLabel``` properties with the ```labelComponent``` property.

Step one for me to reconcile those properties is to better understand the behaviour of ```labelComponent```. I submit this (incomplete) pull request to verify I properly understand how ```labelComponent``` can be used.

### Todo:
- [x] ```VictoryScatter``` ```labelComponent``` documentation.
- [x] ```VictoryLine``` ```labelComponent``` documentation.
- [x] ```VictoryBar``` ```labelComponent``` documentation.