### PR TITLE
Added documentation for VictoryLine label property

### DIFF
--- a/src/components/victory-line/victory-line.jsx
+++ b/src/components/victory-line/victory-line.jsx
@@ -97,8 +97,14 @@ export default class VictoryLine extends React.Component {
       "stepBefore"
     ]),
     /**
-     * The label prop specifies a label to display at the end of a line component,
-     * this prop can be given as a value, or as an entire label component
+     * The label prop specifies a label to display at the end of a line component.
+     * This prop can be given as a value, or as an entire, HTML-complete label component.
+     * If given as a value, a new VictoryLabel will be created with props and
+     * styles from the line. When given as a component, a new element will be
+     * cloned from the label component. The new element will have default
+     * values provided by the line for properties x, y, textAnchor, and
+     * verticalAnchor; and styles filled out with defaults from the line, and
+     * overrides from the datum.
      */
     label: PropTypes.any,
     /**


### PR DESCRIPTION
So, it turns out for #99 that we already have the same behaviour in ```VictoryLine``` as the ```VictoryScatter``` or ```VictoryBar``` ```labelComponent``` property. However, that behaviour is found in ```label```. ```VictoryLine``` ```label``` is an overloaded property. It is similar to ```VictoryBar```'s ```labels``` and ```labelComponent``` properties, combined into one... Although it doesn't support an array of labels.

So there are some pretty interesting ideas between all three implementations. 

- ```VictoryBar``` allowing a heterogeneous mix of plain values and elements in ```label``` and so become more like ```VictoryLine```
- ```VictoryLine``` allowing labels on each datum in the ```data``` property and implementing labeling of specific points along the line, like ```VictoryScatter``` points or ```VictoryBar``` bars.
- ```VictoryLine``` could separate the different implementations of ```label``` into a ```label``` and ```labelComponent``` property as with ```VictoryBar```

Do we know which labeling approaches are favoured by users? I like the idea of having the labels with the datum across the board. I like the idea of having label elements cloned with a data/datum property.

Given the slight differences between each, I think it's been helpful for me to figure out this documentation :-)