### PR TITLE
Use lodash to check x equality when calculating y offset

### DIFF
--- a/src/components/victory-bar/helper-methods.js
+++ b/src/components/victory-bar/helper-methods.js
@@ -46,7 +46,9 @@ module.exports = {
     const previousDataSets = take(datasets, index.seriesIndex);
     const previousBars = flatten(previousDataSets.map((dataset) => {
       return dataset.data
-        .filter((previousDatum) => previousDatum.x === datum.x)
+        .filter((previousDatum) => isDate(datum.x)
+          ? previousDatum.x.getTime() === datum.x.getTime()
+          : previousDatum.x === datum.x)
         .map((previousDatum) => previousDatum.y || 0);
     }));
     return previousBars.reduce((memo, barValue) => {


### PR DESCRIPTION
If the x values where, say, Dates, bars would not stack because `===` equality isn't deep. This PR uses lodash's `isEqual` instead.