### PR TITLE
Prevent axis label collisions and overflows

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "d3-scale": "^0.2.0",
     "d3-shape": "^0.2.0",
     "lodash": "^3.10.1",
+    "measure-text": "0.0.3",
     "radium": "^0.16.2",
     "victory-animation": "^0.1.0",
     "victory-label": "^1.0.1",

--- a/src/components/victory-axis/constrain-tick-labels.js
+++ b/src/components/victory-axis/constrain-tick-labels.js
@@ -20,17 +20,18 @@ const getFontWeight = (fontWeight) => {
 };
 
 const measureTicks = (props, layoutProps, tickProps) => {
-  const { fontSize, fontWeight } = props.style.tickLabels;
+  const FALLBACK_LINE_HEIGHT = 1.2;
+
+  const { fontSize, fontWeight, lineHeight } = props.style.tickLabels;
   const { fontFamily } = layoutProps.style.tickLabels;
   const tickFormat = Helpers.getTickFormat(props, tickProps);
-
   return props.tickValues.map((tick, index) => {
     const text = tickFormat(tick, index);
     const measurement = measureText({
       text: textToArray(text),
       fontFamily,
       fontSize: `${fontSize}px`,
-      lineHeight: 1.2, // TODO: where do you find this?
+      lineHeight: lineHeight || FALLBACK_LINE_HEIGHT,
       fontWeight: getFontWeight(fontWeight),
       canvas: props.canvas
     });

--- a/src/components/victory-axis/constrain-tick-labels.js
+++ b/src/components/victory-axis/constrain-tick-labels.js
@@ -1,0 +1,189 @@
+import measureText from "measure-text";
+import Helpers from "./helper-methods.js";
+
+const parsePx = (string) => parseFloat(
+  string.replace("px", "")
+);
+
+const textToArray = (text) => {
+  return typeof text === "string"
+    ? text.split("\n")
+    : text.toString().split("\n");
+};
+
+const getFontWeight = (fontWeight) => {
+  if (fontWeight) {
+    return typeof fontWeight === "function"
+      ? fontWeight() : fontWeight;
+  }
+  return "normal";
+};
+
+const measureTicks = (props, layoutProps, tickProps) => {
+  const { fontSize, fontWeight } = props.style.tickLabels;
+  const { fontFamily } = layoutProps.style.tickLabels;
+  const tickFormat = Helpers.getTickFormat(props, tickProps);
+
+  return props.tickValues.map((tick, index) => {
+    const text = tickFormat(tick, index);
+    const measurement = measureText({
+      text: textToArray(text),
+      fontFamily,
+      fontSize: `${fontSize}px`,
+      lineHeight: 1.2, // TODO: where do you find this?
+      fontWeight: getFontWeight(fontWeight),
+      canvas: props.canvas
+    });
+    return { text, measurement, index };
+  });
+};
+
+const measurementMaximums = (props, layoutProps) => {
+  if (layoutProps.isVertical) {
+    const { size, padding } = layoutProps.style.ticks;
+    const availableSize = layoutProps.offset.x - size - padding;
+    return {
+      ellipses: availableSize,
+      lineDeletions: props.height
+    };
+  }
+  return {
+    ellipses: props.width,
+    lineDeletions: layoutProps.offset.y
+  };
+};
+
+const truncate = (label) => {
+  const CHARACTERS_TO_TRUNCATE = 4;
+
+  const lines = label.split("\n");
+
+  // If the text is single-line, don't split it
+  if (lines.length === 1) {
+    return `${label.text.slice(0, -CHARACTERS_TO_TRUNCATE)}...`;
+  }
+
+  // truncate the longest line of multi-line text
+  const longestLine = lines.reduce((prev, next, index) => {
+    return next.length > prev.length
+      ? {text: next, index}
+      : {text: prev, index: index - 1};
+  });
+  const truncatedLine = longestLine.text.slice(
+    0, -CHARACTERS_TO_TRUNCATE
+  );
+  const newLines = lines.slice();
+  newLines[longestLine.index] = `${truncatedLine}...`;
+  return newLines.join("\n");
+};
+
+const deleteOverflowingLines = (label) => {
+  const lines = label.split("\n");
+  return lines.slice(0, -1).join("\n"); // eslint-disable-line no-magic-numbers
+};
+
+const constrain = ({
+  props,
+  layoutProps,
+  tickProps,
+  dimension,
+  maximum,
+  hasNeighbors,
+  resolver,
+  guard,
+  guardWarning,
+  measureFunc
+}) => {
+  const measurements = measureFunc(props, layoutProps, tickProps);
+
+  const allEqual = measurements.every((item, index, array) => {
+    return item.measurement[dimension] === array[0].measurement[dimension];
+  });
+
+  if (allEqual) {
+    return {props, layoutProps, tickProps};
+  }
+
+  const outlier = measurements.reduce((prev, next) => {
+    const prevDim = parsePx(prev.measurement[dimension]);
+    const nextDim = parsePx(next.measurement[dimension]);
+    return nextDim > prevDim ? next : prev;
+  });
+
+  const outlierNumber = parsePx(outlier.measurement[dimension]);
+  const outlierSize = hasNeighbors
+    ? outlierNumber * measurements.length
+    : outlierNumber;
+
+  if (outlierSize <= maximum) {
+    return {props, layoutProps, tickProps};
+  }
+
+  const newTickValues = props.tickValues.slice();
+  const resolvedText = resolver(outlier.text);
+
+  if (guard(resolvedText)) {
+    return {
+      props: {
+        ...props,
+        tickValues: newTickValues,
+        failedConstraints: {
+          ...props.failedConstraints,
+          [dimension]: true,
+          [`${dimension}Warning`]: guardWarning
+        }
+      },
+      layoutProps,
+      tickProps
+    };
+  }
+
+  newTickValues[outlier.index] = resolvedText;
+  return constrain(
+    {props: {...props, tickValues: newTickValues}, layoutProps, tickProps,
+    dimension, maximum, hasNeighbors, resolver, guard, guardWarning, measureFunc}
+  );
+};
+
+const constrainTickLabels = ({
+  props,
+  layoutProps,
+  tickProps,
+  measureFunc = measureTicks
+}) => {
+  const maximums = measurementMaximums(props, layoutProps);
+
+  const ellipsizedLabels = constrain({
+    props, layoutProps, tickProps,
+    dimension: "width",
+    maximum: maximums.ellipses,
+    hasNeighbors: !layoutProps.isVertical,
+    resolver: truncate,
+    guard: (text) => text.indexOf("...") === 0,
+    guardWarning: `The tick label font size is too large to avoid horizontal
+      label overlaps.  Try setting a smaller font size.`,
+    measureFunc
+  });
+
+  const deletedLineLabels = constrain({
+    props: ellipsizedLabels.props,
+    layoutProps: ellipsizedLabels.layoutProps,
+    tickProps: ellipsizedLabels.tickProps,
+    dimension: "height",
+    maximum: maximums.lineDeletions,
+    hasNeighbors: layoutProps.isVertical,
+    resolver: deleteOverflowingLines,
+    guard: (text) => !text,
+    guardWarning: `The tick label font size is too large to avoid vertical
+      label overlaps. Try setting a smaller font size.`,
+    measureFunc
+  });
+
+  const { tickValues, failedConstraints } = deletedLineLabels.props;
+  if (failedConstraints) {
+    return { tickValues, failedConstraints };
+  }
+  return { tickValues };
+};
+
+export default constrainTickLabels;

--- a/src/components/victory-axis/constrain-tick-labels.js
+++ b/src/components/victory-axis/constrain-tick-labels.js
@@ -14,7 +14,8 @@ const textToArray = (text) => {
 const getFontWeight = (fontWeight) => {
   if (fontWeight) {
     return typeof fontWeight === "function"
-      ? fontWeight() : fontWeight;
+      ? fontWeight()
+      : fontWeight;
   }
   return "normal";
 };

--- a/src/components/victory-axis/victory-axis.jsx
+++ b/src/components/victory-axis/victory-axis.jsx
@@ -251,18 +251,19 @@ export default class VictoryAxis extends React.Component {
         props, layoutProps, tickProps
       });
     }
+
     return ticks.map((tick, index) => {
       const position = scale(tick);
+      const finalTick = finalTicks && finalTicks.tickValues
+        ? finalTicks.tickValues[index]
+        : undefined;
+
       return (
         <Tick key={`tick-${index}`}
           position={position}
           tick={stringTicks ? props.tickValues[tick - 1] : tick}
           orientation={orientation}
-          label={
-            finalTicks
-              ? finalTicks.tickValues[tick - 1]
-              : tickFormat.call(this, tick, index)
-          }
+          label={finalTick || tickFormat(tick, index)}
           style={{
             ticks: style.ticks,
             tickLabels: style.tickLabels

--- a/src/components/victory-axis/victory-axis.jsx
+++ b/src/components/victory-axis/victory-axis.jsx
@@ -44,6 +44,7 @@ const defaultStyles = {
     fill: "#756f6a",
     fontFamily: "Helvetica",
     fontSize: 10,
+    lineHeight: 1.2,
     padding: 5
   }
 };

--- a/src/components/victory-axis/victory-axis.jsx
+++ b/src/components/victory-axis/victory-axis.jsx
@@ -7,6 +7,7 @@ import { VictoryAnimation } from "victory-animation";
 import AxisLine from "./axis-line";
 import GridLine from "./grid";
 import Tick from "./tick";
+import constrainTickLabels from "./constrain-tick-labels.js";
 import AxisHelpers from "./helper-methods";
 import { PropTypes as CustomPropTypes, Helpers } from "victory-util";
 import Axis from "../../helpers/axis";
@@ -242,6 +243,13 @@ export default class VictoryAxis extends React.Component {
     const {style, orientation} = layoutProps;
     const {scale, ticks, stringTicks} = tickProps;
     const tickFormat = AxisHelpers.getTickFormat(props, tickProps);
+
+    let finalTicks;
+    if (props.tickValues && props.style.tickLabels) {
+      finalTicks = constrainTickLabels({
+        props, layoutProps, tickProps
+      });
+    }
     return ticks.map((tick, index) => {
       const position = scale(tick);
       return (
@@ -249,11 +257,18 @@ export default class VictoryAxis extends React.Component {
           position={position}
           tick={stringTicks ? props.tickValues[tick - 1] : tick}
           orientation={orientation}
-          label={tickFormat.call(this, tick, index)}
+          label={
+            finalTicks
+              ? finalTicks.tickValues[tick - 1]
+              : tickFormat.call(this, tick, index)
+          }
           style={{
             ticks: style.ticks,
             tickLabels: style.tickLabels
           }}
+          failedConstraints={
+            finalTicks && finalTicks.failedConstraints || null
+          }
         />
       );
     });

--- a/src/components/victory-axis/victory-axis.jsx
+++ b/src/components/victory-axis/victory-axis.jsx
@@ -245,32 +245,43 @@ export default class VictoryAxis extends React.Component {
     const {scale, ticks, stringTicks} = tickProps;
     const tickFormat = AxisHelpers.getTickFormat(props, tickProps);
 
-    let finalTicks;
+    let tickValues;
+    let failedConstraints;
     if (props.tickValues && props.style.tickLabels) {
-      finalTicks = constrainTickLabels({
+      const finalTicks = constrainTickLabels({
         props, layoutProps, tickProps
       });
+
+      if (finalTicks) {
+        tickValues = finalTicks.tickValues;
+        failedConstraints = finalTicks.failedConstraints;
+      }
     }
 
     return ticks.map((tick, index) => {
       const position = scale(tick);
-      const finalTick = finalTicks && finalTicks.tickValues
-        ? finalTicks.tickValues[index]
-        : undefined;
+
+      let finalLabel;
+      if (tickValues) {
+        const finalTick = tickValues[index];
+        if (finalTick) {
+          finalLabel = stringTicks
+            ? finalTick
+            : tickFormat(finalTick, index);
+        }
+      }
 
       return (
         <Tick key={`tick-${index}`}
           position={position}
           tick={stringTicks ? props.tickValues[tick - 1] : tick}
           orientation={orientation}
-          label={finalTick || tickFormat(tick, index)}
+          label={finalLabel || tickFormat(tick, index)}
           style={{
             ticks: style.ticks,
             tickLabels: style.tickLabels
           }}
-          failedConstraints={
-            finalTicks && finalTicks.failedConstraints || null
-          }
+          failedConstraints={failedConstraints || null}
         />
       );
     });

--- a/test/client/spec/helpers/constrain-tick-labels.spec.js
+++ b/test/client/spec/helpers/constrain-tick-labels.spec.js
@@ -1,0 +1,433 @@
+/* eslint no-unused-expressions: 0 */
+/* eslint-disable no-magic-numbers */
+require("babel-polyfill");
+import constrainTickLabels from "src/components/victory-axis/constrain-tick-labels";
+
+const mockMeasureText = function * (measurements) {
+  const mapper = (measurement) => (tick, index) => {
+    return {
+      text: tick,
+      measurement: measurement[index],
+      index
+    };
+  };
+  for (const measurement of measurements) {
+    const tickValues = yield;
+    yield tickValues.map(mapper(measurement));
+  }
+};
+
+const mockMeasureTicks = (generator) => {
+  return (props) => {
+    const result = generator.next(props.tickValues).value;
+    generator.next();
+    return result;
+  };
+};
+
+const defaultProps = {
+  orientation: "top",
+  style: {
+    axis: {
+      stroke: "black"
+    },
+    grid: {
+      strokeWidth: 2
+    },
+    ticks: {},
+    tickLabels: {
+      fontSize: 18
+    }
+  },
+  tickValues: [
+    "Mets\nNY",
+    "Giants\nSF",
+    "Yankees\nNY",
+    "Nationals\nDC",
+    "Mariners\nSEA"
+  ],
+  height: 300,
+  padding: 50,
+  scale: "linear",
+  standalone: true,
+  tickCount: 5,
+  width: 450
+};
+
+const defaultLayoutProps = {
+  style: {
+    parent: {
+      height: 300,
+      width: 450
+    },
+    axis: {
+      stroke: "black",
+      fill: "none",
+      strokeWidth: 2,
+      strokeLinecap: "round"
+    },
+    axisLabel: {
+      stroke: "transparent",
+      fill: "#756f6a",
+      fontSize: 16,
+      fontFamily: "Helvetica"
+    },
+    grid: {
+      fill: "none",
+      strokeLinecap: "round",
+      strokeWidth: 2
+    },
+    ticks: {
+      fill: "none",
+      padding: 5,
+      strokeWidth: 2,
+      strokeLinecap: "round",
+      size: 4
+    },
+    tickLabels: {
+      stroke: "transparent",
+      fill: "#756f6a",
+      fontFamily: "Helvetica",
+      fontSize: 18,
+      padding: 5
+    }
+  },
+  padding: {
+    top: 50,
+    bottom: 50,
+    left: 50,
+    right: 50
+  },
+  orientation: "top",
+  isVertical: false,
+  labelPadding: 0,
+  offset: {
+    x: 50,
+    y: 50
+  }
+};
+
+const defaultTickProps = {
+  ticks: [1, 2, 3, 4, 5],
+  stringTicks: true
+};
+
+describe("constrainTickLabels", () => {
+  describe("with horizontal axis", () => {
+    it("uses ellipses to prevent label collision", () => {
+      const normalWidth = defaultProps.width / defaultProps.tickValues.length;
+      const height = defaultLayoutProps.offset.y;
+      const constants = Array(4).fill({
+        width: `${normalWidth}px`, height: `${height}px`
+      });
+      const measureTextGenerator = mockMeasureText([
+        [...constants, {width: `${normalWidth + 20}px`, height: `${height}px`}],
+        [...constants, {width: `${normalWidth + 10}px`, height: `${height}px`}],
+        [...constants, {width: `${normalWidth}px`, height: `${height}px`}],
+        [...constants, {width: `${normalWidth}px`, height: `${height}px`}]
+      ]);
+      measureTextGenerator.next();
+      const ticks = constrainTickLabels({
+        props: defaultProps,
+        layoutProps: defaultLayoutProps,
+        tickProps: defaultTickProps,
+        measureFunc: mockMeasureTicks(measureTextGenerator)
+      });
+
+      expect(ticks).to.not.have.deep.property(
+        "failedConstraints"
+      );
+
+      const { tickValues } = ticks;
+      expect(JSON.stringify(tickValues)).to.equal(
+        JSON.stringify([
+          "Mets\nNY",
+          "Giants\nSF",
+          "Yankees\nNY",
+          "Nationals\nDC",
+          "Mar...\nSEA"
+        ])
+      );
+    });
+
+    it("uses line deletion to prevent vertical overflow", () => {
+      const normalWidth = defaultProps.width / defaultProps.tickValues.length;
+      const height = defaultLayoutProps.offset.y;
+      const constants = Array(4).fill({
+        width: `${normalWidth}px`, height: `${height}px`
+      });
+      const measureTextGenerator = mockMeasureText([
+        [...constants, {width: `${normalWidth}px`, height: `${height + 20}px`}],
+        [...constants, {width: `${normalWidth}px`, height: `${height + 20}px`}],
+        [...constants, {width: `${normalWidth}px`, height: `${height}px`}]
+      ]);
+      measureTextGenerator.next();
+      const ticks = constrainTickLabels({
+        props: defaultProps,
+        layoutProps: defaultLayoutProps,
+        tickProps: defaultTickProps,
+        measureFunc: mockMeasureTicks(measureTextGenerator)
+      });
+
+      expect(ticks).to.not.have.deep.property(
+        "failedConstraints"
+      );
+
+      const { tickValues } = ticks;
+      expect(JSON.stringify(tickValues)).to.equal(
+        JSON.stringify([
+          "Mets\nNY",
+          "Giants\nSF",
+          "Yankees\nNY",
+          "Nationals\nDC",
+          "Mariners"
+        ])
+      );
+    });
+
+    it(`uses ellipses to prevent label collision and
+        label deletion to prevent vertical overflow`, () => {
+      const normalWidth = defaultProps.width / defaultProps.tickValues.length;
+      const height = defaultLayoutProps.offset.y;
+      const constants = Array(4).fill({
+        width: `${normalWidth}px`, height: `${height}px`
+      });
+      const measureTextGenerator = mockMeasureText([
+        [...constants, {width: `${normalWidth + 20}px`, height: `${height + 20}px`}],
+        [...constants, {width: `${normalWidth - 10}px`, height: `${height + 20}px`}],
+        [...constants, {width: `${normalWidth - 10}px`, height: `${height + 20}px`}],
+        [...constants, {width: `${normalWidth - 10}px`, height: `${height - 10}px`}]
+      ]);
+      measureTextGenerator.next();
+      const ticks = constrainTickLabels({
+        props: defaultProps,
+        layoutProps: defaultLayoutProps,
+        tickProps: defaultTickProps,
+        measureFunc: mockMeasureTicks(measureTextGenerator)
+      });
+
+      expect(ticks).to.not.have.deep.property(
+        "failedConstraints"
+      );
+
+      const { tickValues } = ticks;
+      expect(JSON.stringify(tickValues)).to.equal(
+        JSON.stringify([
+          "Mets\nNY",
+          "Giants\nSF",
+          "Yankees\nNY",
+          "Nationals\nDC",
+          "Mari..."
+        ])
+      );
+    });
+
+    it("adds a failedConstraints prop if constraints can't be resolved", () => {
+      const normalWidth = defaultProps.width / defaultProps.tickValues.length;
+      const height = defaultLayoutProps.offset.y;
+      const constants = Array(4).fill({
+        width: `${normalWidth}px`, height: `${height}px`
+      });
+
+      const measureTextGenerator = mockMeasureText([
+        [...constants, {width: `${normalWidth + 20}px`, height: `${height + 20}px`}],
+        [...constants, {width: `${normalWidth + 20}px`, height: `${height + 20}px`}],
+        [...constants, {width: `${normalWidth + 20}px`, height: `${height + 20}px`}],
+        [...constants, {width: `${normalWidth + 20}px`, height: `${height + 20}px`}],
+        [...constants, {width: `${normalWidth + 20}px`, height: `${height + 20}px`}],
+        [...constants, {width: `${normalWidth + 20}px`, height: `${height + 20}px`}],
+        [...constants, {width: `${normalWidth + 20}px`, height: `${height + 20}px`}],
+        [...constants, {width: `${normalWidth + 20}px`, height: `${height + 20}px`}],
+        [...constants, {width: `${normalWidth + 20}px`, height: `${height + 20}px`}],
+        [...constants, {width: `${normalWidth + 20}px`, height: `${height + 20}px`}],
+        [...constants, {width: `${normalWidth + 20}px`, height: `${height + 20}px`}]
+      ]);
+      measureTextGenerator.next();
+
+      const ticks = constrainTickLabels({
+        props: defaultProps,
+        layoutProps: defaultLayoutProps,
+        tickProps: defaultTickProps,
+        measureFunc: mockMeasureTicks(measureTextGenerator)
+      });
+
+      expect(ticks).to.have.deep.property(
+        "failedConstraints.width", true
+      );
+      expect(ticks).to.have.deep.property(
+        "failedConstraints.height", true
+      );
+    });
+  });
+
+  describe("with vertical axis", () => {
+    it("uses ellipses to prevent label collision", () => {
+      const { size, padding } = defaultLayoutProps.style.ticks;
+      const normalWidth = defaultLayoutProps.offset.x - size - padding;
+      const height = defaultProps.height / defaultProps.tickValues.length;
+      const constants = Array(4).fill({
+        width: `${normalWidth}px`, height: `${height}px`
+      });
+      const measureTextGenerator = mockMeasureText([
+        [...constants, {width: `${normalWidth + 20}px`, height: `${height}px`}],
+        [...constants, {width: `${normalWidth + 10}px`, height: `${height}px`}],
+        [...constants, {width: `${normalWidth}px`, height: `${height}px`}],
+        [...constants, {width: `${normalWidth}px`, height: `${height}px`}]
+      ]);
+      measureTextGenerator.next();
+      const ticks = constrainTickLabels({
+        props: defaultProps,
+        layoutProps: {
+          ...defaultLayoutProps,
+          isVertical: true,
+          orientation: "left"
+        },
+        tickProps: defaultTickProps,
+        measureFunc: mockMeasureTicks(measureTextGenerator)
+      });
+
+      expect(ticks).to.not.have.deep.property(
+        "failedConstraints"
+      );
+
+      const { tickValues } = ticks;
+      expect(JSON.stringify(tickValues)).to.equal(
+        JSON.stringify([
+          "Mets\nNY",
+          "Giants\nSF",
+          "Yankees\nNY",
+          "Nationals\nDC",
+          "Mar...\nSEA"
+        ])
+      );
+    });
+
+    it("uses line deletion to prevent vertical overflow", () => {
+      const { size, padding } = defaultLayoutProps.style.ticks;
+      const normalWidth = defaultLayoutProps.offset.x - size - padding;
+      const height = defaultProps.height / defaultProps.tickValues.length;
+      const constants = Array(4).fill({
+        width: `${normalWidth}px`, height: `${height}px`
+      });
+      const measureTextGenerator = mockMeasureText([
+        [...constants, {width: `${normalWidth}px`, height: `${height + 20}px`}],
+        [...constants, {width: `${normalWidth}px`, height: `${height + 20}px`}],
+        [...constants, {width: `${normalWidth}px`, height: `${height}px`}]
+      ]);
+      measureTextGenerator.next();
+
+      const ticks = constrainTickLabels({
+        props: defaultProps,
+        layoutProps: {
+          ...defaultLayoutProps,
+          isVertical: true,
+          orientation: "left"
+        },
+        tickProps: defaultTickProps,
+        measureFunc: mockMeasureTicks(measureTextGenerator)
+      });
+
+      expect(ticks).to.not.have.deep.property(
+        "failedConstraints"
+      );
+
+      const { tickValues } = ticks;
+      expect(JSON.stringify(tickValues)).to.equal(
+        JSON.stringify([
+          "Mets\nNY",
+          "Giants\nSF",
+          "Yankees\nNY",
+          "Nationals\nDC",
+          "Mariners"
+        ])
+      );
+    });
+
+    it(`uses ellipses to prevent label collision and
+        label deletion to prevent vertical overflow`, () => {
+      const { size, padding } = defaultLayoutProps.style.ticks;
+      const normalWidth = defaultLayoutProps.offset.x - size - padding;
+      const height = defaultProps.height / defaultProps.tickValues.length;
+      const constants = Array(4).fill({
+        width: `${normalWidth}px`, height: `${height}px`
+      });
+
+      const measureTextGenerator = mockMeasureText([
+        [...constants, {width: `${normalWidth + 20}px`, height: `${height + 20}px`}],
+        [...constants, {width: `${normalWidth - 10}px`, height: `${height + 20}px`}],
+        [...constants, {width: `${normalWidth - 10}px`, height: `${height + 20}px`}],
+        [...constants, {width: `${normalWidth - 10}px`, height: `${height - 10}px`}]
+      ]);
+      measureTextGenerator.next();
+
+      const ticks = constrainTickLabels({
+        props: defaultProps,
+        layoutProps: {
+          ...defaultLayoutProps,
+          isVertical: true,
+          orientation: "left"
+        },
+        tickProps: defaultTickProps,
+        measureFunc: mockMeasureTicks(measureTextGenerator)
+      });
+
+      expect(ticks).to.not.have.deep.property(
+        "failedConstraints"
+      );
+
+      const { tickValues } = ticks;
+      expect(JSON.stringify(tickValues)).to.equal(
+        JSON.stringify([
+          "Mets\nNY",
+          "Giants\nSF",
+          "Yankees\nNY",
+          "Nationals\nDC",
+          "Mari..."
+        ])
+      );
+    });
+
+    it("adds a failedConstraints prop if constraints can't be resolved", () => {
+      const { size, padding } = defaultLayoutProps.style.ticks;
+      const normalWidth = defaultLayoutProps.offset.x - size - padding;
+      const height = defaultProps.height / defaultProps.tickValues.length;
+      const constants = Array(4).fill({
+        width: `${normalWidth}px`, height: `${height}px`
+      });
+
+      const measureTextGenerator = mockMeasureText([
+        [...constants, {width: `${normalWidth + 20}px`, height: `${height + 20}px`}],
+        [...constants, {width: `${normalWidth + 20}px`, height: `${height + 20}px`}],
+        [...constants, {width: `${normalWidth + 20}px`, height: `${height + 20}px`}],
+        [...constants, {width: `${normalWidth + 20}px`, height: `${height + 20}px`}],
+        [...constants, {width: `${normalWidth + 20}px`, height: `${height + 20}px`}],
+        [...constants, {width: `${normalWidth + 20}px`, height: `${height + 20}px`}],
+        [...constants, {width: `${normalWidth + 20}px`, height: `${height + 20}px`}],
+        [...constants, {width: `${normalWidth + 20}px`, height: `${height + 20}px`}],
+        [...constants, {width: `${normalWidth + 20}px`, height: `${height + 20}px`}],
+        [...constants, {width: `${normalWidth + 20}px`, height: `${height + 20}px`}],
+        [...constants, {width: `${normalWidth + 20}px`, height: `${height + 20}px`}]
+      ]);
+      measureTextGenerator.next();
+
+      const ticks = constrainTickLabels({
+        props: defaultProps,
+        layoutProps: {
+          ...defaultLayoutProps,
+          isVertical: true,
+          orientation: "left"
+        },
+        tickProps: defaultTickProps,
+        measureFunc: mockMeasureTicks(measureTextGenerator)
+      });
+
+      expect(ticks).to.have.deep.property(
+        "failedConstraints.width", true
+      );
+      expect(ticks).to.have.deep.property(
+        "failedConstraints.height", true
+      );
+    });
+  });
+});
+


### PR DESCRIPTION
This PR uses a naive constraint system to prevent label collisions and overflows. If labels are too wide, they are truncated and given ellipses. If multiline labels are too tall, their last line is deleted until they are short enough. The constraints fail gracefully if given a font size that makes collisions/overflows inevitable.

I'm not handling line height yet, but it should be a quick fix. @boygirl do we handle line height for multiline text yet?

This PR is a little messier than I'd like it to be, so I'd love all the review I can get! cc @boygirl @coopy @alexlande @zachhale @baer @exogen @divmain 