### PR TITLE
Add `npm start` script and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ VictoryChart
 
 A flexible charting component for React. VictoryChart composes other victory components into reusable charts. Acting as a coordinator rather than a stand-alone component, VictoryChart reconciles props such as `domain` and `scale` for child components, and provides a set of sensible defaults.
 
-This component works with:
+This component works with the following child components:
 
-- [VictoryAxis](http://github.com/formidablelabs/victory-axis)
-- [VictoryLine](http://github.com/formidablelabs/victory-line)
-- [VictoryScatter](http://github.com/formidablelabs/victory-scatter)
-- [VictoryBar](http://github.com/formidablelabs/victory-bar)
+- [VictoryAxis](src/components/victory-axis/victory-axis.jsx)
+- [VictoryLine](src/components/victory-line/victory-line.jsx)
+- [VictoryScatter](src/components/victory-scatter/victory-scatter.jsx)
+- [VictoryBar](src/components/victory-bar/victory-bar.jsx)
 - _More chart types coming soon!_
 
 

--- a/README.md
+++ b/README.md
@@ -15,22 +15,31 @@ This component works with:
 - _More chart types coming soon!_
 
 
-API Documentation
------------------
+## API Documentation
 Detailed documentation and interactive examples can be found at http://victory.formidable.com/docs/victory-chart/
-
-IMPORTANT
-=========
-
-This project is in a pre-release state. We're hard at work fixing bugs and improving the API. Be prepared for breaking changes!
 
 ## Development
 
-Please see [DEVELOPMENT](https://github.com/FormidableLabs/builder-victory-component/blob/master/dev/DEVELOPMENT.md)
+```sh
+# Run the demo app server
+$ npm start
+
+# Open the demo app
+$ open http://localhost:3000
+
+# Run tests
+$ npm test
+```
+
+For more on the development environment, see [DEVELOPMENT](https://github.com/FormidableLabs/builder-victory-component/blob/master/dev/DEVELOPMENT.md) in the project builder archetype.
 
 ## Contributing
 
-Please see [CONTRIBUTING](https://github.com/FormidableLabs/builder-victory-component/blob/master/dev/CONTRIBUTING.md)
+Please see [CONTRIBUTING](https://github.com/FormidableLabs/builder-victory-component/blob/master/dev/CONTRIBUTING.md) in the project builder archetype.
+
+## _IMPORTANT_
+
+This project is in a pre-release state. We're hard at work fixing bugs and improving the API. Be prepared for breaking changes!
 
 [trav_img]: https://api.travis-ci.org/FormidableLabs/victory-chart.svg
 [trav_site]: https://travis-ci.org/FormidableLabs/victory-chart

--- a/demo/app.jsx
+++ b/demo/app.jsx
@@ -18,11 +18,11 @@ const App = React.createClass({
   render() {
     return (
       <div>
-        <h1>App</h1>
+        <h1>Victory Chart and Friends Demo</h1>
         <ul>
+          <li><Link to="/chart">Victory Chart Demo</Link></li>
           <li><Link to="/axis">Victory Axis Demo</Link></li>
           <li><Link to="/bar">Victory Bar Demo</Link></li>
-          <li><Link to="/chart">Victory Chart Demo</Link></li>
           <li><Link to="/line">Victory Line Demo</Link></li>
           <li><Link to="/scatter">Victory Scatter Demo</Link></li>
         </ul>

--- a/demo/components/victory-axis-demo.jsx
+++ b/demo/components/victory-axis-demo.jsx
@@ -21,7 +21,6 @@ export default class App extends React.Component {
     });
   }
 
-
   getDomain() {
     const someNumber = _.random(2, 5);
     return [-someNumber, someNumber];
@@ -29,12 +28,16 @@ export default class App extends React.Component {
 
   componentDidMount() {
     /* eslint-disable react/no-did-mount-set-state */
-    window.setInterval(() => {
+    this.setStateInterval = window.setInterval(() => {
       this.setState({
         tickValues: this.getTickValues(),
         domain: this.getDomain()
       });
     }, 2000);
+  }
+
+  componentWillUnmount() {
+    window.clearInterval(this.setStateInterval);
   }
 
   render() {
@@ -56,8 +59,9 @@ export default class App extends React.Component {
 
     return (
       <div className="demo">
+        <h1>VictoryAxis</h1>
         <div>
-          <h1>Animating Axis</h1>
+          <h2>Animating Axis</h2>
           <VictoryAxis style={styleOverrides}
             padding={60}
             label={<VictoryLabel>{"animation\nwow!"}</VictoryLabel>}
@@ -67,7 +71,7 @@ export default class App extends React.Component {
           />
         </div>
         <div>
-          <h1>Time Scale Axis</h1>
+          <h2>Time Scale Axis</h2>
           <VictoryAxis
             label="time axis"
             padding={{left: 10, right: 80}}
@@ -83,7 +87,7 @@ export default class App extends React.Component {
           />
         </div>
         <div>
-        <h1>X-Y Axis</h1>
+        <h2>X-Y Axis</h2>
           <svg style={{width: 500, height: 400}}>
             <VictoryAxis crossAxis
               width={500}
@@ -102,7 +106,7 @@ export default class App extends React.Component {
           </svg>
         </div>
         <div>
-        <h1>Log Scale Axis</h1>
+        <h2>Log Scale Axis</h2>
           <VictoryAxis
             label="cool log axis"
             padding={{top: 10, bottom: 60}}
@@ -120,7 +124,7 @@ export default class App extends React.Component {
           />
         </div>
         <div>
-          <h1>Ordinal Scales</h1>
+          <h2>Ordinal Scales</h2>
           <VictoryAxis
             orientation="top"
             style={styleOverrides}

--- a/demo/components/victory-bar-demo.jsx
+++ b/demo/components/victory-bar-demo.jsx
@@ -50,8 +50,9 @@ export default class App extends React.Component {
     });
   }
 
-  componentWillMount() {
-    window.setInterval(() => {
+  componentDidMount() {
+    /* eslint-disable react/no-did-mount-set-state */
+    this.setStateInterval = window.setInterval(() => {
       this.setState({
         barData: this.getBarData(),
         numericBarData: this.getNumericBarData()
@@ -59,10 +60,14 @@ export default class App extends React.Component {
     }, 4000);
   }
 
+  componentWillUnmount() {
+    window.clearInterval(this.setStateInterval);
+  }
+
   render() {
     return (
       <div className="demo">
-        <h1>Victory Bar</h1>
+        <h1>VictoryBar</h1>
 
         <ChartWrap>
           <VictoryBar

--- a/demo/components/victory-chart-demo.jsx
+++ b/demo/components/victory-chart-demo.jsx
@@ -6,7 +6,6 @@ import {
 } from "../../src/index";
 
 const UPDATE_INTERVAL = 2000;
-let updateTimer;
 
 const chartStyle = {parent: {width: 500, height: 350, margin: 50}};
 class App extends React.Component {
@@ -93,8 +92,9 @@ class App extends React.Component {
     };
   }
 
-  componentWillMount() {
-    updateTimer = window.setInterval(() => {
+  componentDidMount() {
+    /* eslint-disable react/no-did-mount-set-state */
+    this.setStateInterval = window.setInterval(() => {
       this.setState({
         scatterData: this.getScatterData(),
         lineData: this.getData(),
@@ -106,12 +106,13 @@ class App extends React.Component {
   }
 
   componentWillUnmount() {
-    window.clearInterval(updateTimer);
+    window.clearInterval(this.setStateInterval);
   }
 
   render() {
     return (
       <div className="demo">
+        <h1>VictoryChart</h1>
         <p>
           <VictoryChart/>
 

--- a/demo/components/victory-line-demo.jsx
+++ b/demo/components/victory-line-demo.jsx
@@ -37,8 +37,9 @@ export default class App extends React.Component {
     };
   }
 
-  componentWillMount() {
-    window.setInterval(() => {
+  componentDidMount() {
+    /* eslint-disable react/no-did-mount-set-state */
+    this.setStateInterval = window.setInterval(() => {
       this.setState({
         data: this.getData(),
         style: this.getStyles()
@@ -46,9 +47,15 @@ export default class App extends React.Component {
     }, 2000);
   }
 
+  componentWillUnmount() {
+    window.clearInterval(this.setStateInterval);
+  }
+
   render() {
     return (
       <div className="demo">
+        <h1>VictoryLine</h1>
+
         <VictoryLine
           style={{parent: {border: "1px solid black", margin: "5px"}, data: this.state.style}}
           data={this.state.data}

--- a/demo/components/victory-scatter-demo.jsx
+++ b/demo/components/victory-scatter-demo.jsx
@@ -56,17 +56,24 @@ export default class App extends React.Component {
     };
   }
 
-  componentWillMount() {
-    window.setInterval(() => {
+  componentDidMount() {
+    /* eslint-disable react/no-did-mount-set-state */
+    this.setStateInterval = window.setInterval(() => {
       this.setState({
         data: getData()
       });
-    }, 3000);
+    }, 2000);
+  }
+
+  componentWillUnmount() {
+    window.clearInterval(this.setStateInterval);
   }
 
   render() {
     return (
-      <div>
+      <div className="demo">
+        <h1>VictoryScatter</h1>
+
         <VictoryScatter
           style={style}
           width={500}

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "postinstall": "cd lib || builder run npm:postinstall || (echo 'POSTINSTALL FAILED: If using npm v2, please upgrade to npm v3. See bug https://github.com/FormidableLabs/builder/issues/35' && exit 1)",
     "preversion": "builder run npm:preversion",
+    "start": "builder run hot",
     "test": "builder run npm:test",
     "version": "builder run npm:version && git add dist && git commit -m \"Commit 'dist/' for publishing\""
   },

--- a/package.json
+++ b/package.json
@@ -16,12 +16,12 @@
   "scripts": {
     "postinstall": "cd lib || builder run npm:postinstall || (echo 'POSTINSTALL FAILED: If using npm v2, please upgrade to npm v3. See bug https://github.com/FormidableLabs/builder/issues/35' && exit 1)",
     "preversion": "builder run npm:preversion",
-    "version": "builder run npm:version && git add dist && git commit -m \"Commit 'dist/' for publishing\"",
-    "test": "builder run npm:test"
+    "test": "builder run npm:test",
+    "version": "builder run npm:version && git add dist && git commit -m \"Commit 'dist/' for publishing\""
   },
   "dependencies": {
-    "builder": "~2.4.0",
     "builder-victory-component": "~0.2.1",
+    "builder": "~2.4.0",
     "d3-scale": "^0.2.0",
     "d3-shape": "^0.2.0",
     "lodash": "^3.10.1",
@@ -35,11 +35,11 @@
     "chai": "^3.2.0",
     "history": "~1.13.1",
     "mocha": "^2.3.3",
-    "react": "^0.14.3",
     "react-addons-test-utils": "^0.14.3",
     "react-dom": "^0.14.3",
     "react-router": "^1.0.0",
-    "sinon": "^1.17.2",
-    "sinon-chai": "^2.8.0"
+    "react": "^0.14.3",
+    "sinon-chai": "^2.8.0",
+    "sinon": "^1.17.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "postinstall": "cd lib || builder run npm:postinstall || (echo 'POSTINSTALL FAILED: If using npm v2, please upgrade to npm v3. See bug https://github.com/FormidableLabs/builder/issues/35' && exit 1)",
     "preversion": "builder run npm:preversion",
     "start": "builder run hot",
-    "test": "builder run npm:test",
+    "test": "builder run check",
     "version": "builder run npm:version && git add dist && git commit -m \"Commit 'dist/' for publishing\""
   },
   "dependencies": {


### PR DESCRIPTION
I've added standard npm scripts and updated the README to have the minimum needed to get started on development.

- `npm start` runs `builder run hot`
- `npm test` runs `builder run check`

Other:
- I've fixed the demo app - when switching between demos, the components unmount, and we need to clear the update-interval.
- I've updated the links to subcomponents in the README to not point to the deprecated repositories (but to the now-contained subcomponents).

/cc @boygirl @tptee