### PR TITLE
Remove Radium

### DIFF
--- a/demo/components/victory-axis-demo.jsx
+++ b/demo/components/victory-axis-demo.jsx
@@ -3,9 +3,7 @@ import React from "react";
 import {VictoryAxis} from "../../src/index";
 import {VictoryLabel} from "victory-core";
 import _ from "lodash";
-import Radium from "radium";
 
-@Radium
 export default class App extends React.Component {
   constructor() {
     super();

--- a/demo/components/victory-scatter-demo.jsx
+++ b/demo/components/victory-scatter-demo.jsx
@@ -1,6 +1,5 @@
 /*global window:false */
 import React from "react";
-import Radium from "radium";
 import _ from "lodash";
 import {VictoryScatter} from "../../src/index";
 import {VictoryLabel} from "victory-core";
@@ -47,7 +46,6 @@ const symbolStyle = {
   }
 };
 
-@Radium
 export default class App extends React.Component {
   constructor(props) {
     super(props);

--- a/docs/victory-line/ecology.md
+++ b/docs/victory-line/ecology.md
@@ -80,8 +80,7 @@ Add labels, style the data, change the interpolation, add a custom domain:
     style={{
       data: {
         stroke: "#822722",
-        strokeWidth: 3,
-        ":hover": {stroke: "#c33b33"}
+        strokeWidth: 3
       },
       labels: {fontSize: 12}
     }}

--- a/docs/victory-scatter/ecology.md
+++ b/docs/victory-scatter/ecology.md
@@ -75,11 +75,7 @@ Style data for the entire chart with props:
       data: {
         fill: "gold",
         stroke: "orange",
-        strokeWidth: 3,
-        ":hover": {
-          fill: "orange",
-          stroke: "gold",
-        }
+        strokeWidth: 3
       }
     }}
  />

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "chai": "^3.2.0",
     "history": "~1.13.1",
     "mocha": "^2.3.3",
+    "radium": "^0.16.2",
     "react-addons-test-utils": "^0.14.3",
     "react-dom": "^0.14.3",
     "react-router": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "d3-shape": "^0.2.0",
     "lodash": "^3.10.1",
     "memoizerific": "^1.5.2",
-    "radium": "^0.16.2",
     "victory-core": "^0.0.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "d3-shape": "^0.2.0",
     "lodash": "^3.10.1",
     "memoizerific": "^1.5.2",
-    "victory-core": "^0.0.2"
+    "victory-core": "^0.0.3"
   },
   "devDependencies": {
     "builder-victory-component-dev": "~0.2.1",

--- a/src/components/victory-axis/axis-line.jsx
+++ b/src/components/victory-axis/axis-line.jsx
@@ -1,7 +1,5 @@
 import React, { PropTypes } from "react";
-import Radium from "radium";
 
-@Radium
 export default class AxisLine extends React.Component {
   static role = "line";
 

--- a/src/components/victory-axis/grid.jsx
+++ b/src/components/victory-axis/grid.jsx
@@ -1,8 +1,6 @@
 import React, { PropTypes } from "react";
-import Radium from "radium";
 import { Helpers } from "victory-core";
 
-@Radium
 export default class GridLine extends React.Component {
   static role = "grid";
 

--- a/src/components/victory-axis/tick.jsx
+++ b/src/components/victory-axis/tick.jsx
@@ -1,8 +1,6 @@
 import React, { PropTypes } from "react";
-import Radium from "radium";
 import { VictoryLabel, Helpers } from "victory-core";
 
-@Radium
 export default class Tick extends React.Component {
   static role = "tick";
 

--- a/src/components/victory-axis/victory-axis.jsx
+++ b/src/components/victory-axis/victory-axis.jsx
@@ -1,7 +1,6 @@
 import merge from "lodash/object/merge";
 import pick from "lodash/object/pick";
 import React, { PropTypes } from "react";
-import Radium from "radium";
 import {
   PropTypes as CustomPropTypes,
   VictoryLabel,
@@ -70,7 +69,6 @@ const getStyles = (props) => {
   };
 };
 
-@Radium
 export default class VictoryAxis extends React.Component {
   static role = "axis";
   static propTypes = {

--- a/src/components/victory-bar/bar-label.jsx
+++ b/src/components/victory-bar/bar-label.jsx
@@ -1,9 +1,7 @@
 import merge from "lodash/object/merge";
 import React, { PropTypes } from "react";
-import Radium from "radium";
 import { VictoryLabel, Helpers } from "victory-core";
 
-@Radium
 export default class BarLabel extends React.Component {
 
   static propTypes = {

--- a/src/components/victory-bar/bar.jsx
+++ b/src/components/victory-bar/bar.jsx
@@ -1,8 +1,6 @@
 import React, { PropTypes } from "react";
-import Radium from "radium";
 import { Helpers } from "victory-core";
 
-@Radium
 export default class Bar extends React.Component {
 
   static propTypes = {

--- a/src/components/victory-bar/victory-bar.jsx
+++ b/src/components/victory-bar/victory-bar.jsx
@@ -1,7 +1,6 @@
 import pick from "lodash/object/pick";
 
 import React, { PropTypes } from "react";
-import Radium from "radium";
 import Scale from "../../helpers/scale";
 import Data from "../../helpers/data";
 import Domain from "../../helpers/domain";
@@ -34,7 +33,6 @@ const defaultData = [
   {x: 4, y: 4}
 ];
 
-@Radium
 export default class VictoryBar extends React.Component {
   static role = "bar";
   static propTypes = {

--- a/src/components/victory-chart/victory-chart.jsx
+++ b/src/components/victory-chart/victory-chart.jsx
@@ -3,7 +3,6 @@ import merge from "lodash/object/merge";
 import some from "lodash/collection/some";
 
 import React, { PropTypes } from "react";
-import Radium from "radium";
 import { PropTypes as CustomPropTypes, Helpers } from "victory-core";
 import VictoryAxis from "../victory-axis/victory-axis";
 import ChartHelpers from "./helper-methods";
@@ -15,7 +14,6 @@ const defaultAxes = {
   dependent: <VictoryAxis dependentAxis animate={{velocity: 0.02}}/>
 };
 
-@Radium
 export default class VictoryChart extends React.Component {
   static propTypes = {
     /**

--- a/src/components/victory-line/line-label.jsx
+++ b/src/components/victory-line/line-label.jsx
@@ -1,9 +1,7 @@
 import merge from "lodash/object/merge";
 import React, { PropTypes } from "react";
-import Radium from "radium";
 import { VictoryLabel, Helpers} from "victory-core";
 
-@Radium
 export default class LineLabel extends React.Component {
   static propTypes = {
     data: PropTypes.array,

--- a/src/components/victory-line/line-segment.jsx
+++ b/src/components/victory-line/line-segment.jsx
@@ -1,9 +1,7 @@
 import React, { PropTypes } from "react";
-import Radium from "radium";
 import d3Shape from "d3-shape";
 import { Helpers } from "victory-core";
 
-@Radium
 export default class LineSegment extends React.Component {
   static propTypes = {
     data: PropTypes.array,

--- a/src/components/victory-line/victory-line.jsx
+++ b/src/components/victory-line/victory-line.jsx
@@ -7,7 +7,6 @@ import isUndefined from "lodash/lang/isUndefined";
 import merge from "lodash/object/merge";
 import pick from "lodash/object/pick";
 import React, { PropTypes } from "react";
-import Radium from "radium";
 import LineSegment from "./line-segment";
 import LineLabel from "./line-label";
 import Scale from "../../helpers/scale";
@@ -33,7 +32,6 @@ const defaultStyles = {
   }
 };
 
-@Radium
 export default class VictoryLine extends React.Component {
   static role = "line";
   static propTypes = {

--- a/src/components/victory-scatter/point.jsx
+++ b/src/components/victory-scatter/point.jsx
@@ -2,11 +2,9 @@ import merge from "lodash/object/merge";
 import omit from "lodash/object/omit";
 import pick from "lodash/object/pick";
 import React, { PropTypes } from "react";
-import Radium from "radium";
 import { VictoryLabel, Helpers } from "victory-core";
 import { getPath } from "./helper-methods";
 
-@Radium
 export default class Point extends React.Component {
   static propTypes = {
     data: PropTypes.shape({

--- a/src/components/victory-scatter/victory-scatter.jsx
+++ b/src/components/victory-scatter/victory-scatter.jsx
@@ -1,5 +1,4 @@
 import React, { PropTypes } from "react";
-import Radium from "radium";
 import pick from "lodash/object/pick";
 import Point from "./point";
 import Scale from "../../helpers/scale";
@@ -26,7 +25,6 @@ const defaultStyles = {
   }
 };
 
-@Radium
 export default class VictoryScatter extends React.Component {
   static role = "scatter";
   static propTypes = {


### PR DESCRIPTION
Docs for re-integrating Radium will be done separately, after custom components are supported.  I didn't see anything related to hover-states, so I didn't make any updates there.  Tests pass and demos work.

Related to https://github.com/FormidableLabs/victory/issues/141.

This should not be merged before https://github.com/FormidableLabs/victory-core/pull/7.

@coopy @boygirl 