### PR TITLE
[WIP] Autolayout for axis

### DIFF
--- a/demo/components/victory-axis-demo.jsx
+++ b/demo/components/victory-axis-demo.jsx
@@ -26,12 +26,12 @@ export default class App extends React.Component {
 
   componentDidMount() {
     /* eslint-disable react/no-did-mount-set-state */
-    this.setStateInterval = window.setInterval(() => {
-      this.setState({
-        tickValues: this.getTickValues(),
-        domain: this.getDomain()
-      });
-    }, 2000);
+    //this.setStateInterval = window.setInterval(() => {
+      //this.setState({
+        //tickValues: this.getTickValues(),
+        //domain: this.getDomain()
+      //});
+    //}, 2000);
   }
 
   componentWillUnmount() {

--- a/package.json
+++ b/package.json
@@ -21,8 +21,9 @@
     "version": "builder run npm:version && git add dist && git commit -m \"Commit 'dist/' for publishing\""
   },
   "dependencies": {
-    "builder-victory-component": "~0.2.1",
+    "autolayout": "^0.5.3",
     "builder": "~2.4.0",
+    "builder-victory-component": "~0.2.1",
     "d3-scale": "^0.2.0",
     "d3-shape": "^0.2.0",
     "lodash": "^3.10.1",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "d3-scale": "^0.2.0",
     "d3-shape": "^0.2.0",
     "lodash": "^3.10.1",
+    "measure-text": "0.0.4",
     "memoizerific": "^1.5.2",
     "victory-core": "^0.0.3"
   },

--- a/src/components/autolayout/autolayout.js
+++ b/src/components/autolayout/autolayout.js
@@ -1,0 +1,65 @@
+import React, { Children, Component, PropTypes, cloneElement } from "react";
+import { View } from "autolayout";
+
+const componentWithLayoutProps = (component, view) => {
+  const {
+    children: rawChildren,
+    viewName,
+    intrinsicWidth,
+    intrinsicHeight
+  } = component.props;
+
+  const children = typeof rawChildren !== "string"
+    ? Children.map(rawChildren, (child) => {
+      return componentWithLayoutProps(child, view);
+    })
+    : null;
+
+  const subViews = view.subViews;
+  console.log(subViews[viewName], viewName);
+  const layout = viewName && subViews[viewName]
+    ? subViews[viewName]
+    : null;
+
+  if (layout && intrinsicWidth) {
+    layout.intrinsicWidth = intrinsicWidth;
+  }
+
+  if (layout && intrinsicHeight) {
+    layout.intrinsicHeight = intrinsicHeight;
+  }
+
+  return cloneElement(component, {
+    children,
+    layout: layout ? {
+      name: layout.name,
+      top: layout.top,
+      right: layout.right,
+      bottom: layout.bottom,
+      left: layout.left,
+      width: layout.width,
+      height: layout.height
+    } : null
+  });
+};
+
+export class AutoLayout extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      view: new View({
+        constraints: props.constraints,
+        width: props.width,
+        height: props.height,
+        spacing: 0
+      })
+    };
+  }
+
+  render() {
+    return componentWithLayoutProps(
+      this.props.children, this.state.view
+    );
+  }
+}
+

--- a/src/components/victory-axis/axis-line.jsx
+++ b/src/components/victory-axis/axis-line.jsx
@@ -12,6 +12,15 @@ export default class AxisLine extends React.Component {
   };
 
   render() {
-    return <line {...this.props}/>;
+    //return <line {...this.props}/>;
+    return (
+      <line
+        {...this.props}
+        x1={this.props.layout.left}
+        x2={this.props.layout.left + this.props.layout.width}
+        y1={this.props.layout.top}
+        y2={this.props.layout.top + this.props.layout.height}
+      />
+    );
   }
 }

--- a/src/components/victory-axis/grid.jsx
+++ b/src/components/victory-axis/grid.jsx
@@ -15,13 +15,13 @@ export default class GridLine extends React.Component {
 
   render() {
     return (
-      <g transform={`translate(${this.props.xTransform}, ${this.props.yTransform})`}>
-        <line
-          x2={this.props.x2}
-          y2={this.props.y2}
-          style={Helpers.evaluateStyle(this.props.style, this.props.tick)}
-        />
-      </g>
+      <line
+        x1={this.props.layout.left}
+        x2={this.props.layout.left}
+        y1={this.props.layout.top}
+        y2={this.props.layout.bottom}
+        style={Helpers.evaluateStyle(this.props.style, this.props.tick)}
+      />
     );
   }
 }

--- a/src/components/victory-axis/tick-label.jsx
+++ b/src/components/victory-axis/tick-label.jsx
@@ -1,0 +1,67 @@
+import React, { Component, PropTypes } from "react";
+import { VictoryLabel, Helpers } from "victory-core";
+import measureText from "measure-text";
+
+export default class TickLabel extends Component {
+  static role = "tickLabel";
+
+  static propTypes = {
+    position: PropTypes.number,
+    tick: PropTypes.any,
+    orientation: PropTypes.oneOf(["top", "bottom", "left", "right"]),
+    style: PropTypes.object,
+    label: PropTypes.any
+  };
+
+  getAnchors(props, isVertical) {
+    const anchorOrientation = { top: "end", left: "end", right: "start", bottom: "start" };
+    const anchor = anchorOrientation[props.orientation];
+    return {
+      textAnchor: isVertical ? anchor : "middle",
+      verticalAnchor: isVertical ? "middle" : anchor
+    };
+  }
+
+  renderLabel(props, isVertical) {
+    if (!props.label) {
+      return undefined;
+    }
+    const componentProps = props.label.props ? props.label.props : {};
+    const style = componentProps.style || props.style;
+    const anchors = this.getAnchors(props, isVertical);
+    const newProps = {
+      verticalAnchor: "start",
+      textAnchor: componentProps.textAnchor || anchors.textAnchor,
+      //verticalAnchor: componentProps.verticalAnchor || anchors.verticalAnchor,
+      x: props.layout.left,
+      y: props.layout.top,
+      style
+      //style: Helpers.evaluateStyle(style, props.tick)
+    };
+    return props.label.props ?
+      React.cloneElement(props.label, newProps) :
+      React.createElement(VictoryLabel, newProps, props.label);
+  }
+
+  render() {
+    const isVertical = this.props.orientation === "left" || this.props.orientation === "right";
+    return this.renderLabel(this.props, isVertical);
+  }
+}
+
+
+export const addMeasurements = (element) => {
+  const { fontSize, fontFamily, lineHeight, fontWeight, fontStyle } = element.props.style;
+  const measurement = measureText({
+    text: element.props.label.split ? element.props.label.split("\n") : element.props.label,
+    fontFamily, fontSize: `${fontSize}px`,
+    lineHeight: lineHeight || 1.2,
+    fontWeight: fontWeight || 400,
+    fontStyle: fontStyle || "normal"
+  });
+  const { width, height } = measurement;
+  return React.cloneElement(element, {
+    intrinsicWidth: width.value,
+    intrinsicHeight: height.value
+  });
+};

--- a/src/components/victory-axis/tick-label.jsx
+++ b/src/components/victory-axis/tick-label.jsx
@@ -49,11 +49,26 @@ export default class TickLabel extends Component {
   }
 }
 
+const extractText = (element) => {
+  const { props } = element;
+
+  if (props) {
+    if (props.children && props.children.split) {
+      return props.children.split("\n");
+    }
+    if (props.label && props.label.split) {
+      return props.label.split("\n");
+    }
+    return props.label.toString();
+  }
+  return "";
+};
 
 export const addMeasurements = (element) => {
   const { fontSize, fontFamily, lineHeight, fontWeight, fontStyle } = element.props.style;
+
   const measurement = measureText({
-    text: element.props.label.split ? element.props.label.split("\n") : element.props.label,
+    text: extractText(element),
     fontFamily, fontSize: `${fontSize}px`,
     lineHeight: lineHeight || 1.2,
     fontWeight: fontWeight || 400,
@@ -65,3 +80,4 @@ export const addMeasurements = (element) => {
     intrinsicHeight: height.value
   });
 };
+

--- a/src/components/victory-axis/tick.jsx
+++ b/src/components/victory-axis/tick.jsx
@@ -1,5 +1,5 @@
 import React, { PropTypes } from "react";
-import { VictoryLabel, Helpers } from "victory-core";
+import { Helpers } from "victory-core";
 
 export default class Tick extends React.Component {
   static role = "tick";
@@ -25,41 +25,13 @@ export default class Tick extends React.Component {
     };
   }
 
-  getAnchors(props, isVertical) {
-    const anchorOrientation = { top: "end", left: "end", right: "start", bottom: "start" };
-    const anchor = anchorOrientation[props.orientation];
-    return {
-      textAnchor: isVertical ? anchor : "middle",
-      verticalAnchor: isVertical ? "middle" : anchor
-    };
-  }
-
-  renderLabel(props, position, isVertical) {
-    if (!props.label) {
-      return undefined;
-    }
-    const componentProps = props.label.props ? props.label.props : {};
-    const style = componentProps.style || props.style.tickLabels;
-    const anchors = this.getAnchors(props, isVertical);
-    const newProps = {
-      x: position.x,
-      y: position.y,
-      textAnchor: componentProps.textAnchor || anchors.textAnchor,
-      verticalAnchor: componentProps.verticalAnchor || anchors.verticalAnchor,
-      style: Helpers.evaluateStyle(style, props.tick)
-    };
-    return props.label.props ?
-      React.cloneElement(props.label, newProps) :
-      React.createElement(VictoryLabel, newProps, props.label);
-  }
-
   renderTick(props, position) {
     return (
       <line
-        x={position.x}
-        x2={position.x2}
-        y={position.y}
-        y2={position.y2}
+        x1={this.props.layout.left}
+        x2={this.props.layout.left}
+        y1={this.props.layout.top}
+        y2={this.props.layout.bottom}
         style={Helpers.evaluateStyle(props.style.ticks, props.ticks)}
       />
     );
@@ -67,14 +39,7 @@ export default class Tick extends React.Component {
 
   render() {
     const isVertical = this.props.orientation === "left" || this.props.orientation === "right";
-    const transform = isVertical ?
-      `translate(0, ${this.props.position})` : `translate(${this.props.position}, 0)`;
     const position = this.getPosition(this.props, isVertical);
-    return (
-      <g transform={transform}>
-        {this.renderTick(this.props, position)}
-        {this.renderLabel(this.props, position, isVertical)}
-      </g>
-    );
+    return this.renderTick(this.props, position);
   }
 }

--- a/src/components/victory-axis/victory-axis.jsx
+++ b/src/components/victory-axis/victory-axis.jsx
@@ -13,7 +13,7 @@ import GridLine from "./grid";
 import Tick from "./tick";
 import AxisHelpers from "./helper-methods";
 import Axis from "../../helpers/axis";
-
+import { AutoLayout } from "../autolayout/autolayout.js";
 
 const defaultStyles = {
   axis: {
@@ -325,7 +325,7 @@ export default class VictoryAxis extends React.Component {
   render() {
     // If animating, return a `VictoryAnimation` element that will create
     // a new `VictoryAxis` with nearly identical props, except (1) tweened
-    // and (2) `animate` set to null so we don't recurse forever.
+    // and (2) `animate` set to null so we don"t recurse forever.
     if (this.props.animate) {
       // Do less work by having `VictoryAnimation` tween only values that
       // make sense to tween. In the future, allow customization of animated
@@ -346,13 +346,68 @@ export default class VictoryAxis extends React.Component {
     const {style} = layoutProps;
     const transform = AxisHelpers.getTransform(this.props, layoutProps);
     const group = (
-      <g style={style.parent} transform={transform}>
-        {this.renderLabel(this.props, layoutProps)}
-        {this.renderTicks(this.props, layoutProps, tickProps)}
-        {this.renderLine(this.props, layoutProps)}
-        {this.renderGrid(this.props, layoutProps, tickProps)}
-      </g>
+      <AutoLayout
+        width={400}
+        height={350}
+        constraints={[
+          {
+            view1: null,
+            attr1: "width",    // see AutoLayout.Attribute
+            relation: "equ",   // see AutoLayout.Relation
+            view2: "superview",
+            attr2: "width"
+          },
+          {
+            view1: null,
+            attr1: "height",    // see AutoLayout.Attribute
+            relation: "equ",   // see AutoLayout.Relation
+            view2: "superview",
+            attr2: "height"
+          },
+          {
+            view1: null,
+            attr1: "centerX",    // see AutoLayout.Attribute
+            relation: "equ",   // see AutoLayout.Relation
+            view2: "superview",
+            attr2: "centerX"
+          },
+          {
+            view1: null,
+            attr1: "centerY",    // see AutoLayout.Attribute
+            relation: "equ",   // see AutoLayout.Relation
+            view2: "superview",
+            attr2: "centerY"
+          },
+          {
+            view1: "line",
+            attr1: "centerX",    // see AutoLayout.Attribute
+            relation: "equ",   // see AutoLayout.Relation
+            view2: "superview",
+            attr2: "centerX"
+          },
+          {
+            view1: "line",
+            attr1: "bottom",    // see AutoLayout.Attribute
+            relation: "equ",   // see AutoLayout.Relation
+            view2: "superview",
+            attr2: "bottom",
+            constant: 20
+          }
+        ]}
+      >
+        <div viewName="superview">
+          <p viewName="line" intrinsicWidth="100" intrinsicHeight="50">lol</p>
+        </div>
+      </AutoLayout>
     );
+    //const group = (
+      //<g style={style.parent} transform={transform}>
+        //{this.renderLabel(this.props, layoutProps)}
+        //{this.renderTicks(this.props, layoutProps, tickProps)}
+        //{this.renderLine(this.props, layoutProps)}
+        //{this.renderGrid(this.props, layoutProps, tickProps)}
+      //</g>
+    //);
     return this.props.standalone ? (
       <svg style={style.parent}>
         {group}

--- a/src/components/victory-axis/victory-axis.jsx
+++ b/src/components/victory-axis/victory-axis.jsx
@@ -249,8 +249,6 @@ export default class VictoryAxis extends React.Component {
           constraints={[
             constrain(gridName, "top").equals(null, "top"),
             constrain(gridName, "height").equals("line", "top").withPriority(1000),
-            //constrain(gridName, "bottom").equals(null, "bottom"),
-            //constrain(gridName, "height").constant(200),
             constrain(gridName, "left").constant(position)
           ]}
         />
@@ -296,6 +294,27 @@ export default class VictoryAxis extends React.Component {
 
   renderLine(props, layoutProps) {
     const {style, padding, isVertical} = layoutProps;
+
+    const constraints = isVertical ?
+      [
+        constrain("line", "top").equals(null, "top"),
+        constrain("line", "bottom").equals(null, "bottom").minus(50),
+        constrain("line", "left").equals(null, "left")
+          .plus(layoutProps.padding.left),
+        constrain("line", "right").equals(null, "left")
+          .plus(layoutProps.padding.left),
+        //constrain("line", "bottom").lessThanOrEqualTo(null, "bottom").minus(50),
+        //constrain("line", "centerX").equals(null, "centerX")
+      ] :
+      [
+        constrain("line", "left").equals(null, "left")
+          .plus(layoutProps.padding.left),
+        constrain("line", "right").equals(null, "right")
+          .minus(layoutProps.padding.right),
+        constrain("line", "bottom").lessThanOrEqualTo(null, "bottom").minus(50),
+        constrain("line", "centerX").equals(null, "centerX")
+      ];
+
     return (
       <AxisLine key="line"
         viewName="line"
@@ -304,14 +323,7 @@ export default class VictoryAxis extends React.Component {
         x2={isVertical ? null : props.width - padding.right}
         y1={isVertical ? padding.top : null}
         y2={isVertical ? props.height - padding.bottom : null}
-        constraints={[
-          constrain("line", "left").equals(null, "left")
-            .plus(layoutProps.padding.left),
-          constrain("line", "right").equals(null, "right")
-            .minus(layoutProps.padding.right),
-          constrain("line", "bottom").lessThanOrEqualTo(null, "bottom").minus(50),
-          constrain("line", "centerX").equals(null, "centerX")
-        ]}
+        constraints={constraints}
       />
     );
   }


### PR DESCRIPTION
**NOT READY FOR MERGE, EVERYTHING'S STILL GROSS**
This is the beginning of work on using a subset of Autolayout.js for axis layout. If this layout system and PR is approved, we'll move on to using Autolayout for victory-bar.

A constraint-based layout system will help us in some degree with the following issues:
#33 #106 #107 #121 #122 
FormidableLabs/victory#41

TODO
- [ ] Reimplement custom label component support for axis and tick labels
- [x] Layout axis labels
- [ ] Fix layouts for all orientations
- [ ] Fix layout for cross axis
- [ ] Avoid Autolayout.js huge bundle size by not including VFL parser code and using the kiwi solver instead of cassowary.js
- [ ] Extract AutoLayout component into a standalone module 
- [ ] Pass tests and lint
- [ ] Refactor vigorously after everything works