### PR TITLE
Fix docs

### DIFF
--- a/docs/victory-axis/ecology.md
+++ b/docs/victory-axis/ecology.md
@@ -1,7 +1,7 @@
 VictoryAxis
 =============
 
-VictoryAxis draws an SVG chart axis with [React](https://github.com/facebook/react). Styles and data can be customized by passing in your own values as properties to the component. Data changes are animated with [victory-animation](https://github.com/FormidableLabs/victory-animation).
+VictoryAxis draws an SVG chart axis with [React][]. Styles and data can be customized by passing in your own values as properties to the component. Data changes are animated with [VictoryAnimation][].
 
 ## Features
 
@@ -36,7 +36,7 @@ Axes are meant to be composable.
 </svg>
 ```
 
-And can be made to cross each other by setting `offsetX`,  `offsetY`, and `crossAxis` props as shown below. Getting crossed axes to look correct requires calculating the appropriate offsets. This is handled automatically in [VictoryChart](https://github.com/FormidableLabs/victory-chart).
+And can be made to cross each other by setting `offsetX`,  `offsetY`, and `crossAxis` props as shown below. Getting crossed axes to look correct requires calculating the appropriate offsets. This is handled automatically in [VictoryChart][].
 
 ```playground
 <svg width={400} height={400}>
@@ -109,7 +109,7 @@ Here's how you make a log scale:
 
 ### Animating
 
-VictoryAxis animates with [VictoryAnimation](http://github.com/formidablelabs/victory-animation) as props change when an `animate` prop is provided.
+VictoryAxis animates with [VictoryAnimation][] as props change when an `animate` prop is provided.
 
 ```playground_norender
 class App extends React.Component {
@@ -168,3 +168,7 @@ ReactDOM.render(<App/>, mountNode);
 ```
 
 ### Props
+
+[React]: https://github.com/facebook/react
+[VictoryAnimation]: http://victory.formidable.com/docs/victory-animation
+[VictoryChart]: http://victory.formidable.com/docs/victory-chart

--- a/docs/victory-bar/ecology.md
+++ b/docs/victory-bar/ecology.md
@@ -205,7 +205,7 @@ class App extends React.Component {
   }
 
   getData() {
-    return _.map(_.range(5), (index) => {
+    return _.map(_.range(4), (index) => {
       return [
         {x: "apples", y: _.random(1, 5)},
         {x: "oranges", y: _.random(1, 5)},

--- a/docs/victory-bar/ecology.md
+++ b/docs/victory-bar/ecology.md
@@ -1,7 +1,7 @@
 VictoryBar
 =============
 
-Draw SVG bar charts with [React](https://github.com/facebook/react). VictoryBar is a composable component, so it doesn't include axes. Check out [VictoryChart](https://github.com/FormidableLabs/victory-chart) for complete bar charts and more.
+Draw SVG bar charts with [React][]. VictoryBar is a composable component, so it doesn't include axes. Check out [VictoryChart][] for complete bar charts and more.
 
 ## Features
 
@@ -193,7 +193,7 @@ Functional styles allow elements to determine their own styles based on data
 
 ### Animating
 
-VictoryBar animates with [VictoryAnimation](http://github.com/formidablelabs/victory-animation) as data changes when an `animate` prop is provided.
+VictoryBar animates with [VictoryAnimation][] as data changes when an `animate` prop is provided.
 
 ```playground_norender
 class App extends React.Component {
@@ -246,3 +246,9 @@ class App extends React.Component {
 ReactDOM.render(<App/>, mountNode);
 
 ```
+
+### Props
+
+[React]: https://github.com/facebook/react
+[VictoryAnimation]: http://victory.formidable.com/docs/victory-animation
+[VictoryChart]: http://victory.formidable.com/docs/victory-chart

--- a/docs/victory-bar/ecology.md
+++ b/docs/victory-bar/ecology.md
@@ -1,7 +1,7 @@
 VictoryBar
 =============
 
-Draw SVG bar charts with [React](https://github.com/facebook/react). VictoryBar is a composable component, so it doesn't include axes. Check out [VictoryChart](https://github.com/FormidableLabs/victory-animation) for complete bar charts and more.
+Draw SVG bar charts with [React](https://github.com/facebook/react). VictoryBar is a composable component, so it doesn't include axes. Check out [VictoryChart](https://github.com/FormidableLabs/victory-chart) for complete bar charts and more.
 
 ## Features
 

--- a/docs/victory-chart/ecology.md
+++ b/docs/victory-chart/ecology.md
@@ -3,10 +3,10 @@ VictoryChart
 
 A flexible charting component for React. VictoryChart composes other Victory components into reusable charts. Acting as a coordinator rather than a stand-alone component, VictoryChart reconciles props such as `domain` and `scale` for child components, and provides a set of sensible defaults. This component works with:
 
-- [VictoryAxis](http://github.com/formidablelabs/victory-axis)
-- [VictoryLine](http://github.com/formidablelabs/victory-line)
-- [VictoryScatter](http://github.com/formidablelabs/victory-scatter)
-- [VictoryBar](http://github.com/formidablelabs/victory-bar)
+- [VictoryAxis][]
+- [VictoryLine][]
+- [VictoryScatter][]
+- [VictoryBar][]
 - More chart types coming soon!
 
 ## Features
@@ -28,7 +28,7 @@ VictoryChart was designed to build charts from minimal information. Pass in only
 </VictoryChart>
 ```
 
-In the example above, VictoryChart was given a VictoryLine component as a child. In addition, it also created a set of VictoryAxis components with the correct domain for the data being plotted by VictoryLine, created tick values based on that data, aligned all of its child components into a correct chart, and applied a set of default styles.
+In the example above, VictoryChart was given a [VictoryLine][] component as a child. In addition, it also created a set of VictoryAxis components with the correct domain for the data being plotted by [VictoryLine][], created tick values based on that data, aligned all of its child components into a correct chart, and applied a set of default styles.
 
 ### Declarative Composition
 
@@ -194,7 +194,7 @@ Time series data is also supported:
 
 ### Animating
 
-VictoryChart animates with [VictoryAnimation](http://github.com/formidablelabs/victory-animation) as data changes. Child components stay in sync.
+VictoryChart animates with [VictoryAnimation][] as data changes. Child components stay in sync.
 
 ```playground_norender
 class App extends React.Component {
@@ -253,3 +253,10 @@ ReactDOM.render(<App/>, mountNode);
 ```
 
 ### Props
+
+[React]: https://github.com/facebook/react
+[VictoryAnimation]: http://victory.formidable.com/docs/victory-animation
+[VictoryAxis]: http://victory.formidable.com/docs/victory-axis
+[VictoryLine]: http://victory.formidable.com/docs/victory-line
+[VictoryScatter]: http://victory.formidable.com/docs/victory-scatter
+[VictoryBar]: http://victory.formidable.com/docs/victory-bar

--- a/docs/victory-line/ecology.md
+++ b/docs/victory-line/ecology.md
@@ -1,7 +1,7 @@
 VictoryLine
 =============
 
-VictoryLine creates a line based on data. VictoryLine is a composable component, so it does not include an axis.  Check out [VictoryChart](https://github.com/formidablelabs/victory-chart) for easy to use line charts and more.
+VictoryLine creates a line based on data. VictoryLine is a composable component, so it does not include an axis.  Check out [VictoryChart][] for easy to use line charts and more.
 
 ## Features
 
@@ -117,7 +117,7 @@ VictoryLine also supports functional styles. Unlike other data components, style
 
 ### Animating
 
-VictoryLine animates with [VictoryAnimation](http://github.com/formidablelabs/victory-animation) as data changes when an `animate` prop is provided.
+VictoryLine animates with [VictoryAnimation][] as data changes when an `animate` prop is provided.
 
 ```playground_norender
 class App extends React.Component {
@@ -171,3 +171,8 @@ class App extends React.Component {
 ReactDOM.render(<App/>, mountNode);
 
 ```
+
+### Props
+
+[VictoryAnimation]: http://victory.formidable.com/docs/victory-animation
+[VictoryChart]: http://victory.formidable.com/docs/victory-chart

--- a/docs/victory-scatter/ecology.md
+++ b/docs/victory-scatter/ecology.md
@@ -1,7 +1,7 @@
 VictoryScatter
 =============
 
-VictoryScatter creates a scatter of points from data. VictoryScatter is a composable component, so it does not include an axis. Check out [VictoryChart](https://github.com/formidablelabs/victory-chart) for easy to use scatter plots and more.
+VictoryScatter creates a scatter of points from data. VictoryScatter is a composable component, so it does not include an axis. Check out [VictoryChart][] for easy to use scatter plots and more.
 
 ## Features
 
@@ -143,7 +143,7 @@ Functional styles allow elements to determine their own styles based on data
 
 ### Animating
 
-VictoryScatter animates with [VictoryAnimation](http://github.com/formidablelabs/victory-animation) as data changes when an `animate` prop is provided.
+VictoryScatter animates with [VictoryAnimation][] as data changes when an `animate` prop is provided.
 
 ```playground_norender
 class App extends React.Component {
@@ -200,3 +200,6 @@ ReactDOM.render(<App/>, mountNode);
 ```
 
 ### Props
+
+[VictoryAnimation]: http://victory.formidable.com/docs/victory-animation
+[VictoryChart]: http://victory.formidable.com/docs/victory-chart


### PR DESCRIPTION
- Fix VictoryAnimation link -> VictoryChart
- Use Markdown reusable-link syntax (`[Link][]`)
- Consistently link to docs pages (victory.formidable.com rather than github)
- Fix bar example: Make length of data match dataAttributes