### PR TITLE
Fix style transition animations

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,12 +21,12 @@
     "version": "builder run npm:version && git add dist && git commit -m \"Commit 'dist/' for publishing\""
   },
   "dependencies": {
-    "builder-victory-component": "0.2.1",
     "builder": "~2.4.0",
+    "builder-victory-component": "~0.2.1",
     "d3-scale": "^0.2.0",
     "d3-shape": "^0.5.1",
     "lodash": "^3.10.1",
-    "memoizerific": "^1.5.2",
+    "lru-memoize": "^1.0.1",
     "victory-core": "^1.1.1"
   },
   "devDependencies": {

--- a/src/components/victory-area/victory-area.jsx
+++ b/src/components/victory-area/victory-area.jsx
@@ -11,7 +11,7 @@ import { PropTypes as CustomPropTypes, Helpers, VictoryAnimation } from "victory
 import Area from "./area";
 import AreaLabel from "./area-label";
 import AreaHelpers from "./helper-methods";
-import memoizerific from "memoizerific";
+import lruMemoize from "lru-memoize";
 
 const defaultStyles = {
   data: {
@@ -241,7 +241,7 @@ export default class VictoryArea extends React.Component {
   componentWillMount() {
     this.memoized = {
       // Provide performant, multiple-argument memoization with LRU cache-size of 1.
-      getStyles: memoizerific(1)(Helpers.getStyles)
+      getStyles: lruMemoize(1, true)(Helpers.getStyles)
     };
   }
 

--- a/src/components/victory-bar/victory-bar.jsx
+++ b/src/components/victory-bar/victory-bar.jsx
@@ -1,5 +1,5 @@
 import pick from "lodash/object/pick";
-import memoizerific from "memoizerific";
+import lruMemoize from "lru-memoize";
 import React, { PropTypes } from "react";
 import { PropTypes as CustomPropTypes, Helpers, VictoryAnimation } from "victory-core";
 
@@ -260,7 +260,7 @@ export default class VictoryBar extends React.Component {
   componentWillMount() {
     this.memoized = {
       // Provide performant, multiple-argument memoization with LRU cache-size of 1.
-      getStyles: memoizerific(1)(Helpers.getStyles)
+      getStyles: lruMemoize(1, true)(Helpers.getStyles)
     };
   }
 

--- a/src/components/victory-line/victory-line.jsx
+++ b/src/components/victory-line/victory-line.jsx
@@ -8,7 +8,7 @@ import Scale from "../../helpers/scale";
 import Domain from "../../helpers/domain";
 import Data from "../../helpers/data";
 import { PropTypes as CustomPropTypes, Helpers, VictoryAnimation } from "victory-core";
-import memoizerific from "memoizerific";
+import lruMemoize from "lru-memoize";
 
 const defaultStyles = {
   data: {
@@ -205,7 +205,7 @@ export default class VictoryLine extends React.Component {
   componentWillMount() {
     this.memoized = {
       // Provide performant, multiple-argument memoization with LRU cache-size of 1.
-      getStyles: memoizerific(1)(Helpers.getStyles)
+      getStyles: lruMemoize(1, true)(Helpers.getStyles)
     };
   }
 

--- a/src/components/victory-scatter/victory-scatter.jsx
+++ b/src/components/victory-scatter/victory-scatter.jsx
@@ -6,7 +6,7 @@ import Domain from "../../helpers/domain";
 import Data from "../../helpers/data";
 import { PropTypes as CustomPropTypes, Helpers, VictoryAnimation } from "victory-core";
 import ScatterHelpers from "./helper-methods";
-import memoizerific from "memoizerific";
+import lruMemoize from "lru-memoize";
 
 const defaultStyles = {
   data: {
@@ -213,7 +213,7 @@ export default class VictoryScatter extends React.Component {
   componentWillMount() {
     this.memoized = {
       // Provide performant, multiple-argument memoization with LRU cache-size of 1.
-      getStyles: memoizerific(1)(Helpers.getStyles)
+      getStyles: lruMemoize(1, true)(Helpers.getStyles)
     };
   }
 


### PR DESCRIPTION
I forgot to open a PR for this.  This swaps out memoizerific for lru-memoize, which has proper cache support for deep objects.  Closes #139.

@boygirl @coopy 