### PR TITLE
Data transitions

### DIFF
--- a/demo/components/victory-chart-demo.jsx
+++ b/demo/components/victory-chart-demo.jsx
@@ -5,7 +5,10 @@ import {
   VictoryChart, VictoryLine, VictoryAxis, VictoryBar, VictoryScatter
 } from "../../src/index";
 
-const UPDATE_INTERVAL = 2000;
+
+const UPDATE_INTERVAL = 3000;
+let scatterDataToggle = false;
+
 
 const chartStyle = {parent: {width: 500, height: 350, margin: 50}};
 class App extends React.Component {
@@ -71,11 +74,12 @@ class App extends React.Component {
     const colors =
       ["violet", "cornflowerblue", "gold", "orange", "turquoise", "tomato", "greenyellow"];
     const symbols = ["circle", "star", "square", "triangleUp", "triangleDown", "diamond", "plus"];
-    return _.map(_.range(20), (index) => {
+    const elementNum = (scatterDataToggle = !scatterDataToggle) ? 10 : 40;
+    return _.map(_.range(elementNum), (index) => {
       const scaledIndex = _.floor(index % 7);
       return {
-        x: _.random(20),
-        y: _.random(20),
+        x: _.random(!scatterDataToggle ? 50 : 10) - (!scatterDataToggle ? 25 : 5),
+        y: _.random(!scatterDataToggle ? 50 : 10),
         size: _.random(8) + 3,
         symbol: symbols[scaledIndex],
         fill: colors[_.random(0, 6)],
@@ -191,7 +195,7 @@ class App extends React.Component {
             />
           </VictoryChart>
 
-          <VictoryChart animate={{velocity: 0.02}}>
+          <VictoryChart animate={{duration: 750}}>
             <VictoryScatter data={this.state.scatterData}/>
             <VictoryLine y={(data) => data.x}/>
           </VictoryChart>

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "d3-scale": "^0.2.0",
     "d3-shape": "^0.6.0",
     "lodash": "^4.6.1",
-    "victory-core": "^1.2.2"
+    "victory-core": "^1.3.0"
   },
   "devDependencies": {
     "builder-victory-component-dev": "^2.1.0",

--- a/src/components/victory-scatter/victory-scatter.jsx
+++ b/src/components/victory-scatter/victory-scatter.jsx
@@ -29,6 +29,8 @@ const defaultStyles = {
 
 export default class VictoryScatter extends React.Component {
   static role = "scatter";
+  static supportsTransitions = true;
+
   static propTypes = {
     /**
      * The animate prop specifies props for victory-animation to use. It this prop is


### PR DESCRIPTION
This adds transitions for data that is exiting and entering the dataset.  When transitioning from dataset A to dataset B:

- if datum X is present in A but not in B, X will fade in before the primary transition occurs
- if datum Y is present in A and B, Y will move to its new location (primary transition)
- if datum Z is present in B but not A, Z will fade in after the primary transition

There were issues with domain interpolation for components without entering/exiting data, but that was resolved.

Here's what remains to be done:

- [x] Fix issue in `componentWillReceiveProps` with `this.props.children` when single child is supplied.
- [x] Evaluate performance impact.
- [x] Pull `getNodeTransitions` out of `VictoryScatter` and into separate helper module, using a static class property to indicate exit/enter transition-support per component.
- [x] Add proper keyed-data support - some of the groundwork is there, but we're still relying on datum array index for matching nodes to their exiting/entering counterparts.
- [x] Answer: _Do we want chart animation duration to encompass the entire transition (including exit/enter) or should it only be used for the data movement?_
- [x] Identify why there is that last little "zoom-out" when entering nodes fade in, and whether we care about it.
- [x] The duration of exit/enter transitions should be configurable.
- [x] Identify shortcomings with individual data-point opacity, and how that interacts with this new functionality.

**Here's what it looks like:**

![exit-and-enter-transitions](https://cloud.githubusercontent.com/assets/5016978/13758422/ab9ff188-e9e6-11e5-9acd-c96c3c790baf.gif)

/cc @boygirl @coopy @kenwheeler @tptee 