### PR TITLE
Fix docs-hot webpack config

### DIFF
--- a/docs/app.jsx
+++ b/docs/app.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Link } from "react-router";
+import { StyleRoot } from "radium";
 
 const App = React.createClass({
   propTypes: {
@@ -8,7 +9,7 @@ const App = React.createClass({
 
   render() {
     return (
-      <div>
+      <StyleRoot>
         <ul>
           <li><Link to="/area">Victory Area Docs</Link></li>
           <li><Link to="/axis">Victory Axis Docs</Link></li>
@@ -18,7 +19,7 @@ const App = React.createClass({
           <li><Link to="/scatter">Victory Scatter Docs</Link></li>
         </ul>
         {this.props.children}
-      </div>
+      </StyleRoot>
     );
   }
 });

--- a/docs/app.jsx
+++ b/docs/app.jsx
@@ -1,14 +1,5 @@
 import React from "react";
-import ReactDOM from "react-dom";
-import { Router, Route, Link } from "react-router";
-import AreaDocs from "./victory-area/docs";
-import AxisDocs from "./victory-axis/docs";
-import BarDocs from "./victory-bar/docs";
-import ChartDocs from "./victory-chart/docs";
-import LineDocs from "./victory-line/docs";
-import ScatterDocs from "./victory-scatter/docs";
-
-const content = document.getElementById("content");
+import { Link } from "react-router";
 
 const App = React.createClass({
   propTypes: {
@@ -32,15 +23,4 @@ const App = React.createClass({
   }
 });
 
-ReactDOM.render((
-  <Router>
-    <Route path="/" component={App}>
-      <Route path="area" component={AreaDocs}/>
-      <Route path="axis" component={AxisDocs}/>
-      <Route path="bar" component={BarDocs}/>
-      <Route path="chart" component={ChartDocs}/>
-      <Route path="line" component={LineDocs}/>
-      <Route path="scatter" component={ScatterDocs}/>
-    </Route>
-  </Router>
-), content);
+export default App;

--- a/docs/entry.jsx
+++ b/docs/entry.jsx
@@ -1,0 +1,25 @@
+import React from "react";
+import ReactDOM from "react-dom";
+import { Router, Route } from "react-router";
+import App from "./app";
+import AreaDocs from "./victory-area/docs";
+import AxisDocs from "./victory-axis/docs";
+import BarDocs from "./victory-bar/docs";
+import ChartDocs from "./victory-chart/docs";
+import LineDocs from "./victory-line/docs";
+import ScatterDocs from "./victory-scatter/docs";
+
+const content = document.getElementById("content");
+
+ReactDOM.render((
+  <Router>
+    <Route path="/" component={App}>
+      <Route path="area" component={AreaDocs}/>
+      <Route path="axis" component={AxisDocs}/>
+      <Route path="bar" component={BarDocs}/>
+      <Route path="chart" component={ChartDocs}/>
+      <Route path="line" component={LineDocs}/>
+      <Route path="scatter" component={ScatterDocs}/>
+    </Route>
+  </Router>
+), content);

--- a/docs/index.html
+++ b/docs/index.html
@@ -23,7 +23,6 @@
   <div id="content" class="Container">
     <p>Oops! Something is broken or JavaScript is not enabled.</p>
   </div>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-core/5.8.25/browser.js"></script>
   <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.0.0/codemirror.min.js"></script>
   <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.0.0/mode/javascript/javascript.min.js"></script>
   <script async defer type="text/javascript" src="main.js"></script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -23,7 +23,6 @@
   <div id="content" class="Container">
     <p>Oops! Something is broken or JavaScript is not enabled.</p>
   </div>
-  <script src="https://fb.me/react-0.13.3.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-core/5.8.25/browser.js"></script>
   <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.0.0/codemirror.min.js"></script>
   <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.0.0/mode/javascript/javascript.min.js"></script>

--- a/docs/victory-bar/docs.jsx
+++ b/docs/victory-bar/docs.jsx
@@ -16,10 +16,11 @@ class Docs extends React.Component {
           overview={require("!!raw!./ecology.md")}
           source={docgen.parse(require("!!raw!../../src/components/victory-bar/victory-bar"))}
           scope={{_, React, ReactDOM, VictoryLabel, VictoryBar}}
-          playgroundtheme="elegant" />
+          playgroundtheme="elegant"
+        />
         <Style rules={VictoryTheme}/>
       </div>
-    )
+    );
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -23,14 +23,14 @@
   },
   "dependencies": {
     "builder": "~2.9.1",
-    "builder-victory-component": "^2.0.0",
+    "builder-victory-component": "^2.0.1",
     "d3-scale": "^0.2.0",
     "d3-shape": "^0.6.0",
     "lodash": "^4.6.1",
     "victory-core": "^1.2.2"
   },
   "devDependencies": {
-    "builder-victory-component-dev": "^2.0.0",
+    "builder-victory-component-dev": "^2.0.1",
     "chai": "^3.2.0",
     "history": "~1.17.0",
     "ecology": "^1.2.0",


### PR DESCRIPTION
**Don't merge**: Depends on https://github.com/FormidableLabs/builder-victory-component/pull/52

- Export app.jsx as module to support hot reloading.
- `docs/entry.jsx` is the new entrypoint.
- Wrap docs in `StyleRoot`