### PR TITLE
Adds dataComponent prop to Scatter

### DIFF
--- a/demo/components/victory-scatter-demo.jsx
+++ b/demo/components/victory-scatter-demo.jsx
@@ -46,6 +46,38 @@ const symbolStyle = {
   }
 };
 
+class CatPoint extends React.Component {
+  static propTypes = {
+    x: React.PropTypes.number,
+    y: React.PropTypes.number,
+    symbol: React.PropTypes.string
+  };
+
+  render() {
+    const {x, y, symbol} = this.props;
+
+    return (
+      <text x={x} y={y}>
+        {this.renderSymbol(symbol)}
+      </text>
+    );
+  }
+
+  static symbolMap = {
+    "circle": 0x1F431,
+    "diamond": 0x1F638,
+    "plus": 0x1F639,
+    "square": 0x1F63A,
+    "star": 0x1F63B,
+    "triangleDown": 0x1F63C,
+    "triangleUp": 0x1F63D
+  };
+
+  renderSymbol(symbol) {
+    return String.fromCodePoint(CatPoint.symbolMap[symbol]);
+  }
+}
+
 export default class App extends React.Component {
   constructor(props) {
     super(props);
@@ -72,6 +104,16 @@ export default class App extends React.Component {
     return (
       <div className="demo">
         <h1>VictoryScatter</h1>
+        <VictoryScatter
+          style={style}
+          width={500}
+          height={500}
+          domain={[0, 600]}
+          animate={{velocity: 0.03}}
+          data={this.state.data}
+          dataComponent={<CatPoint />}
+        />
+
         <VictoryScatter
           style={style}
           width={500}

--- a/test/client/spec/components/victory-scatter/victory-scatter.spec.jsx
+++ b/test/client/spec/components/victory-scatter/victory-scatter.spec.jsx
@@ -9,6 +9,11 @@ import _ from "lodash";
 import VictoryScatter from "src/components/victory-scatter/victory-scatter";
 import Point from "src/components/victory-scatter/point";
 
+class MyPoint extends React.Component {
+
+  render() { }
+}
+
 describe("components/victory-scatter", () => {
   describe("default component rendering", () => {
     it("renders an svg with the correct width and height", () => {
@@ -22,6 +27,16 @@ describe("components/victory-scatter", () => {
   });
 
   describe("rendering data", () => {
+    it("renders injected points for {x, y} shaped data (default)", () => {
+      const data = _.range(10).map((i) => ({x: i, y: i}));
+      const wrapper = shallow(
+        <VictoryScatter data={data} dataComponent={<MyPoint />} />
+      );
+
+      const points = wrapper.find(MyPoint);
+      expect(points.length).to.equal(10);
+    });
+
     it("renders points for {x, y} shaped data (default)", () => {
       const data = _.range(10).map((i) => ({x: i, y: i}));
       const wrapper = shallow(


### PR DESCRIPTION
1. Includes a (single) shallow test to assert the type of node matches that provided in the props.
2. Includes a refactoring of `renderPoint` to extract the props manipulation into separate functions.

~~Missing: an example in the victory scatter demos! Happy to hear some ideas about that!~~

Contributes to resolution of FormidableLabs/victory-chart#100