### PR TITLE
Adds dataComponent prop to Line

### DIFF
--- a/demo/components/victory-line-demo.jsx
+++ b/demo/components/victory-line-demo.jsx
@@ -2,7 +2,54 @@
 import React from "react";
 import _ from "lodash";
 import {VictoryLine} from "../../src/index";
+import LineSegment from "../../src/components/victory-line/line-segment";
+import Point from "../../src/components/victory-scatter/point";
 import {VictoryLabel} from "victory-core";
+
+class PointedLine extends React.Component {
+  static propTypes = {
+    ...LineSegment.propTypes,
+    index: React.PropTypes.number
+  };
+
+  renderLine(props) {
+    return <LineSegment {...props} />;
+  }
+
+  renderPoints(props) {
+    const {index, data, scale} = props;
+    return (data.map(
+      (datum, pointIndex) => {
+        const {x, y} = datum;
+
+        const position = {
+          x: scale.x.call(null, x),
+          y: scale.y.call(null, y)
+        };
+
+        return (<Point
+          symbol="circle"
+          size={2}
+          key={`line-${index}-point-${pointIndex}`}
+          index={parseFloat(`${index}.${pointIndex}`)}
+          datum={datum}
+          {...position}
+                />);
+      })
+    );
+  }
+
+  render() {
+    const {index} = this.props;
+
+    return (
+      <g key={`line-point-group-${index}`}>
+        {this.renderLine(this.props)}
+        {this.renderPoints(this.props)}
+      </g>
+    );
+  }
+}
 
 export default class App extends React.Component {
   constructor() {
@@ -84,6 +131,14 @@ export default class App extends React.Component {
           data={_.range(0, 100)}
           x={null}
           y={(d) => d * d}
+        />
+
+        <VictoryLine
+          style={{parent: {border: "1px solid black", margin: "5px"}}}
+          data={this.state.arrayData}
+          x={0}
+          y={1}
+          dataComponent={<PointedLine />}
         />
 
         <VictoryLine

--- a/src/components/victory-line/victory-line.jsx
+++ b/src/components/victory-line/victory-line.jsx
@@ -46,6 +46,16 @@ export default class VictoryLine extends React.Component {
      */
     data: PropTypes.array,
     /**
+     * The dataComponent prop takes an entire, HTML-complete data component which will be used to
+     * create line segments between each point in the plotted line. The new element created from
+     * the passed dataComponent will have the property data set by the line for the segment it
+     * renders; properties scale and style calculated by the VictoryLine component; a key and index
+     * property set corresponding to the location of the segment in the data provided to the line;
+     * and all the remaining properties from the VictoryLine data at the index of the segment.
+     * If a dataComponent is not provided, VictoryLine's LineSegment component will be used.
+     */
+    dataComponent: PropTypes.element,
+    /**
      * The domain prop describes the range of values your chart will include. This prop can be
      * given as a array of the minimum and maximum expected values for your chart,
      * or as an object that specifies separate arrays for x and y.
@@ -218,7 +228,8 @@ export default class VictoryLine extends React.Component {
     standalone: true,
     width: 450,
     x: "x",
-    y: "y"
+    y: "y",
+    dataComponent: <LineSegment />
   };
 
   static getDomain = Domain.getDomain.bind(Domain);
@@ -258,20 +269,22 @@ export default class VictoryLine extends React.Component {
 
   renderLine(calculatedProps) {
     const {dataSegments, scale, style} = calculatedProps;
+    const {interpolation, dataComponent, events} = this.props;
+
     return dataSegments.map((segment, index) => {
-      const getBoundEvents = Helpers.getEvents.bind(this);
-      return (
-        <LineSegment
-          key={`line-segment-${index}`}
-          index={index}
-          events={getBoundEvents(this.props.events.data, "data")}
-          data={segment}
-          interpolation={this.props.interpolation}
-          scale={scale}
-          style={style.data}
-          {...this.state.dataState[index]}
-        />
-      );
+      const lineEvents = Helpers.getEvents.bind(this)(events.data, "data");
+      const key = `line-segment-${index}`;
+
+      return React.cloneElement(dataComponent, {
+        key,
+        index,
+        events: lineEvents,
+        data: segment,
+        interpolation,
+        scale,
+        style: style.data,
+        ...this.state.dataState[index]
+      });
     });
   }
 

--- a/test/client/spec/components/victory-line/victory-line.spec.jsx
+++ b/test/client/spec/components/victory-line/victory-line.spec.jsx
@@ -9,6 +9,10 @@ import { shallow, mount } from "enzyme";
 import VictoryLine from "src/components/victory-line/victory-line";
 import Line from "src/components/victory-line/line-segment";
 
+class MyLineSegment extends React.Component {
+  render() { }
+}
+
 describe("components/victory-line", () => {
   describe("default component rendering", () => {
     it("renders an svg with the correct width and height", () => {
@@ -22,6 +26,27 @@ describe("components/victory-line", () => {
   });
 
   describe("rendering with null data", () => {
+    it("renders one dataComponent for the line when there is no null data", () => {
+      const data = [
+        {x: 1, y: 1},
+        {x: 2, y: 4},
+        {x: 3, y: 5},
+        {x: 4, y: 2},
+        {x: 5, y: 3},
+        {x: 6, y: 4},
+        {x: 7, y: 6}
+      ];
+      const wrapper = shallow(
+        <VictoryLine
+          data={data}
+          dataComponent={<MyLineSegment />}
+        />
+      );
+
+      const lines = wrapper.find(MyLineSegment);
+      expect(lines.length).to.equal(1);
+    });
+
     it("renders one line segment when there is no null data", () => {
       const data = [
         {x: 1, y: 1},


### PR DESCRIPTION
Includes a (single) shallow test to assert the type of node matches
that provided in the props. I noticed we have a set of tests designed to
test the segmentation of datasets. I chose to add this test using the
simplest case.

~~Missing: an example in the victory line demos!~~

Contributes to resolution of FormidableLabs/victory-chart#100