### PR TITLE
Invert rendering order within victory-axis group

### DIFF
--- a/src/components/victory-axis/victory-axis.jsx
+++ b/src/components/victory-axis/victory-axis.jsx
@@ -411,10 +411,10 @@ export default class VictoryAxis extends React.Component {
     const transform = AxisHelpers.getTransform(this.props, layoutProps);
     const group = (
       <g style={style.parent} transform={transform}>
-        {this.renderLabel(this.props, layoutProps)}
-        {this.renderTicks(this.props, layoutProps, tickProps)}
-        {this.renderLine(this.props, layoutProps)}
         {this.renderGrid(this.props, layoutProps, tickProps)}
+        {this.renderLine(this.props, layoutProps)}
+        {this.renderTicks(this.props, layoutProps, tickProps)}
+        {this.renderLabel(this.props, layoutProps)}
       </g>
     );
     return this.props.standalone ? (


### PR DESCRIPTION
This leads to the more expected behavior of the labels having precedence in the DOM over the gridlines. 

Specifically this change is needed if one implements a custom tick label component that doesn't behave exactly like the default. The custom tick labels may overlap the gridlines and should be displayed over top of them.