### PR TITLE
fix x-adjust for bar charts

### DIFF
--- a/src/components/victory-bar/helper-methods.js
+++ b/src/components/victory-bar/helper-methods.js
@@ -28,8 +28,7 @@ export default {
     const style = calculatedProps.style.data;
     const x = datum.x;
     const datasets = calculatedProps.datasets;
-    const center = datasets.length % 2 === 0 ?
-      datasets.length / 2 : (datasets.length - 1) / 2;
+    const center = (datasets.length - 1) / 2;
     const centerOffset = index - center;
     const totalWidth = this.pixelsToValue(style.padding, "x", calculatedProps) +
       this.pixelsToValue(style.width, "x", calculatedProps);


### PR DESCRIPTION
I noticed that bar charts with an even number of series weren't being totally centered around their axis point and saw the the x-offset was being computed differently in those (even series) cases. Not sure if there is a reason for that, but always computing the offset in the same way produces what I think is a better outcome:

BEFORE:
![screen shot 2016-03-31 at 3 58 50 pm](https://cloud.githubusercontent.com/assets/2760121/14189718/d1d3edf4-f75c-11e5-98db-8829211def46.png)


AFTER:
![screen shot 2016-03-31 at 3 59 07 pm](https://cloud.githubusercontent.com/assets/2760121/14189723/d655ea3a-f75c-11e5-8c14-d7a362da4290.png)

