### PR TITLE
VictoryScatter default transitions

### DIFF
--- a/demo/components/victory-chart-demo.jsx
+++ b/demo/components/victory-chart-demo.jsx
@@ -195,9 +195,23 @@ class App extends React.Component {
             />
           </VictoryChart>
 
-          <VictoryChart animate={{duration: 750}}>
-            <VictoryScatter data={this.state.scatterData}/>
-            <VictoryLine y={(data) => data.x}/>
+          <VictoryChart animate={{ duration: 1500 }}>
+            <VictoryScatter
+              data={this.state.scatterData}
+              animate={{
+                onExit: {
+                  duration: 500,
+                  before: () => ({ opacity: 1 }),
+                  after: (datum) => {
+                    return {
+                      opacity: 0,
+                      x: datum.x + ((Math.random() - 0.5) * 8),
+                      y: datum.y + ((Math.random() - 0.5) * 8)
+                    };
+                  }
+                }
+              }}
+            />
           </VictoryChart>
 
           <VictoryChart>

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "builder-victory-component": "^2.1.0",
     "d3-scale": "^0.2.0",
     "d3-shape": "^0.6.0",
-    "lodash": "^4.6.1",
-    "victory-core": "^1.3.0"
+    "lodash": "~4.6.1",
+    "victory-core": "^1.3.2"
   },
   "devDependencies": {
     "builder-victory-component-dev": "^2.1.0",

--- a/src/components/victory-chart/victory-chart.jsx
+++ b/src/components/victory-chart/victory-chart.jsx
@@ -251,7 +251,7 @@ export default class VictoryChart extends React.Component {
     );
 
     return childComponents.map((child, index) => {
-      const transitionProps = getTransitionProps(child.props, index);
+      const transitionProps = getTransitionProps(child.props, child.type, index);
       const style = defaults({}, child.props.style, {parent: baseStyle.parent});
       const childProps = this.getChildProps(child, props, calculatedProps);
 

--- a/src/components/victory-scatter/victory-scatter.jsx
+++ b/src/components/victory-scatter/victory-scatter.jsx
@@ -29,7 +29,19 @@ const defaultStyles = {
 
 export default class VictoryScatter extends React.Component {
   static role = "scatter";
-  static supportsTransitions = true;
+
+  static defaultTransitions = {
+    onExit: {
+      duration: 600,
+      before: (datum) => ({ opacity: "opacity" in datum ? datum.opacity : 1 }),
+      after: () => ({ opacity: 0 })
+    },
+    onEnter: {
+      duration: 600,
+      before: () => ({ opacity: 0 }),
+      after: (datum) => ({ opacity: "opacity" in datum ? datum.opacity : 1 })
+    }
+  }
 
   static propTypes = {
     /**


### PR DESCRIPTION
This defines default transitions for `VictoryScatter` component.  I don't think this will pass CI until the [sibling PR](https://github.com/FormidableLabs/victory-core/pull/42) is merged, and the `package.json` reference is updated here.

I also included a change to the demo, to show how the `onEnter` default is use, and to give an example of an override.

@boygirl 