### PR TITLE
Default transitions

### DIFF
--- a/demo/components/victory-area-demo.jsx
+++ b/demo/components/victory-area-demo.jsx
@@ -9,8 +9,26 @@ export default class App extends React.Component {
     this.state = {
       data: this.getData(),
       arrayData: this.getArrayData(),
-      groupedData: this.getGroupedData()
+      groupedData: this.getGroupedData(),
+      multiTransitionData: this.getMultiTransitionData(),
+      areaTransitionData: this.getAreaTransitionData()
     };
+  }
+
+  getMultiTransitionData() {
+    const areas = _.random(8, 10);
+    return _.map(_.range(5), () => {
+      return _.map(_.range(areas), (area) => {
+        return {x: area, y: _.random(2, 10)};
+      });
+    });
+  }
+
+  getAreaTransitionData() {
+    const areas = _.random(6, 10);
+    return _.map(_.range(areas), (area) => {
+      return {x: area, y: _.random(2, 10)};
+    });
   }
 
   getData() {
@@ -65,6 +83,8 @@ export default class App extends React.Component {
       this.setState({
         data: this.getData(),
         groupedData: this.getGroupedData(),
+        multiTransitionData: this.getMultiTransitionData(),
+        areaTransitionData: this.getAreaTransitionData(),
         style: this.getStyles()
       });
     }, 2000);
@@ -77,6 +97,22 @@ export default class App extends React.Component {
 
     return (
       <div className="demo">
+
+        <VictoryArea
+          style={style} animate={{duration: 1000}}
+          data={this.state.areaTransitionData}
+        />
+
+        <VictoryStack
+          style={style}
+          animate={{duration: 1000}}
+          colorScale={"warm"}
+        >
+          {this.state.multiTransitionData.map((data, index) => {
+            return <VictoryArea key={index} data={data} interpolation={"basis"}/>;
+          })}
+        </VictoryStack>
+
         <VictoryArea style={style}/>
 
         <VictoryArea

--- a/demo/components/victory-bar-demo.jsx
+++ b/demo/components/victory-bar-demo.jsx
@@ -8,6 +8,8 @@ export default class App extends React.Component {
     super();
     this.state = {
       barData: this.getBarData(),
+      barTransitionData: this.getBarTransitionData(),
+      multiTransitionData: this.getMultiTransitionData(),
       numericBarData: this.getNumericBarData()
     };
   }
@@ -50,14 +52,32 @@ export default class App extends React.Component {
     });
   }
 
+  getBarTransitionData() {
+    const bars = _.random(6, 10);
+    return _.map(_.range(bars), (bar) => {
+      return {x: bar, y: _.random(2, 10)}
+    })
+  }
+
+  getMultiTransitionData() {
+    const bars = _.random(6, 10);
+    return _.map(_.range(5), () => {
+      return _.map(_.range(bars), (bar) => {
+        return {x: bar, y: _.random(2, 10)}
+      });
+    });
+  }
+
   componentDidMount() {
     /* eslint-disable react/no-did-mount-set-state */
     this.setStateInterval = window.setInterval(() => {
       this.setState({
         barData: this.getBarData(),
+        barTransitionData: this.getBarTransitionData(),
+        multiTransitionData: this.getMultiTransitionData(),
         numericBarData: this.getNumericBarData()
       });
-    }, 4000);
+    }, 2000);
   }
 
   componentWillUnmount() {
@@ -73,6 +93,20 @@ export default class App extends React.Component {
     return (
       <div className="demo">
         <h1>VictoryBar</h1>
+        <VictoryBar
+          style={{parent: parentStyle}} animate={{duration: 1000}}
+          data={this.state.barTransitionData}
+        />
+
+        <VictoryStack
+          style={{parent: parentStyle}}
+          animate={{duration: 1000}}
+          colorScale={"warm"}
+        >
+          {this.state.multiTransitionData.map((data, index) => {
+            return <VictoryBar key={index} data={data}/>;
+          })}
+        </VictoryStack>
 
         <VictoryGroup
           style={{parent: parentStyle}} offset={18}

--- a/demo/components/victory-bar-demo.jsx
+++ b/demo/components/victory-bar-demo.jsx
@@ -55,15 +55,15 @@ export default class App extends React.Component {
   getBarTransitionData() {
     const bars = _.random(6, 10);
     return _.map(_.range(bars), (bar) => {
-      return {x: bar, y: _.random(2, 10)}
-    })
+      return {x: bar, y: _.random(2, 10)};
+    });
   }
 
   getMultiTransitionData() {
     const bars = _.random(6, 10);
     return _.map(_.range(5), () => {
       return _.map(_.range(bars), (bar) => {
-        return {x: bar, y: _.random(2, 10)}
+        return {x: bar, y: _.random(2, 10)};
       });
     });
   }

--- a/demo/components/victory-bar-demo.jsx
+++ b/demo/components/victory-bar-demo.jsx
@@ -60,8 +60,8 @@ export default class App extends React.Component {
   }
 
   getMultiTransitionData() {
-    const bars = _.random(6, 10);
-    return _.map(_.range(5), () => {
+    const bars = _.random(3, 5);
+    return _.map(_.range(4), () => {
       return _.map(_.range(bars), (bar) => {
         return {x: bar, y: _.random(2, 10)};
       });
@@ -91,7 +91,16 @@ export default class App extends React.Component {
       <div className="demo">
         <h1>VictoryBar</h1>
         <VictoryBar
-          style={{parent: parentStyle}} animate={{duration: 1000}}
+          style={{parent: parentStyle}}
+          animate={{
+            duration: 500,
+            onExit: {
+              duration: 1000
+            },
+            onEnter: {
+              duration: 500
+            }
+          }}
           data={this.state.barTransitionData}
         />
 
@@ -104,6 +113,17 @@ export default class App extends React.Component {
             return <VictoryBar key={index} data={data}/>;
           })}
         </VictoryStack>
+
+        <VictoryGroup
+          offset={15}
+          style={{parent: parentStyle}}
+          animate={{duration: 1000}}
+          colorScale={"qualitative"}
+        >
+          {this.state.multiTransitionData.map((data, index) => {
+            return <VictoryBar key={index} data={data}/>;
+          })}
+        </VictoryGroup>
 
         <VictoryGroup
           style={{parent: parentStyle}} offset={18}

--- a/demo/components/victory-chart-demo.jsx
+++ b/demo/components/victory-chart-demo.jsx
@@ -8,8 +8,6 @@ import {
 
 
 const UPDATE_INTERVAL = 3000;
-let scatterDataToggle = false;
-
 
 const chartStyle = {parent: {width: 500, height: 350, margin: 50}};
 class App extends React.Component {
@@ -75,8 +73,8 @@ class App extends React.Component {
   getBarTransitionData() {
     const bars = _.random(6, 10);
     return _.map(_.range(bars), (bar) => {
-      return {x: bar, y: _.random(2, 10)}
-    })
+      return {x: bar, y: _.random(2, 10)};
+    });
   }
 
   getScatterData() {
@@ -228,13 +226,13 @@ class App extends React.Component {
               animate={{
                 onExit: {
                   duration: 500,
-                  before: (datum) => ({ opacity: 0.5}),
+                  before: (datum) => ({ opacity: datum.opacity || 0.5}),
                   after: () => ({opacity: 0.1})
                 },
                 onEnter: {
                   duration: 500,
                   before: () => ({ opacity: 0.1 }),
-                  after: (datum) => ({ opacity: 0.5 })
+                  after: (datum) => ({ opacity: datum.opacity || 0.5 })
                 }
               }}
             />
@@ -316,6 +314,23 @@ class App extends React.Component {
                 })}
               </VictoryStack>
             </VictoryGroup>
+          </VictoryChart>
+
+          <VictoryChart>
+            <VictoryStack colorScale={"qualitative"}>
+              <VictoryArea
+                data={[{x: 1, y: 2}, {x: 2, y: 3}, {x: 3, y: 5}, {x: 4, y: 4}, {x: 5, y: 7}]}
+              />
+              <VictoryArea
+                data={[{x: 1, y: 1}, {x: 2, y: 4}, {x: 3, y: 5}, {x: 4, y: 7}, {x: 5, y: 5}]}
+              />
+              <VictoryArea
+                data={[{x: 1, y: 3}, {x: 2, y: 2}, {x: 3, y: 6}, {x: 4, y: 2}, {x: 5, y: 6}]}
+              />
+              <VictoryArea
+                data={[{x: 1, y: 2}, {x: 2, y: 3}, {x: 3, y: 3}, {x: 4, y: 4}, {x: 5, y: 7}]}
+              />
+            </VictoryStack>
           </VictoryChart>
 
         </p>

--- a/demo/components/victory-chart-demo.jsx
+++ b/demo/components/victory-chart-demo.jsx
@@ -2,7 +2,8 @@
 import React from "react";
 import _ from "lodash";
 import {
-  VictoryChart, VictoryLine, VictoryAxis, VictoryBar, VictoryScatter, VictoryStack, VictoryGroup
+  VictoryChart, VictoryLine, VictoryAxis, VictoryBar, VictoryArea,
+  VictoryScatter, VictoryStack, VictoryGroup
 } from "../../src/index";
 
 
@@ -19,6 +20,7 @@ class App extends React.Component {
       lineData: this.getData(),
       numericBarData: this.getNumericBarData(),
       barData: this.getBarData(),
+      barTransitionData: this.getBarTransitionData(),
       lineStyle: this.getStyles()
     };
   }
@@ -70,6 +72,13 @@ class App extends React.Component {
     });
   }
 
+  getBarTransitionData() {
+    const bars = _.random(6, 10);
+    return _.map(_.range(bars), (bar) => {
+      return {x: bar, y: _.random(2, 10)}
+    })
+  }
+
   getScatterData() {
     const colors =
       ["violet", "cornflowerblue", "gold", "orange", "turquoise", "tomato", "greenyellow"];
@@ -103,6 +112,7 @@ class App extends React.Component {
         scatterData: this.getScatterData(),
         lineData: this.getData(),
         barData: this.getBarData(),
+        barTransitionData: this.getBarTransitionData(),
         numericBarData: this.getNumericBarData(),
         lineStyle: this.getStyles()
       });
@@ -118,179 +128,15 @@ class App extends React.Component {
       <div className="demo">
         <h1>VictoryChart</h1>
         <p>
-          <VictoryChart/>
 
-          <VictoryChart height={500} width={200}>
-            <VictoryScatter/>
-          </VictoryChart>
 
-          <VictoryChart>
-            <VictoryLine/>
-          </VictoryChart>
-
-          <VictoryChart>
-            <VictoryBar/>
-          </VictoryChart>
-
-          <VictoryChart scale={"linear"}>
-            <VictoryLine
-              style={{data:
-                {stroke: "red", strokeWidth: 4}
-              }}
-              y={(data) => Math.sin(2 * Math.PI * data.x)}
-            />
-            <VictoryLine
-              style={{data:
-                {stroke: "blue", strokeWidth: 4}
-              }}
-              y={(data) => Math.cos(2 * Math.PI * data.x)}
+          <VictoryChart animate={{ duration: 600 }} padding={0}>
+            <VictoryBar
+              data={this.state.barTransitionData}
             />
           </VictoryChart>
 
-          <VictoryChart style={chartStyle} animate={{velocity: 0.02}}>
-            <VictoryAxis dependentAxis orientation="left" style={{grid: {strokeWidth: 1}}}/>
-            <VictoryLine
-              data={this.state.lineData}
-              style={{data: this.state.lineStyle}}
-            />
-          </VictoryChart>
 
-          <VictoryChart style={chartStyle}
-            scale={{
-              x: "time"
-            }}
-          >
-            <VictoryAxis
-              orientation="bottom"
-              tickValues={[
-                new Date(1980, 1, 1),
-                new Date(1990, 1, 1),
-                new Date(2000, 1, 1),
-                new Date(2010, 1, 1),
-                new Date(2020, 1, 1)
-              ]}
-              tickFormat={(x) => x.getFullYear()}
-            />
-            <VictoryLine
-              style={{
-                data: {stroke: "red", strokeWidth: 5},
-                labels: {fontSize: 12}
-              }}
-              events={{data: {
-                onClick: (evt) => {
-                  this.setState({label: `x: ${evt.clientX}, y: ${evt.clientY}`});
-                }
-              }}}
-              label={this.state.label}
-              data={[
-                {x: new Date(1982, 1, 1), y: 125},
-                {x: new Date(1987, 1, 1), y: 257},
-                {x: new Date(1993, 1, 1), y: 345},
-                {x: new Date(1997, 1, 1), y: 515},
-                {x: new Date(2001, 1, 1), y: 132},
-                {x: new Date(2005, 1, 1), y: 305},
-                {x: new Date(2011, 1, 1), y: 270},
-                {x: new Date(2015, 1, 1), y: 470}
-              ]}
-            />
-          </VictoryChart>
-
-          <VictoryChart animate={{ duration: 1500 }}>
-            <VictoryScatter
-              data={this.state.scatterData}
-              animate={{
-                onExit: {
-                  duration: 500,
-                  before: () => ({ opacity: 1 }),
-                  after: (datum) => {
-                    return {
-                      opacity: 0,
-                      x: datum.x + ((Math.random() - 0.5) * 8),
-                      y: datum.y + ((Math.random() - 0.5) * 8)
-                    };
-                  }
-                }
-              }}
-            />
-          </VictoryChart>
-
-          <VictoryChart>
-            <VictoryAxis dependentAxis orientation="right"/>
-            <VictoryAxis orientation="top"/>
-            <VictoryLine y={(d) => 0.5 * d.x + 0.5} style={{data: {stroke: "red"}}}/>
-            <VictoryScatter y={(d) => d.x * d.x} style={{data: {stroke: "red"}}}/>
-          </VictoryChart>
-
-          <VictoryChart animate={{duration: 2000}}
-            domainPadding={{x: 100}}
-          >
-            <VictoryStack>
-              {this.state.barData.map((data, index) => {
-                return <VictoryBar data={data} key={index}/>;
-              })}
-            </VictoryStack>
-          </VictoryChart>
-
-          <VictoryChart domainPadding={{x: 30, y: 30}}>
-            <VictoryAxis
-              tickValues={[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]}
-              tickFormat={(x) => `${x}\ntick`}
-              style={{
-                axis: {stroke: "black", strokeWidth: 2},
-                ticks: {stroke: "transparent"},
-                tickLabels: {fill: "black"}
-              }}
-            />
-            <VictoryAxis label="y axis" dependentAxis
-              tickValues={[0, 1.5, 3, 4.5]}
-              style={{
-                grid: {strokeWidth: 1},
-                axis: {stroke: "transparent"},
-                ticks: {stroke: "transparent", padding: 15}
-              }}
-            />
-            <VictoryBar style={{data: {width: 15, fill: "orange"}}}
-              data={[
-                {x: 1, y: 1},
-                {x: 2, y: 2},
-                {x: 3, y: 3},
-                {x: 4, y: 2},
-                {x: 5, y: 1},
-                {x: 6, y: 2},
-                {x: 7, y: 3},
-                {x: 8, y: 2},
-                {x: 9, y: 1},
-                {x: 10, y: 2},
-                {x: 11, y: 3},
-                {x: 12, y: 2},
-                {x: 13, y: 1}
-              ]}
-            />
-            <VictoryLine y={() => 0.5}
-              style={{data: {stroke: "gold", strokeWidth: 3}}}
-              label="LINE"
-            />
-          </VictoryChart>
-
-          <VictoryChart domainPadding={{x: 50}} animate={{duration: 2000}}>
-            <VictoryGroup offset={15}>
-              <VictoryStack colorScale={"red"}>
-                {this.getBarData().map((data, index) => {
-                  return <VictoryBar key={index} data={data}/>;
-                })}
-              </VictoryStack>
-              <VictoryStack colorScale={"green"}>
-                {this.getBarData().map((data, index) => {
-                  return <VictoryBar key={index} data={data}/>;
-                })}
-              </VictoryStack>
-              <VictoryStack colorScale={"blue"}>
-                {this.getBarData().map((data, index) => {
-                  return <VictoryBar key={index} data={data}/>;
-                })}
-              </VictoryStack>
-            </VictoryGroup>
-          </VictoryChart>
         </p>
       </div>
     );

--- a/demo/components/victory-chart-demo.jsx
+++ b/demo/components/victory-chart-demo.jsx
@@ -241,13 +241,12 @@ class App extends React.Component {
               animate={{
                 onExit: {
                   duration: 500,
-                  before: (datum) => ({ opacity: datum.opacity || 0.5}),
-                  after: () => ({opacity: 0.1})
+                  before: () => ({opacity: 0.3})
                 },
                 onEnter: {
                   duration: 500,
-                  before: () => ({ opacity: 0.1 }),
-                  after: (datum) => ({ opacity: datum.opacity || 0.5 })
+                  before: () => ({ opacity: 0.3 }),
+                  after: (datum) => ({ opacity: datum.opacity || 1 })
                 }
               }}
             />

--- a/demo/components/victory-chart-demo.jsx
+++ b/demo/components/victory-chart-demo.jsx
@@ -133,7 +133,7 @@ class App extends React.Component {
               data={this.state.barTransitionData}
               animate={{
                 onExit: {
-                  duration: 1000,
+                  duration: 500,
                   before: (datum) => ({ y: datum.y}),
                   after: () => ({y: 0})
                 },
@@ -196,7 +196,7 @@ class App extends React.Component {
                 new Date(2010, 1, 1),
                 new Date(2020, 1, 1)
               ]}
-              tickFormat={(x) => x.getFullYear()}
+              tickFormat={(x) => new Date(x).getFullYear()}
             />
             <VictoryLine
               style={{
@@ -222,7 +222,7 @@ class App extends React.Component {
             />
           </VictoryChart>
 
-          <VictoryChart animate={{ duration: 1500 }}>
+          <VictoryChart animate={{ duration: 2000 }}>
             <VictoryScatter
               data={this.state.scatterData}
               animate={{

--- a/demo/components/victory-chart-demo.jsx
+++ b/demo/components/victory-chart-demo.jsx
@@ -83,16 +83,16 @@ class App extends React.Component {
     const colors =
       ["violet", "cornflowerblue", "gold", "orange", "turquoise", "tomato", "greenyellow"];
     const symbols = ["circle", "star", "square", "triangleUp", "triangleDown", "diamond", "plus"];
-    const elementNum = (scatterDataToggle = !scatterDataToggle) ? 10 : 40;
+    const elementNum = _.random(10, 40);
     return _.map(_.range(elementNum), (index) => {
       const scaledIndex = _.floor(index % 7);
       return {
-        x: _.random(!scatterDataToggle ? 50 : 10) - (!scatterDataToggle ? 25 : 5),
-        y: _.random(!scatterDataToggle ? 50 : 10),
+        x: _.random(10, 50),
+        y: _.random(2, 100),
         size: _.random(8) + 3,
         symbol: symbols[scaledIndex],
         fill: colors[_.random(0, 6)],
-        opacity: _.random(0.3, 1)
+        opacity: 1
       };
     });
   }
@@ -128,21 +128,195 @@ class App extends React.Component {
       <div className="demo">
         <h1>VictoryChart</h1>
         <p>
-
-
-          <VictoryChart animate={{ duration: 600 }}>
+          <VictoryChart animate={{ duration: 1500 }}>
             <VictoryBar
               data={this.state.barTransitionData}
               animate={{
                 onExit: {
-                  duration: 500,
+                  duration: 1000,
                   before: (datum) => ({ y: datum.y}),
                   after: () => ({y: 0})
+                },
+                onEnter: {
+                  duration: 500,
+                  before: () => ({ y: 0 }),
+                  after: (datum) => ({ y: datum.y })
+                }
+              }}
+            />
+          </VictoryChart>
+          <VictoryChart/>
+
+          <VictoryChart height={500} width={200}>
+            <VictoryScatter/>
+          </VictoryChart>
+
+          <VictoryChart>
+            <VictoryLine/>
+          </VictoryChart>
+
+          <VictoryChart>
+            <VictoryBar/>
+          </VictoryChart>
+
+          <VictoryChart scale={"linear"}>
+            <VictoryLine
+              style={{data:
+                {stroke: "red", strokeWidth: 4}
+              }}
+              y={(data) => Math.sin(2 * Math.PI * data.x)}
+            />
+            <VictoryLine
+              style={{data:
+                {stroke: "blue", strokeWidth: 4}
+              }}
+              y={(data) => Math.cos(2 * Math.PI * data.x)}
+            />
+          </VictoryChart>
+
+          <VictoryChart style={chartStyle} animate={{velocity: 0.02}}>
+            <VictoryAxis dependentAxis orientation="left" style={{grid: {strokeWidth: 1}}}/>
+            <VictoryLine
+              data={this.state.lineData}
+              style={{data: this.state.lineStyle}}
+            />
+          </VictoryChart>
+
+          <VictoryChart style={chartStyle}
+            scale={{
+              x: "time"
+            }}
+          >
+            <VictoryAxis
+              orientation="bottom"
+              tickValues={[
+                new Date(1980, 1, 1),
+                new Date(1990, 1, 1),
+                new Date(2000, 1, 1),
+                new Date(2010, 1, 1),
+                new Date(2020, 1, 1)
+              ]}
+              tickFormat={(x) => x.getFullYear()}
+            />
+            <VictoryLine
+              style={{
+                data: {stroke: "red", strokeWidth: 5},
+                labels: {fontSize: 12}
+              }}
+              events={{data: {
+                onClick: (evt) => {
+                  this.setState({label: `x: ${evt.clientX}, y: ${evt.clientY}`});
+                }
+              }}}
+              label={this.state.label}
+              data={[
+                {x: new Date(1982, 1, 1), y: 125},
+                {x: new Date(1987, 1, 1), y: 257},
+                {x: new Date(1993, 1, 1), y: 345},
+                {x: new Date(1997, 1, 1), y: 515},
+                {x: new Date(2001, 1, 1), y: 132},
+                {x: new Date(2005, 1, 1), y: 305},
+                {x: new Date(2011, 1, 1), y: 270},
+                {x: new Date(2015, 1, 1), y: 470}
+              ]}
+            />
+          </VictoryChart>
+
+          <VictoryChart animate={{ duration: 1500 }}>
+            <VictoryScatter
+              data={this.state.scatterData}
+              animate={{
+                onExit: {
+                  duration: 500,
+                  before: (datum) => ({ opacity: 0.5}),
+                  after: () => ({opacity: 0.1})
+                },
+                onEnter: {
+                  duration: 500,
+                  before: () => ({ opacity: 0.1 }),
+                  after: (datum) => ({ opacity: 0.5 })
                 }
               }}
             />
           </VictoryChart>
 
+          <VictoryChart>
+            <VictoryAxis dependentAxis orientation="right"/>
+            <VictoryAxis orientation="top"/>
+            <VictoryLine y={(d) => 0.5 * d.x + 0.5} style={{data: {stroke: "red"}}}/>
+            <VictoryScatter y={(d) => d.x * d.x} style={{data: {stroke: "red"}}}/>
+          </VictoryChart>
+
+          <VictoryChart animate={{duration: 2000}}
+            domainPadding={{x: 100}}
+          >
+            <VictoryStack>
+              {this.state.barData.map((data, index) => {
+                return <VictoryBar data={data} key={index}/>;
+              })}
+            </VictoryStack>
+          </VictoryChart>
+
+          <VictoryChart domainPadding={{x: 30, y: 30}}>
+            <VictoryAxis
+              tickValues={[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]}
+              tickFormat={(x) => `${x}\ntick`}
+              style={{
+                axis: {stroke: "black", strokeWidth: 2},
+                ticks: {stroke: "transparent"},
+                tickLabels: {fill: "black"}
+              }}
+            />
+            <VictoryAxis label="y axis" dependentAxis
+              tickValues={[0, 1.5, 3, 4.5]}
+              style={{
+                grid: {strokeWidth: 1},
+                axis: {stroke: "transparent"},
+                ticks: {stroke: "transparent", padding: 15}
+              }}
+            />
+            <VictoryBar style={{data: {width: 15, fill: "orange"}}}
+              data={[
+                {x: 1, y: 1},
+                {x: 2, y: 2},
+                {x: 3, y: 3},
+                {x: 4, y: 2},
+                {x: 5, y: 1},
+                {x: 6, y: 2},
+                {x: 7, y: 3},
+                {x: 8, y: 2},
+                {x: 9, y: 1},
+                {x: 10, y: 2},
+                {x: 11, y: 3},
+                {x: 12, y: 2},
+                {x: 13, y: 1}
+              ]}
+            />
+            <VictoryLine y={() => 0.5}
+              style={{data: {stroke: "gold", strokeWidth: 3}}}
+              label="LINE"
+            />
+          </VictoryChart>
+
+          <VictoryChart domainPadding={{x: 50}} animate={{duration: 2000}}>
+            <VictoryGroup offset={15}>
+              <VictoryStack colorScale={"red"}>
+                {this.getBarData().map((data, index) => {
+                  return <VictoryBar key={index} data={data}/>;
+                })}
+              </VictoryStack>
+              <VictoryStack colorScale={"green"}>
+                {this.getBarData().map((data, index) => {
+                  return <VictoryBar key={index} data={data}/>;
+                })}
+              </VictoryStack>
+              <VictoryStack colorScale={"blue"}>
+                {this.getBarData().map((data, index) => {
+                  return <VictoryBar key={index} data={data}/>;
+                })}
+              </VictoryStack>
+            </VictoryGroup>
+          </VictoryChart>
 
         </p>
       </div>

--- a/demo/components/victory-chart-demo.jsx
+++ b/demo/components/victory-chart-demo.jsx
@@ -130,9 +130,16 @@ class App extends React.Component {
         <p>
 
 
-          <VictoryChart animate={{ duration: 600 }} padding={0}>
+          <VictoryChart animate={{ duration: 600 }}>
             <VictoryBar
               data={this.state.barTransitionData}
+              animate={{
+                onExit: {
+                  duration: 500,
+                  before: (datum) => ({ y: datum.y}),
+                  after: () => ({y: 0})
+                }
+              }}
             />
           </VictoryChart>
 

--- a/demo/components/victory-chart-demo.jsx
+++ b/demo/components/victory-chart-demo.jsx
@@ -19,6 +19,7 @@ class App extends React.Component {
       numericBarData: this.getNumericBarData(),
       barData: this.getBarData(),
       barTransitionData: this.getBarTransitionData(),
+      multiBarTransitionData: this.getMultiBarTransitionData(),
       lineStyle: this.getStyles()
     };
   }
@@ -77,6 +78,15 @@ class App extends React.Component {
     });
   }
 
+  getMultiBarTransitionData() {
+    const bars = _.random(6, 10);
+    return _.map(_.range(5), () => {
+      return _.map(_.range(bars), (bar) => {
+        return {x: bar, y: _.random(2, 10)};
+      });
+    });
+  }
+
   getScatterData() {
     const colors =
       ["violet", "cornflowerblue", "gold", "orange", "turquoise", "tomato", "greenyellow"];
@@ -111,6 +121,7 @@ class App extends React.Component {
         lineData: this.getData(),
         barData: this.getBarData(),
         barTransitionData: this.getBarTransitionData(),
+        multiBarTransitionData: this.getMultiBarTransitionData(),
         numericBarData: this.getNumericBarData(),
         lineStyle: this.getStyles()
       });
@@ -129,20 +140,17 @@ class App extends React.Component {
           <VictoryChart animate={{ duration: 1500 }}>
             <VictoryBar
               data={this.state.barTransitionData}
-              animate={{
-                onExit: {
-                  duration: 500,
-                  before: (datum) => ({ y: datum.y}),
-                  after: () => ({y: 0})
-                },
-                onEnter: {
-                  duration: 500,
-                  before: () => ({ y: 0 }),
-                  after: (datum) => ({ y: datum.y })
-                }
-              }}
             />
           </VictoryChart>
+
+          <VictoryChart animate={{duration: 1000}}>
+            <VictoryStack colorScale={"warm"}>
+              {this.state.multiBarTransitionData.map((data, index) => {
+                return <VictoryBar key={index} data={data}/>;
+              })}
+            </VictoryStack>
+          </VictoryChart>
+
           <VictoryChart/>
 
           <VictoryChart height={500} width={200}>

--- a/demo/components/victory-line-demo.jsx
+++ b/demo/components/victory-line-demo.jsx
@@ -27,14 +27,16 @@ class PointedLine extends React.Component {
           y: scale.y.call(null, y)
         };
 
-        return (<Point
-          symbol="circle"
-          size={2}
-          key={`line-${index}-point-${pointIndex}`}
-          index={parseFloat(`${index}.${pointIndex}`)}
-          datum={datum}
-          {...position}
-                />);
+        return (
+          <Point
+            symbol="circle"
+            size={2}
+            key={`line-${index}-point-${pointIndex}`}
+            index={parseFloat(`${index}.${pointIndex}`)}
+            datum={datum}
+            position={position}
+          />
+        );
       })
     );
   }
@@ -56,12 +58,20 @@ export default class App extends React.Component {
     super();
     this.state = {
       data: this.getData(),
+      transitionData: this.getTransitionData(),
       arrayData: this.getArrayData(),
       style: {
         stroke: "blue",
         strokeWidth: 2
       }
     };
+  }
+
+  getTransitionData() {
+    const lines = _.random(6, 10);
+    return _.map(_.range(lines), (line) => {
+      return {x: line, y: _.random(2, 10)};
+    });
   }
 
   getData() {
@@ -89,6 +99,7 @@ export default class App extends React.Component {
     this.setStateInterval = window.setInterval(() => {
       this.setState({
         data: this.getData(),
+        transitionData: this.getTransitionData(),
         style: this.getStyles()
       });
     }, 2000);
@@ -104,11 +115,17 @@ export default class App extends React.Component {
       <div className="demo">
         <h1>VictoryLine</h1>
 
+          <VictoryLine
+            style={{parent: parentStyle, data: this.state.style}}
+            data={this.state.transitionData}
+            animate={{duration: 800}}
+          />
+
         <VictoryLine
           style={{parent: parentStyle, data: this.state.style}}
           data={this.state.data}
           label={"label\none"}
-          animate={{duration: 2000}}
+          animate={{duration: 1500}}
         />
 
         <VictoryLine

--- a/demo/components/victory-scatter-demo.jsx
+++ b/demo/components/victory-scatter-demo.jsx
@@ -42,16 +42,15 @@ const symbolStyle = {
 
 class CatPoint extends React.Component {
   static propTypes = {
-    x: React.PropTypes.number,
-    y: React.PropTypes.number,
+    position: React.PropTypes.object,
     symbol: React.PropTypes.string
   };
 
   render() {
-    const {x, y, symbol} = this.props;
+    const {position, symbol} = this.props;
 
     return (
-      <text x={x} y={y}>
+      <text x={position.x} y={position.y}>
         {this.renderSymbol(symbol)}
       </text>
     );

--- a/docs/victory-bar/ecology.md
+++ b/docs/victory-bar/ecology.md
@@ -224,7 +224,7 @@ state can be accessed by index on the `dataState`, and `labelsState` state objec
 VictoryBar animates with [VictoryAnimation][] as data changes when an `animate` prop is provided.
 VictoryBar defines a set of default transition behaviors for entering and exiting data nodes.
 Provide `onExit` and `onEnter` via the animate prop to define custom enter and exit transitions.
-Values returned from `before` and `after` functions will alter the data prop of entering.
+Values returned from `before` and `after` functions will alter the data prop of entering or exiting nodes.
 
 ```playground_norender
 class App extends React.Component {
@@ -262,7 +262,7 @@ class App extends React.Component {
           duration: 500,
           onExit: {
             duration: 1000,
-            after: () => ({y: -1})
+            before: () => ({y: -1})
           },
         }}
       >

--- a/docs/victory-bar/ecology.md
+++ b/docs/victory-bar/ecology.md
@@ -222,6 +222,9 @@ state can be accessed by index on the `dataState`, and `labelsState` state objec
 ### Animating
 
 VictoryBar animates with [VictoryAnimation][] as data changes when an `animate` prop is provided.
+VictoryBar defines a set of default transition behaviors for entering and exiting data nodes.
+Provide `onExit` and `onEnter` via the animate prop to define custom enter and exit transitions.
+Values returned from `before` and `after` functions will alter the data prop of entering.
 
 ```playground_norender
 class App extends React.Component {
@@ -233,12 +236,11 @@ class App extends React.Component {
   }
 
   getData() {
+    const num = _.random(3, 5);
     return _.map(_.range(4), (index) => {
-      return [
-        {x: "apples", y: _.random(1, 5)},
-        {x: "oranges", y: _.random(1, 5)},
-        {x: "bananas", y: _.random(1, 5)}
-      ];
+      return _.map(_.range(num), (i) => {
+        return {x: i, y: _.random(2, 10)};
+      })
     });
   }
 
@@ -247,7 +249,7 @@ class App extends React.Component {
       this.setState({
         data: this.getData(),
       });
-    }, 2000);
+    }, 3000);
   }
 
   render() {
@@ -255,13 +257,14 @@ class App extends React.Component {
       <VictoryGroup
         height={600}
         offset={15}
-        animate={{duration: 2000}}
-        colorScale={[
-          "cornflowerblue",
-          "tomato",
-          "orange",
-          "gold",
-        ]}
+        colorScale={"qualitative"}
+        animate={{
+          duration: 500,
+          onExit: {
+            duration: 1000,
+            after: () => ({y: -1})
+          },
+        }}
       >
         {this.state.data.map((data, i) => {
           return (

--- a/docs/victory-chart/ecology.md
+++ b/docs/victory-chart/ecology.md
@@ -197,6 +197,9 @@ Time series data is also supported:
 ### Animating
 
 VictoryChart animates with [VictoryAnimation][] as data changes. Child components stay in sync.
+Victory components have default transition behaviors for entering and exiting data nodes.
+Provide `onExit` and `onEnter` via the animate prop to define custom enter and exit transitions.
+Values returned from `before` and `after` functions will alter the data prop of entering or exiting nodes.
 
 ```playground_norender
 class App extends React.Component {
@@ -204,35 +207,23 @@ class App extends React.Component {
     super(props);
     this.state = {
       data: this.getData(),
-      style: this.getStyles()
     };
   }
 
   getData() {
-    return _.map(_.range(25), (i) => {
+    const n = _.random(4, 10)
+    return _.map(_.range(n), (i) => {
       return {
         x: i,
-        y: Math.random()
+        y: _.random(2, 10)
       };
     });
-  }
-
-  getStyles() {
-    const colors = [
-      "red", "orange", "magenta",
-      "gold", "blue", "purple"
-    ];
-    return {
-      stroke: colors[_.random(0, 5)],
-      strokeWidth: _.random(1, 5)
-    };
   }
 
   componentDidMount() {
     setInterval(() => {
       this.setState({
-        data: this.getData(),
-        style: this.getStyles()
+        data: this.getData()
       });
     }, 2000);
   }
@@ -240,10 +231,24 @@ class App extends React.Component {
   render() {
     return (
       <VictoryChart height={500}
-        animate={{duration: 2000}}>
-        <VictoryLine
+        animate={{duration: 1000}}>
+        <VictoryBar
           data={this.state.data}
-          style={{data: this.state.style}}
+          style={{
+            data: {
+              fill: "tomato", width: 12
+            }
+          }}
+          animate={{
+            onExit: {
+              duration: 500,
+              before: () => ({
+                y: 0,
+                fill: "orange",
+                label: "BYE"
+              })
+            }
+          }}
         />
       </VictoryChart>
     );

--- a/docs/victory-scatter/ecology.md
+++ b/docs/victory-scatter/ecology.md
@@ -190,9 +190,7 @@ state can be accessed by index on the `dataState`, and `labelsState` state objec
 VictoryScatter animates with [VictoryAnimation][] as data changes when an `animate` prop is provided.
 VictoryScatter defines a set of default transition behaviors for entering and exiting data nodes.
 Provide `onExit` and `onEnter` via the animate prop to define custom enter and exit transitions.
-Values returned from `before` and `after` functions will alter the data prop of entering.
-and exiting nodes. In the example below, the opacity of the entering nodes is set to 0.3, so
-that the transition is more apparent.
+Values returned from `before` and `after` functions will alter the data prop of entering and exiting nodes. In the example below, the opacity of the entering nodes is set to 0.3, so that the transition is more apparent.
 
 ```playground_norender
 class App extends React.Component {
@@ -255,7 +253,7 @@ ReactDOM.render(<App/>, mountNode);
 
 ### Custom Data and Label Components
 
-VictoryScatter accepts custom data and label components via the `dataComponent` and `labelComponent` props. Custom components will soon be supported across all chart types (VictoryLine, VictoryBar, VictoryArea, VictoryPie).
+VictoryScatter accepts custom data and label components via the `dataComponent` and `labelComponent` props. Custom components are supported across all chart types (VictoryLine, VictoryBar, VictoryArea, VictoryPie).
 
 ```playground_norender
 class CatPoint extends React.Component {

--- a/docs/victory-scatter/ecology.md
+++ b/docs/victory-scatter/ecology.md
@@ -188,6 +188,11 @@ state can be accessed by index on the `dataState`, and `labelsState` state objec
 ### Animating
 
 VictoryScatter animates with [VictoryAnimation][] as data changes when an `animate` prop is provided.
+VictoryScatter defines a set of default transition behaviors for entering and exiting data nodes.
+Provide `onExit` and `onEnter` via the animate prop to define custom enter and exit transitions.
+Values returned from `before` and `after` functions will alter the data prop of entering.
+and exiting nodes. In the example below, the opacity of the entering nodes is set to 0.3, so
+that the transition is more apparent.
 
 ```playground_norender
 class App extends React.Component {
@@ -200,21 +205,19 @@ class App extends React.Component {
 
   getData() {
     const colors =[
-      "violet", "tomato", "cornflowerblue",
-      "turquoise",  "greenyellow", "orange"
+      "orange", "tomato", "gold", "cyan"
     ];
     const symbols = [
-      "circle", "star", "square", "diamond",
-      "triangleUp", "triangleDown", "plus"
+      "circle", "star", "plus", "diamond"
     ];
-    return _.map(_.range(25), (index) => {
+    const samples = _.random(5, 25);
+    return _.map(_.range(samples), (i) => {
       return {
         x: _.random(100),
         y: _.random(100),
         size: _.random(15) + 3,
-        symbol: symbols[index % 7],
-        fill: colors[_.random(0, 5)],
-        opacity: _.random(0.3, 1)
+        symbol: symbols[i % 4],
+        fill: colors[_.random(0, 3)],
       };
     });
   }
@@ -232,7 +235,14 @@ class App extends React.Component {
       <VictoryScatter
         height={600}
         domain={[0, 100]}
-        animate={{duration: 2000}}
+        animate={{
+          duration: 1000,
+          onEnter: {
+            duration: 500,
+            before: () => ({opacity: 0.3}),
+            after: () => ({opacity: 1})
+          }
+        }}
         data={this.state.data}
       />
 
@@ -250,11 +260,11 @@ VictoryScatter accepts custom data and label components via the `dataComponent` 
 ```playground_norender
 class CatPoint extends React.Component {
   render() {
-    const {x, y, datum} = this.props;
+    const {position, datum} = this.props;
     const cat = datum.y >= 0 ?
       '😻' : '😹';
     return (
-      <text x={x} y={y} fontSize={20}>
+      <text {...position} fontSize={20}>
         {cat}
       </text>
     );

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "d3-scale": "^0.6.0",
     "d3-shape": "^0.6.0",
     "lodash": "~4.6.1",
-    "victory-core": "^1.3.2"
+    "victory-core": "^1.4.0"
   },
   "devDependencies": {
     "builder-victory-component-dev": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "d3-scale": "^0.6.0",
     "d3-shape": "^0.6.0",
     "lodash": "~4.6.1",
-    "victory-core": "^1.4.2"
+    "victory-core": "^1.4.3"
   },
   "devDependencies": {
     "builder-victory-component-dev": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "d3-scale": "^0.6.0",
     "d3-shape": "^0.6.0",
     "lodash": "~4.6.1",
-    "victory-core": "^1.4.0"
+    "victory-core": "^1.4.2"
   },
   "devDependencies": {
     "builder-victory-component-dev": "^2.1.1",

--- a/src/components/victory-area/victory-area.jsx
+++ b/src/components/victory-area/victory-area.jsx
@@ -25,12 +25,12 @@ export default class VictoryArea extends React.Component {
 
   static defaultTransitions = {
     onExit: {
-      duration: 600,
+      duration: 500,
       before: (datum) => ({y: datum.y, yOffset: datum.yOffset, xOffset: datum.xOffset }),
       after: () => ({ y: 0, yOffset: 0, xOffset: 0 })
     },
     onEnter: {
-      duration: 600,
+      duration: 500,
       before: () => ({ y: 0, yOffset: 0, xOffset: 0 }),
       after: (datum) => ({ y: datum.y, yOffset: datum.yOffset, xOffset: datum.xOffset })
     }

--- a/src/components/victory-area/victory-area.jsx
+++ b/src/components/victory-area/victory-area.jsx
@@ -6,7 +6,7 @@ import React, { PropTypes } from "react";
 import Data from "../../helpers/data";
 import Domain from "../../helpers/domain";
 import Scale from "../../helpers/scale";
-import { PropTypes as CustomPropTypes, Helpers, VictoryAnimation } from "victory-core";
+import { PropTypes as CustomPropTypes, Helpers, VictoryTransition } from "victory-core";
 import Area from "./area";
 import AreaLabel from "./area-label";
 
@@ -28,11 +28,13 @@ export default class VictoryArea extends React.Component {
   static defaultTransitions = {
     onExit: {
       duration: 600,
-      after: (datum) => ({ y: 0 })
+      before: (datum) => ({y: datum.y, yOffset: datum.yOffset, xOffset: datum.xOffset }),
+      after: () => ({ y: 0, yOffset: 0, xOffset: 0 })
     },
     onEnter: {
       duration: 600,
-      before: (datum) => ({ y: 0 }),
+      before: () => ({ y: 0, yOffset: 0, xOffset: 0 }),
+      after: (datum) => ({ y: datum.y, yOffset: datum.yOffset, xOffset: datum.xOffset })
     }
   };
 
@@ -327,22 +329,17 @@ export default class VictoryArea extends React.Component {
   }
 
   render() {
-    // If animating, return a `VictoryAnimation` element that will create
-    // a new `VictoryBar` with nearly identical props, except (1) tweened
-    // and (2) `animate` set to null so we don't recurse forever.
     if (this.props.animate) {
-      // Do less work by having `VictoryAnimation` tween only values that
-      // make sense to tween. In the future, allow customization of animated
-      // prop whitelist/blacklist?
-      const animateData = pick(this.props, [
+      const whitelist = [
         "data", "domain", "height", "padding", "style", "width"
-      ]);
+      ];
       return (
-        <VictoryAnimation {...this.props.animate} data={animateData}>
-          {(props) => <VictoryArea {...this.props} {...props} animate={null}/>}
-        </VictoryAnimation>
+        <VictoryTransition animate={this.props.animate} animationWhitelist={whitelist}>
+          <VictoryArea {...this.props}/>
+        </VictoryTransition>
       );
     }
+
     const style = Helpers.getStyles(
       this.props.style, defaultStyles, this.props.height, this.props.width);
     const group = <g style={style.parent}>{this.renderData(this.props, style)}</g>;

--- a/src/components/victory-area/victory-area.jsx
+++ b/src/components/victory-area/victory-area.jsx
@@ -26,8 +26,7 @@ export default class VictoryArea extends React.Component {
   static defaultTransitions = {
     onExit: {
       duration: 500,
-      before: (datum) => ({y: datum.y, yOffset: datum.yOffset, xOffset: datum.xOffset }),
-      after: () => ({ y: 0, yOffset: 0, xOffset: 0 })
+      before: () => ({ y: 0, yOffset: 0 })
     },
     onEnter: {
       duration: 500,
@@ -38,10 +37,10 @@ export default class VictoryArea extends React.Component {
 
   static propTypes = {
     /**
-     * The animate prop specifies props for victory-animation to use. It this prop is
-     * not given, the bar chart will not tween between changing data / style props.
-     * Large datasets might animate slowly due to the inherent limits of svg rendering.
-     * @examples {duration: 500, onEnd: () => alert("done!")}
+     * The animate prop specifies props for VictoryAnimation to use. The animate prop should
+     * also be used to specify enter and exit transition configurations with the `onExit`
+     * and `onEnter` namespaces respectively.
+     * @examples {duration: 500, onEnd: () => {}, onEnter: {duration: 500, before: () => ({y: 0})})}
      */
     animate: PropTypes.object,
     /**
@@ -111,7 +110,8 @@ export default class VictoryArea extends React.Component {
       parent: PropTypes.object
     }),
     /**
-     * The height props specifies the height of the chart container element in pixels
+     * The height props specifies the height the svg viewBox of the chart container.
+     * This value should be given as a number of pixels
      */
     height: CustomPropTypes.nonNegative,
     /**
@@ -194,10 +194,11 @@ export default class VictoryArea extends React.Component {
      */
     standalone: PropTypes.bool,
     /**
-     * The style prop specifies styles for your chart. VictoryBar relies on Radium,
-     * so valid Radium style objects should work for this prop, however height, width, and margin
-     * are used to calculate range, and need to be expressed as a number of pixels
-     * @examples {data: {fill: "red", width: 8}, labels: {fontSize: 12}}
+     * The style prop specifies styles for your VictoryArea. Any valid inline style properties
+     * will be applied. Height, width, and padding should be specified via the height,
+     * width, and padding props, as they are used to calculate the alignment of
+     * components within chart.
+     * @examples {data: {fill: "red"}, labels: {fontSize: 12}}
      */
     style: PropTypes.shape({
       parent: PropTypes.object,
@@ -205,7 +206,8 @@ export default class VictoryArea extends React.Component {
       labels: PropTypes.object
     }),
     /**
-     * The width prop specifies the width of the chart container element in pixels
+     * The width props specifies the width of the svg viewBox of the chart container
+     * This value should be given as a number of pixels
      */
     width: CustomPropTypes.nonNegative,
     /**

--- a/src/components/victory-area/victory-area.jsx
+++ b/src/components/victory-area/victory-area.jsx
@@ -24,6 +24,18 @@ const defaultStyles = {
 
 export default class VictoryArea extends React.Component {
   static role = "area";
+
+  static defaultTransitions = {
+    onExit: {
+      duration: 600,
+      after: (datum) => ({ y: 0 })
+    },
+    onEnter: {
+      duration: 600,
+      before: (datum) => ({ y: 0 }),
+    }
+  };
+
   static propTypes = {
     /**
      * The animate prop specifies props for victory-animation to use. It this prop is

--- a/src/components/victory-area/victory-area.jsx
+++ b/src/components/victory-area/victory-area.jsx
@@ -1,4 +1,3 @@
-import pick from "lodash/pick";
 import last from "lodash/last";
 import assign from "lodash/assign";
 

--- a/src/components/victory-axis/victory-axis.jsx
+++ b/src/components/victory-axis/victory-axis.jsx
@@ -1,12 +1,6 @@
 import defaults from "lodash/defaults";
-import pick from "lodash/pick";
-
 import React, { PropTypes } from "react";
-import {
-  PropTypes as CustomPropTypes,
-  VictoryAnimation,
-  Helpers
-} from "victory-core";
+import { PropTypes as CustomPropTypes, VictoryTransition, Helpers } from "victory-core";
 import AxisLine from "./axis-line";
 import AxisLabel from "./axis-label";
 import GridLine from "./grid";
@@ -72,6 +66,15 @@ const getStyles = (props) => {
 
 export default class VictoryAxis extends React.Component {
   static role = "axis";
+  static defaultTransitions = {
+    onExit: {
+      duration: 500
+    },
+    onEnter: {
+      duration: 500
+    }
+  };
+
   static propTypes = {
     /**
      * The animate prop specifies props for victory-animation to use. It this prop is
@@ -387,9 +390,6 @@ export default class VictoryAxis extends React.Component {
   }
 
   render() {
-    // If animating, return a `VictoryAnimation` element that will create
-    // a new `VictoryAxis` with nearly identical props, except (1) tweened
-    // and (2) `animate` set to null so we don't recurse forever.
     if (this.props.animate) {
       // Do less work by having `VictoryAnimation` tween only values that
       // make sense to tween. In the future, allow customization of animated
@@ -398,11 +398,10 @@ export default class VictoryAxis extends React.Component {
         "style", "domain", "range", "tickCount", "tickValues",
         "offsetX", "offsetY", "padding", "width", "height"
       ];
-      const animateData = pick(this.props, whitelist);
       return (
-        <VictoryAnimation {...this.props.animate} data={animateData}>
-          {(props) => <VictoryAxis {...this.props} {...props} animate={null}/>}
-        </VictoryAnimation>
+        <VictoryTransition animate={this.props.animate} animationWhitelist={whitelist}>
+          <VictoryAxis {...this.props}/>
+        </VictoryTransition>
       );
     }
     const layoutProps = this.getLayoutProps(this.props);

--- a/src/components/victory-axis/victory-axis.jsx
+++ b/src/components/victory-axis/victory-axis.jsx
@@ -124,7 +124,8 @@ export default class VictoryAxis extends React.Component {
       tickLabels: PropTypes.object
     }),
     /**
-     * The height prop specifies the height of the chart container element in pixels.
+     * The height props specifies the height the svg viewBox of the chart container.
+     * This value should be given as a number of pixels
      */
     height: CustomPropTypes.nonNegative,
     /**
@@ -183,10 +184,10 @@ export default class VictoryAxis extends React.Component {
      */
     standalone: PropTypes.bool,
     /**
-     * The style prop specifies styles for your chart. Victory Axis relies on Radium,
-     * so valid Radium style objects should work for this prop, however height, width, and margin
-     * are used to calculate range, and need to be expressed as a number of pixels.
-     * Styles for axis lines, gridlines, and ticks are scoped to separate props.
+     * The style prop specifies styles for your VictoryAxis. Any valid inline style properties
+     * will be applied. Height, width, and padding should be specified via the height,
+     * width, and padding props, as they are used to calculate the alignment of
+     * components within chart.
      * @examples {axis: {stroke: "#756f6a"}, grid: {stroke: "grey"}, ticks: {stroke: "grey"},
      * tickLabels: {fontSize: 10, padding: 5}, axisLabel: {fontSize: 16, padding: 20}}
      */
@@ -219,7 +220,8 @@ export default class VictoryAxis extends React.Component {
      */
     tickValues: CustomPropTypes.homogeneousArray,
     /**
-     * The width props specifies the width of the chart container element in pixels
+     * The width props specifies the width of the svg viewBox of the chart container
+     * This value should be given as a number of pixels
      */
     width: CustomPropTypes.nonNegative
   };

--- a/src/components/victory-bar/victory-bar.jsx
+++ b/src/components/victory-bar/victory-bar.jsx
@@ -293,11 +293,7 @@ export default class VictoryBar extends React.Component {
   }
 
   renderData(props, data, style) {
-    const deadNodes = props.deadNodes || [];
     return data.map((datum, index) => {
-      if (deadNodes.indexOf(`${index}`) !== -1) {
-        return null;
-      }
       const position = this.getBarPosition(props, datum);
       const getBoundEvents = Helpers.getEvents.bind(this);
       const barComponent = (

--- a/src/components/victory-bar/victory-bar.jsx
+++ b/src/components/victory-bar/victory-bar.jsx
@@ -36,6 +36,20 @@ const defaultData = [
 
 export default class VictoryBar extends React.Component {
   static role = "bar";
+
+  static defaultTransitions = {
+    onExit: {
+      duration: 600,
+      before: (datum) => ({ y: datum.y }),
+      after: () => ({ y: 0 })
+    },
+    onEnter: {
+      duration: 600,
+      before: () => ({ y: 0 }),
+      after: (datum) => ({ y: datum.y })
+    }
+  };
+
   static propTypes = {
     /**
      * The animate prop specifies props for victory-animation to use. It this prop is

--- a/src/components/victory-bar/victory-bar.jsx
+++ b/src/components/victory-bar/victory-bar.jsx
@@ -39,8 +39,7 @@ export default class VictoryBar extends React.Component {
   static defaultTransitions = {
     onExit: {
       duration: 500,
-      before: (datum) => ({y: datum.y, yOffset: datum.yOffset }),
-      after: () => ({ y: 0, yOffset: 0 })
+      before: () => ({ y: 0, yOffset: 0 })
     },
     onEnter: {
       duration: 500,
@@ -51,10 +50,10 @@ export default class VictoryBar extends React.Component {
 
   static propTypes = {
     /**
-     * The animate prop specifies props for victory-animation to use. It this prop is
-     * not given, the bar chart will not tween between changing data / style props.
-     * Large datasets might animate slowly due to the inherent limits of svg rendering.
-     * @examples {duration: 500, onEnd: () => alert("done!")}
+     * The animate prop specifies props for VictoryAnimation to use. The animate prop should
+     * also be used to specify enter and exit transition configurations with the `onExit`
+     * and `onEnter` namespaces respectively.
+     * @examples {duration: 500, onEnd: () => {}, onEnter: {duration: 500, before: () => ({y: 0})})}
      */
     animate: PropTypes.object,
     /**
@@ -125,7 +124,8 @@ export default class VictoryBar extends React.Component {
       parent: PropTypes.object
     }),
     /**
-     * The height props specifies the height of the chart container element in pixels
+     * The height props specifies the height the svg viewBox of the chart container.
+     * This value should be given as a number of pixels
      */
     height: CustomPropTypes.nonNegative,
     /**
@@ -191,9 +191,10 @@ export default class VictoryBar extends React.Component {
      */
     standalone: PropTypes.bool,
     /**
-     * The style prop specifies styles for your chart. VictoryBar relies on Radium,
-     * so valid Radium style objects should work for this prop, however height, width, and margin
-     * are used to calculate range, and need to be expressed as a number of pixels
+     * The style prop specifies styles for your VictoryBar. Any valid inline style properties
+     * will be applied. Height, width, and padding should be specified via the height,
+     * width, and padding props, as they are used to calculate the alignment of
+     * components within chart.
      * @examples {data: {fill: "red", width: 8}, labels: {fontSize: 12}}
      */
     style: PropTypes.shape({
@@ -202,7 +203,8 @@ export default class VictoryBar extends React.Component {
       labels: PropTypes.object
     }),
     /**
-     * The width prop specifies the width of the chart container element in pixels
+     * The width props specifies the width of the svg viewBox of the chart container
+     * This value should be given as a number of pixels
      */
     width: CustomPropTypes.nonNegative,
     /**

--- a/src/components/victory-bar/victory-bar.jsx
+++ b/src/components/victory-bar/victory-bar.jsx
@@ -293,7 +293,11 @@ export default class VictoryBar extends React.Component {
   }
 
   renderData(props, data, style) {
+    const deadNodes = props.deadNodes || [];
     return data.map((datum, index) => {
+      if (deadNodes.indexOf(`${index}`) !== -1) {
+        return null;
+      }
       const position = this.getBarPosition(props, datum);
       const getBoundEvents = Helpers.getEvents.bind(this);
       const barComponent = (
@@ -331,6 +335,7 @@ export default class VictoryBar extends React.Component {
   }
 
   render() {
+
     // If animating, return a `VictoryAnimation` element that will create
     // a new `VictoryBar` with nearly identical props, except (1) tweened
     // and (2) `animate` set to null so we don't recurse forever.

--- a/src/components/victory-bar/victory-bar.jsx
+++ b/src/components/victory-bar/victory-bar.jsx
@@ -39,13 +39,13 @@ export default class VictoryBar extends React.Component {
   static defaultTransitions = {
     onExit: {
       duration: 500,
-      before: (datum) => ({y: datum.y, yOffset: datum.yOffset, xOffset: datum.xOffset }),
-      after: () => ({ y: 0, yOffset: 0, xOffset: 0 })
+      before: (datum) => ({y: datum.y, yOffset: datum.yOffset }),
+      after: () => ({ y: 0, yOffset: 0 })
     },
     onEnter: {
       duration: 500,
-      before: () => ({ y: 0, yOffset: 0, xOffset: 0 }),
-      after: (datum) => ({ y: datum.y, yOffset: datum.yOffset, xOffset: datum.xOffset })
+      before: () => ({ y: 0, yOffset: 0 }),
+      after: (datum) => ({ y: datum.y, yOffset: datum.yOffset })
     }
   };
 

--- a/src/components/victory-bar/victory-bar.jsx
+++ b/src/components/victory-bar/victory-bar.jsx
@@ -1,4 +1,3 @@
-import pick from "lodash/pick";
 import omit from "lodash/omit";
 import defaults from "lodash/defaults";
 import get from "lodash/get";

--- a/src/components/victory-bar/victory-bar.jsx
+++ b/src/components/victory-bar/victory-bar.jsx
@@ -3,7 +3,7 @@ import omit from "lodash/omit";
 import defaults from "lodash/defaults";
 import get from "lodash/get";
 import React, { PropTypes } from "react";
-import { PropTypes as CustomPropTypes, Helpers, VictoryAnimation } from "victory-core";
+import { PropTypes as CustomPropTypes, Helpers, VictoryTransition } from "victory-core";
 
 import Bar from "./bar";
 import BarLabel from "./bar-label";
@@ -39,14 +39,14 @@ export default class VictoryBar extends React.Component {
 
   static defaultTransitions = {
     onExit: {
-      duration: 600,
-      before: (datum) => ({y: datum.y}),
-      after: () => ({ y: 0 })
+      duration: 500,
+      before: (datum) => ({y: datum.y, yOffset: datum.yOffset, xOffset: datum.xOffset }),
+      after: () => ({ y: 0, yOffset: 0, xOffset: 0 })
     },
     onEnter: {
-      duration: 600,
-      before: () => ({ y: 0 }),
-      after: (datum) => ({ y: datum.y })
+      duration: 500,
+      before: () => ({ y: 0, yOffset: 0, xOffset: 0 }),
+      after: (datum) => ({ y: datum.y, yOffset: datum.yOffset, xOffset: datum.xOffset })
     }
   };
 
@@ -335,17 +335,13 @@ export default class VictoryBar extends React.Component {
     // a new `VictoryBar` with nearly identical props, except (1) tweened
     // and (2) `animate` set to null so we don't recurse forever.
     if (this.props.animate) {
-      // Do less work by having `VictoryAnimation` tween only values that
-      // make sense to tween. In the future, allow customization of animated
-      // prop whitelist/blacklist?
       const whitelist = [
         "data", "domain", "height", "padding", "style", "width"
       ];
-      const animateData = pick(this.props, whitelist);
       return (
-        <VictoryAnimation {...this.props.animate} data={animateData}>
-          {(props) => <VictoryBar {...this.props} {...props} animate={null}/>}
-        </VictoryAnimation>
+        <VictoryTransition animate={this.props.animate} animationWhitelist={whitelist}>
+          <VictoryBar {...this.props}/>
+        </VictoryTransition>
       );
     }
 

--- a/src/components/victory-bar/victory-bar.jsx
+++ b/src/components/victory-bar/victory-bar.jsx
@@ -40,7 +40,7 @@ export default class VictoryBar extends React.Component {
   static defaultTransitions = {
     onExit: {
       duration: 600,
-      before: (datum) => ({ y: datum.y }),
+      before: (datum) => ({y: datum.y}),
       after: () => ({ y: 0 })
     },
     onEnter: {

--- a/src/components/victory-chart/victory-chart.jsx
+++ b/src/components/victory-chart/victory-chart.jsx
@@ -1,12 +1,6 @@
 import defaults from "lodash/defaults";
-import partialRight from "lodash/partialRight";
-
 import React, { PropTypes } from "react";
-import {
-  PropTypes as CustomPropTypes,
-  Helpers,
-  Transitions
-} from "victory-core";
+import { PropTypes as CustomPropTypes, Helpers } from "victory-core";
 import VictoryAxis from "../victory-axis/victory-axis";
 import ChartHelpers from "./helper-methods";
 import Axis from "../../helpers/axis";
@@ -130,26 +124,8 @@ export default class VictoryChart extends React.Component {
   };
 
   componentWillReceiveProps(nextProps) {
-    if (!this.props.animate) {
-      return;
-    }
-    const oldChildren = Wrapper.flattenChildren(this.props);
-    const nextChildren = Wrapper.flattenChildren(nextProps);
-
-    const {
-      nodesWillExit,
-      nodesWillEnter,
-      childrenTransitions,
-      nodesShouldEnter
-    } = Transitions.getInitialTransitionState(oldChildren, nextChildren);
-
-    this.setState({
-      nodesWillExit,
-      nodesWillEnter,
-      childrenTransitions,
-      nodesShouldEnter,
-      oldProps: nodesWillExit ? this.props : null
-    });
+    const setAnimationState = Wrapper.setAnimationState.bind(this);
+    setAnimationState(nextProps);
   }
 
   getStyles(props) {
@@ -234,28 +210,14 @@ export default class VictoryChart extends React.Component {
     return {axisComponents, categories, domain, horizontal, scale, stringMap};
   }
 
-  getAnimationProps(props, child, index) {
-    let getTransitions = props.animate && props.animate.getTransitions;
-    const parentState = props.animate && props.animate.parentState || this.state;
-    if (!getTransitions) {
-      const getTransitionProps = Transitions.getTransitionPropsFactory(
-        props,
-        this.state,
-        (newState) => this.setState(newState)
-      );
-      getTransitions = partialRight(getTransitionProps, index);
-    }
-    return defaults({getTransitions, parentState}, props.animate, child.props.animate);
-  }
-
   getNewChildren(props, childComponents, baseStyle) {
     const calculatedProps = this.getCalculatedProps(props, childComponents);
-
+    const getAnimationProps = Wrapper.getAnimationProps.bind(this);
     return childComponents.map((child, index) => {
       const style = defaults({}, child.props.style, {parent: baseStyle.parent});
       const childProps = this.getChildProps(child, props, calculatedProps);
       const newProps = defaults({
-        animate: this.getAnimationProps(props, child, index),
+        animate: getAnimationProps(props, child, index),
         height: props.height,
         width: props.width,
         padding: Helpers.getPadding(props),

--- a/src/components/victory-chart/victory-chart.jsx
+++ b/src/components/victory-chart/victory-chart.jsx
@@ -133,8 +133,8 @@ export default class VictoryChart extends React.Component {
     if (!this.props.animate) {
       return;
     }
-    const oldChildren = this.getFlatChildren(this.props)
-    const nextChildren = this.getFlatChildren(nextProps)
+    const oldChildren = Wrapper.flattenChildren(this.props);
+    const nextChildren = Wrapper.flattenChildren(nextProps);
 
     const {
       nodesWillExit,
@@ -150,20 +150,6 @@ export default class VictoryChart extends React.Component {
       nodesShouldEnter,
       oldProps: nodesWillExit ? this.props : null
     });
-  }
-
-  getFlatChildren(props) {
-    const allFlat = ([first, ...rest]) => {
-      if (typeof first === "undefined") {
-        return [];
-      } else if (first.props.children) {
-        return [...allFlat(React.Children.toArray(first.props.children)), ...allFlat(rest)];
-      } else {
-        return [first, ...allFlat(rest)];
-      }
-    }
-    const children = React.Children.toArray(props.children);
-    return allFlat(children);
   }
 
   getStyles(props) {
@@ -250,7 +236,7 @@ export default class VictoryChart extends React.Component {
 
   getAnimationProps(props, child, index) {
     let getTransitions = props.animate && props.animate.getTransitions;
-    let parentState = props.animate && props.animate.parentState || this.state;
+    const parentState = props.animate && props.animate.parentState || this.state;
     if (!getTransitions) {
       const getTransitionProps = Transitions.getTransitionPropsFactory(
         props,
@@ -276,7 +262,7 @@ export default class VictoryChart extends React.Component {
         ref: index,
         key: index,
         standalone: false,
-        style,
+        style
       }, childProps);
       return React.cloneElement(child, newProps);
     });

--- a/src/components/victory-chart/victory-chart.jsx
+++ b/src/components/victory-chart/victory-chart.jsx
@@ -242,6 +242,7 @@ export default class VictoryChart extends React.Component {
 
     return childComponents.map((child, index) => {
       const transitionProps = getTransitionProps(child.props, child.type, index);
+      // const transitionProps = getTransitionProps(props, child, index);
       const style = defaults({}, child.props.style, {parent: baseStyle.parent});
       const childProps = this.getChildProps(child, props, calculatedProps);
 
@@ -259,12 +260,12 @@ export default class VictoryChart extends React.Component {
 
   render() {
     const style = this.getStyles(this.props);
-    const childComponents = this.state && this.state.nodesWillExit ?
-      ChartHelpers.getChildComponents(this.state.oldProps, defaultAxes) :
-      ChartHelpers.getChildComponents(this.props, defaultAxes);
+    const propsToRender = this.state && this.state.nodesWillExit ?
+      this.state.oldProps : this.props;
+    const childComponents = ChartHelpers.getChildComponents(propsToRender, defaultAxes);
     const group = (
       <g style={style.parent}>
-        {this.getNewChildren(this.props, childComponents, style)}
+        {this.getNewChildren(propsToRender, childComponents, style)}
       </g>
     );
     return this.props.standalone ?

--- a/src/components/victory-chart/victory-chart.jsx
+++ b/src/components/victory-chart/victory-chart.jsx
@@ -172,7 +172,6 @@ export default class VictoryChart extends React.Component {
   }
 
   getCalculatedProps(props, childComponents) {
-    // props = this.state && this.state.oldProps ? this.state.oldProps : props;
     const horizontal = childComponents.some((component) => component.props.horizontal);
     const axisComponents = {
       x: Axis.getAxisComponent(childComponents, "x"),

--- a/src/components/victory-chart/victory-chart.jsx
+++ b/src/components/victory-chart/victory-chart.jsx
@@ -15,15 +15,22 @@ const defaultAxes = {
 export default class VictoryChart extends React.Component {
   static propTypes = {
     /**
-     * The animate prop specifies props for victory-animation to use. If this prop is
+     * The animate prop specifies props for VictoryAnimation to use. If this prop is
      * given, all children defined in chart will pass the options specified in this prop to
-     * victory-animation, unless they have animation props of their own specified.
-     * Large datasets might animate slowly due to the inherent limits of svg rendering.
-     * @examples {duration: 500, onEnd: () => alert("woo!")}
+     * VictoryTransition and VictoryAnimation. Child animation props will be added for any
+     * values not provided via the animation prop for VictoryChart. The animate prop should
+     * also be used to specify enter and exit transition configurations with the `onExit`
+     * and `onEnter` namespaces respectively. VictoryChart will coodrinate transitions between all
+     * of its child components so that animation stays in sync
+     * @examples {duration: 500, onEnd: () => {}, onEnter: {duration: 500, before: () => ({y: 0})})}
      */
     animate: PropTypes.object,
     /**
-     * If you're not passing children to VictoryChart... you're probably doint it wrong.
+     * VictoryChart is a wrapper component that controls the layout and animation behaviors of its
+     * children. VictoryChart works with VictoryArea, VictoryAxis, VictoryBar, VictoryLine, and
+     * VictoryScatter. Wrapper components like VictoryGroup and VictoryStack may also be
+     * wrapped with VictoryChart. If not children are provided, VictoryChart will render a
+     * set of empty axes.
      */
     children: React.PropTypes.oneOfType([
       React.PropTypes.arrayOf(React.PropTypes.node),
@@ -60,12 +67,13 @@ export default class VictoryChart extends React.Component {
     /**
      * The events prop attaches arbitrary event handlers to the top level chart svg.
      * To attach events to individual pieces of data, use the events prop in child componenets.
-     * Event handlers are currently only called with their corresponding events.
+     * Event handlers on VictoryCharts are called with their corresponding events.
      * @examples {(evt) => alert(`x: ${evt.clientX}, y: ${evt.clientY}`)}
      */
     events: PropTypes.object,
     /**
-     * The height props specifies the height of the chart container element in pixels
+     * The height props specifies the height the svg viewBox of the chart container.
+     * This value should be given as a number of pixels
      */
     height: CustomPropTypes.nonNegative,
     /**
@@ -85,8 +93,9 @@ export default class VictoryChart extends React.Component {
     ]),
     /**
      * The scale prop determines which scales your chart should use. This prop can be
-     * given as a function, or as an object that specifies separate functions for x and y.
-     * @examples d3.time.scale(), {x: d3.scale.linear(), y: d3.scale.log()}
+     * given as a string or a function, or as an object that specifies separate scales for x and y.
+     * Supported string scales are "linear", "time", "log" and "sqrt"
+     * @examples d3.time.scale(), {x: "linear", y: "log" }
      */
     scale: PropTypes.oneOfType([
       CustomPropTypes.scale,
@@ -98,19 +107,22 @@ export default class VictoryChart extends React.Component {
     /**
      * The standalone prop determines whether the component will render a standalone svg
      * or a <g> tag that will be included in an external svg. Set standalone to false to
-     * compose VictoryChart with other components within an enclosing <svg> tag.
+     * compose VictoryChart with other components within an enclosing <svg> tag. Victory
+     * Component are responsive by default. If you need to create a fixed-size chart, set
+     * standalone to false, and wrap VictoryChart in a custom <svg>
      */
     standalone: PropTypes.bool,
     /**
-     * The style prop specifies styles for your chart. Victory Chart relies on Radium,
-     * so valid Radium style objects should work for this prop. Height, width, and
-     * padding should be specified via the height, width, and padding props, as they
-     * are used to calculate the alignment of components within chart.
-     * @examples {background: transparent, margin: 50}
+     * The style prop specifies styles for your chart. Any valid inline style properties
+     * will be applied. Height, width, and padding should be specified via the height,
+     * width, and padding props, as they are used to calculate the alignment of
+     * components within chart.
+     * @examples {border: "1px solid #ccc", margin: "2%", maxWidth: "40%"}
      */
     style: PropTypes.object,
     /**
-     * The width props specifies the width of the chart container element in pixels
+     * The width props specifies the width of the svg viewBox of the chart container
+     * This value should be given as a number of pixels
      */
     width: CustomPropTypes.nonNegative
   };

--- a/src/components/victory-chart/victory-chart.jsx
+++ b/src/components/victory-chart/victory-chart.jsx
@@ -129,11 +129,6 @@ export default class VictoryChart extends React.Component {
     standalone: true
   };
 
-  componentDidMount() {
-    const children = this.getFlatChildren(this.props);
-    this.setState({deadNodes: children.map((child) => [])});
-  }
-
   componentWillReceiveProps(nextProps) {
     if (!this.props.animate) {
       return;
@@ -267,15 +262,6 @@ export default class VictoryChart extends React.Component {
     return defaults({getTransitions, parentState}, props.animate, child.props.animate);
   }
 
-  getDeadNodes(child, index) {
-    const deadNodes = this.state && this.state.deadNodes || [];
-    if (child.type.role === "group-wrapper" || child.type.role ==="stack-wrapper") {
-      const children = this.getFlatChildren(child.props.children);
-      return deadNodes.slice(index + 1, index + children.length + 2);
-    }
-    return deadNodes[index]
-  }
-
   getNewChildren(props, childComponents, baseStyle) {
     const calculatedProps = this.getCalculatedProps(props, childComponents);
 
@@ -291,7 +277,6 @@ export default class VictoryChart extends React.Component {
         key: index,
         standalone: false,
         style,
-        deadNodes: this.getDeadNodes(child, index)
       }, childProps);
       return React.cloneElement(child, newProps);
     });

--- a/src/components/victory-chart/victory-chart.jsx
+++ b/src/components/victory-chart/victory-chart.jsx
@@ -138,7 +138,7 @@ export default class VictoryChart extends React.Component {
       nodesWillEnter,
       childrenTransitions,
       nodesShouldEnter
-    } = Transitions.getInitialTransitionState(this.props.children, nextProps.children);
+    } = Transitions.getInitialTransitionState(this.props, nextProps);
 
     this.setState({
       nodesWillExit,
@@ -148,7 +148,6 @@ export default class VictoryChart extends React.Component {
       oldProps: nodesWillExit ? this.props : null
     });
   }
-
 
   getStyles(props) {
     const styleProps = props.style && props.style.parent;
@@ -194,6 +193,7 @@ export default class VictoryChart extends React.Component {
   }
 
   getCalculatedProps(props, childComponents) {
+    // props = this.state && this.state.oldProps ? this.state.oldProps : props;
     const horizontal = childComponents.some((component) => component.props.horizontal);
     const axisComponents = {
       x: Axis.getAxisComponent(childComponents, "x"),
@@ -235,9 +235,8 @@ export default class VictoryChart extends React.Component {
     const calculatedProps = this.getCalculatedProps(props, childComponents);
 
     const getTransitionProps = Transitions.getTransitionPropsFactory(
-      childComponents,
+      props,
       this.state,
-      this.props.animate,
       (newState) => this.setState(newState)
     );
 

--- a/src/components/victory-group/victory-group.jsx
+++ b/src/components/victory-group/victory-group.jsx
@@ -196,8 +196,8 @@ export default class VictoryGroup extends React.Component {
     if (!this.props.animate || this.props.animate.parentTransitions) {
       return;
     }
-    if (this.props.animate.state){
-      this.setState(this.props.animate.state);
+    if (this.props.animate.parentState) {
+      this.setState(this.props.animate.parentState);
     } else {
       const {
         nodesWillExit,
@@ -297,7 +297,7 @@ export default class VictoryGroup extends React.Component {
 
   getAnimationProps(props, child, index) {
     let getTransitions = props.animate && props.animate.getTransitions;
-    let parentState = props.animate && props.animate.parentState || this.state;
+    const parentState = props.animate && props.animate.parentState || this.state;
     if (!getTransitions) {
       const getTransitionProps = Transitions.getTransitionPropsFactory(
         props,
@@ -325,7 +325,7 @@ export default class VictoryGroup extends React.Component {
         style,
         data,
         xOffset: child.type.role === "stack-wrapper" ? xOffset : undefined,
-        colorScale: this.getColorScale(props, child),
+        colorScale: this.getColorScale(props, child)
       }, childProps));
     });
   }

--- a/src/components/victory-group/victory-group.jsx
+++ b/src/components/victory-group/victory-group.jsx
@@ -1,9 +1,7 @@
 import assign from "lodash/assign";
-import defaults from "lodash/defaults";
 import uniq from "lodash/uniq";
-import partialRight from "lodash/partialRight";
 import React, { PropTypes } from "react";
-import { PropTypes as CustomPropTypes, Helpers, Log, Transitions } from "victory-core";
+import { PropTypes as CustomPropTypes, Helpers, Log } from "victory-core";
 import Scale from "../../helpers/scale";
 import Data from "../../helpers/data";
 import Wrapper from "../../helpers/wrapper";
@@ -193,27 +191,8 @@ export default class VictoryGroup extends React.Component {
   static getData = Wrapper.getData.bind(Wrapper);
 
   componentWillReceiveProps(nextProps) {
-    if (!this.props.animate || this.props.animate.parentTransitions) {
-      return;
-    }
-    if (this.props.animate.parentState) {
-      this.setState(this.props.animate.parentState);
-    } else {
-      const {
-        nodesWillExit,
-        nodesWillEnter,
-        childrenTransitions,
-        nodesShouldEnter
-      } = Transitions.getInitialTransitionState(this.props.children, nextProps.children);
-
-      this.setState({
-        nodesWillExit,
-        nodesWillEnter,
-        childrenTransitions,
-        nodesShouldEnter,
-        oldProps: nodesWillExit ? this.props : null
-      });
-    }
+    const setAnimationState = Wrapper.setAnimationState.bind(this);
+    setAnimationState(nextProps);
   }
 
   getCalculatedProps(props, childComponents, style) {
@@ -295,30 +274,17 @@ export default class VictoryGroup extends React.Component {
     return child.props.colorScale || props.colorScale;
   }
 
-  getAnimationProps(props, child, index) {
-    let getTransitions = props.animate && props.animate.getTransitions;
-    const parentState = props.animate && props.animate.parentState || this.state;
-    if (!getTransitions) {
-      const getTransitionProps = Transitions.getTransitionPropsFactory(
-        props,
-        this.state,
-        (newState) => this.setState(newState)
-      );
-      getTransitions = partialRight(getTransitionProps, index);
-    }
-    return defaults({getTransitions, parentState}, props.animate, child.props.animate);
-  }
-
   // the old ones were bad
   getNewChildren(props, childComponents, calculatedProps) {
     const { datasets } = calculatedProps;
     const childProps = this.getChildProps(props, calculatedProps);
+    const getAnimationProps = Wrapper.getAnimationProps.bind(this);
     return childComponents.map((child, index) => {
       const xOffset = this.getXO(props, calculatedProps, datasets, index);
       const data = datasets[index].map((datum) => assign(datum, {xOffset}));
       const style = Wrapper.getChildStyle(child, index, calculatedProps);
       return React.cloneElement(child, assign({
-        animate: this.getAnimationProps(props, child, index),
+        animate: getAnimationProps(props, child, index),
         key: index,
         labels: this.getLabels(props, datasets, index) || child.props.labels,
         labelComponent: props.labelComponent || child.props.labelComponent,

--- a/src/components/victory-group/victory-group.jsx
+++ b/src/components/victory-group/victory-group.jsx
@@ -192,11 +192,6 @@ export default class VictoryGroup extends React.Component {
   static getDomain = Wrapper.getDomainFromChildren.bind(Wrapper);
   static getData = Wrapper.getData.bind(Wrapper);
 
-  componentDidMount() {
-    const children = React.Children.toArray(this.props.children);
-    this.setState({deadNodes: this.props.deadNodes || children.map((child) => [])});
-  }
-
   componentWillReceiveProps(nextProps) {
     if (!this.props.animate || this.props.animate.parentTransitions) {
       return;
@@ -218,9 +213,6 @@ export default class VictoryGroup extends React.Component {
         nodesShouldEnter,
         oldProps: nodesWillExit ? this.props : null
       });
-    }
-    if (this.props.deadNodes) {
-      this.setState({deadNodes: this.props.deadNodes})
     }
   }
 
@@ -321,7 +313,6 @@ export default class VictoryGroup extends React.Component {
   getNewChildren(props, childComponents, calculatedProps) {
     const { datasets } = calculatedProps;
     const childProps = this.getChildProps(props, calculatedProps);
-    const deadNodes = this.state && this.state.deadNodes || [];
     return childComponents.map((child, index) => {
       const xOffset = this.getXO(props, calculatedProps, datasets, index);
       const data = datasets[index].map((datum) => assign(datum, {xOffset}));
@@ -335,7 +326,6 @@ export default class VictoryGroup extends React.Component {
         data,
         xOffset: child.type.role === "stack-wrapper" ? xOffset : undefined,
         colorScale: this.getColorScale(props, child),
-        deadNodes: deadNodes[index]
       }, childProps));
     });
   }

--- a/src/components/victory-group/victory-group.jsx
+++ b/src/components/victory-group/victory-group.jsx
@@ -192,6 +192,11 @@ export default class VictoryGroup extends React.Component {
   static getDomain = Wrapper.getDomainFromChildren.bind(Wrapper);
   static getData = Wrapper.getData.bind(Wrapper);
 
+  componentDidMount() {
+    const children = React.Children.toArray(this.props.children);
+    this.setState({deadNodes: this.props.deadNodes || children.map((child) => [])});
+  }
+
   componentWillReceiveProps(nextProps) {
     if (!this.props.animate || this.props.animate.parentTransitions) {
       return;
@@ -213,6 +218,9 @@ export default class VictoryGroup extends React.Component {
         nodesShouldEnter,
         oldProps: nodesWillExit ? this.props : null
       });
+    }
+    if (this.props.deadNodes) {
+      this.setState({deadNodes: this.props.deadNodes})
     }
   }
 
@@ -313,6 +321,7 @@ export default class VictoryGroup extends React.Component {
   getNewChildren(props, childComponents, calculatedProps) {
     const { datasets } = calculatedProps;
     const childProps = this.getChildProps(props, calculatedProps);
+    const deadNodes = this.state && this.state.deadNodes || [];
     return childComponents.map((child, index) => {
       const xOffset = this.getXO(props, calculatedProps, datasets, index);
       const data = datasets[index].map((datum) => assign(datum, {xOffset}));
@@ -325,7 +334,8 @@ export default class VictoryGroup extends React.Component {
         style,
         data,
         xOffset: child.type.role === "stack-wrapper" ? xOffset : undefined,
-        colorScale: this.getColorScale(props, child)
+        colorScale: this.getColorScale(props, child),
+        deadNodes: deadNodes[index]
       }, childProps));
     });
   }

--- a/src/components/victory-group/victory-group.jsx
+++ b/src/components/victory-group/victory-group.jsx
@@ -18,11 +18,14 @@ export default class VictoryGroup extends React.Component {
 
   static propTypes = {
     /**
-     * The animate prop specifies props for victory-animation to use. If this prop is
-     * given, all children defined in chart will pass the options specified in this prop to
-     * victory-animation, unless they have animation props of their own specified.
-     * Large datasets might animate slowly due to the inherent limits of svg rendering.
-     * @examples {duration: 500, onEnd: () => alert("woo!")}
+     * The animate prop specifies props for VictoryAnimation to use. If this prop is
+     * given, all children of VictoryGroup will pass the options specified in this prop to
+     * VictoryTransition and VictoryAnimation. Child animation props will be added for any
+     * values not provided via the animation prop for VictoryGroup. The animate prop should
+     * also be used to specify enter and exit transition configurations with the `onExit`
+     * and `onEnter` namespaces respectively. VictoryGroup will coodrinate transitions between all
+     * of its child components so that animation stays in sync
+     * @examples {duration: 500, onEnd: () => {}, onEnter: {duration: 500, before: () => ({y: 0})})}
      */
     animate: PropTypes.object,
     /**
@@ -42,7 +45,9 @@ export default class VictoryGroup extends React.Component {
       })
     ]),
     /**
-     * If you're not passing children to VictoryGroup... you're probably doing it wrong.
+     * VictoryGroup is a wrapper component that controls the layout and animation behaviors of its
+     * children. VictoryGroup creates a grouped layout for  VictoryArea, or VictoryBar components.
+     * VictoryGroup  can also group components wrapped in VictoryStack
      */
     children: React.PropTypes.oneOfType([
       React.PropTypes.arrayOf(React.PropTypes.node),
@@ -90,7 +95,8 @@ export default class VictoryGroup extends React.Component {
       CustomPropTypes.nonNegative
     ]),
     /**
-     * The height props specifies the height of the chart container element in pixels
+     * The height props specifies the height the svg viewBox of the chart container.
+     * This value should be given as a number of pixels
      */
     height: CustomPropTypes.nonNegative,
     /**
@@ -173,7 +179,8 @@ export default class VictoryGroup extends React.Component {
       labels: PropTypes.object
     }),
     /**
-     * The width props specifies the width of the chart container element in pixels
+     * The width props specifies the width of the svg viewBox of the chart container
+     * This value should be given as a number of pixels
      */
     width: CustomPropTypes.nonNegative
   };

--- a/src/components/victory-line/victory-line.jsx
+++ b/src/components/victory-line/victory-line.jsx
@@ -31,8 +31,7 @@ export default class VictoryLine extends React.Component {
   static defaultTransitions = {
     onExit: {
       duration: 500,
-      before: (datum) => ({ y: datum.y}),
-      after: () => ({ y: null })
+      before: () => ({ y: null })
     },
     onEnter: {
       duration: 500,
@@ -43,10 +42,10 @@ export default class VictoryLine extends React.Component {
 
   static propTypes = {
     /**
-     * The animate prop specifies props for victory-animation to use. It this prop is
-     * not given, the line will not tween between changing data / style props.
-     * Large datasets might animate slowly due to the inherent limits of svg rendering.
-     * @examples {duration: 500, onEnd: () => alert("done!")}
+     * The animate prop specifies props for VictoryAnimation to use. The animate prop should
+     * also be used to specify enter and exit transition configurations with the `onExit`
+     * and `onEnter` namespaces respectively.
+     * @examples {duration: 500, onEnd: () => {}, onEnter: {duration: 500, before: () => ({y: 0})})}
      */
     animate: PropTypes.object,
     /**
@@ -119,7 +118,8 @@ export default class VictoryLine extends React.Component {
       parent: PropTypes.object
     }),
     /**
-     * The height props specifies the height of the chart container element in pixels
+     * The height props specifies the height the svg viewBox of the chart container.
+     * This value should be given as a number of pixels
      */
     height: CustomPropTypes.nonNegative,
     /**
@@ -198,10 +198,11 @@ export default class VictoryLine extends React.Component {
      */
     standalone: PropTypes.bool,
     /**
-     * The style prop specifies styles for your chart. VictoryLine relies on Radium,
-     * so valid Radium style objects should work for this prop, however height, width, and margin
-     * are used to calculate range, and need to be expressed as a number of pixels
-     * @examples {data: {stroke: "red"}, labels: {fontSize: 14}}
+     * The style prop specifies styles for your VictoryLine. Any valid inline style properties
+     * will be applied. Height, width, and padding should be specified via the height,
+     * width, and padding props, as they are used to calculate the alignment of
+     * components within chart.
+     * @examples {data: {stroke: "red"}, labels: {fontSize: 12}}
      */
     style: PropTypes.shape({
       parent: PropTypes.object,
@@ -209,7 +210,8 @@ export default class VictoryLine extends React.Component {
       labels: PropTypes.object
     }),
     /**
-     * The width props specifies the width of the chart container element in pixels
+     * The width props specifies the width of the svg viewBox of the chart container
+     * This value should be given as a number of pixels
      */
     width: CustomPropTypes.nonNegative,
     /**

--- a/src/components/victory-line/victory-line.jsx
+++ b/src/components/victory-line/victory-line.jsx
@@ -28,6 +28,20 @@ const defaultStyles = {
 
 export default class VictoryLine extends React.Component {
   static role = "line";
+
+  static defaultTransitions = {
+    onExit: {
+      duration: 600,
+      before: (datum) => ({ opacity: "opacity" in datum ? datum.opacity : 1 }),
+      after: () => ({ opacity: 0 })
+    },
+    onEnter: {
+      duration: 600,
+      before: () => ({ opacity: 0 }),
+      after: (datum) => ({ opacity: "opacity" in datum ? datum.opacity : 1 })
+    }
+  };
+
   static propTypes = {
     /**
      * The animate prop specifies props for victory-animation to use. It this prop is

--- a/src/components/victory-line/victory-line.jsx
+++ b/src/components/victory-line/victory-line.jsx
@@ -1,5 +1,4 @@
 import sortBy from "lodash/sortBy";
-import pick from "lodash/pick";
 import defaults from "lodash/defaults";
 import React, { PropTypes } from "react";
 import LineSegment from "./line-segment";

--- a/src/components/victory-line/victory-line.jsx
+++ b/src/components/victory-line/victory-line.jsx
@@ -7,7 +7,7 @@ import LineLabel from "./line-label";
 import Scale from "../../helpers/scale";
 import Domain from "../../helpers/domain";
 import Data from "../../helpers/data";
-import { PropTypes as CustomPropTypes, Helpers, VictoryAnimation } from "victory-core";
+import { PropTypes as CustomPropTypes, Helpers, VictoryTransition } from "victory-core";
 
 const defaultStyles = {
   data: {
@@ -32,13 +32,13 @@ export default class VictoryLine extends React.Component {
   static defaultTransitions = {
     onExit: {
       duration: 600,
-      before: (datum) => ({ opacity: "opacity" in datum ? datum.opacity : 1 }),
+      before: (datum) => ({ opacity: datum.opacity || 1 }),
       after: () => ({ opacity: 0 })
     },
     onEnter: {
       duration: 600,
       before: () => ({ opacity: 0 }),
-      after: (datum) => ({ opacity: "opacity" in datum ? datum.opacity : 1 })
+      after: (datum) => ({ opacity: datum.opacity || 1 })
     }
   };
 
@@ -379,11 +379,10 @@ export default class VictoryLine extends React.Component {
       const whitelist = [
         "data", "domain", "height", "padding", "samples", "style", "width", "x", "y"
       ];
-      const animateData = pick(this.props, whitelist);
       return (
-        <VictoryAnimation {...this.props.animate} data={animateData}>
-          {(props) => <VictoryLine {...this.props} {...props} animate={null}/>}
-        </VictoryAnimation>
+        <VictoryTransition animate={this.props.animate} animationWhitelist={whitelist}>
+          <VictoryLine {...this.props}/>
+        </VictoryTransition>
       );
     }
     const style = Helpers.getStyles(

--- a/src/components/victory-line/victory-line.jsx
+++ b/src/components/victory-line/victory-line.jsx
@@ -30,14 +30,14 @@ export default class VictoryLine extends React.Component {
 
   static defaultTransitions = {
     onExit: {
-      duration: 600,
-      before: (datum) => ({ opacity: datum.opacity || 1 }),
-      after: () => ({ opacity: 0 })
+      duration: 500,
+      before: (datum) => ({ y: datum.y}),
+      after: () => ({ y: null })
     },
     onEnter: {
-      duration: 600,
-      before: () => ({ opacity: 0 }),
-      after: (datum) => ({ opacity: datum.opacity || 1 })
+      duration: 500,
+      before: () => ({ y: null }),
+      after: (datum) => ({ y: datum.y})
     }
   };
 

--- a/src/components/victory-scatter/point-label.jsx
+++ b/src/components/victory-scatter/point-label.jsx
@@ -9,8 +9,7 @@ export default class PointLabel extends React.Component {
     events: PropTypes.object,
     labelComponent: React.PropTypes.element,
     style: PropTypes.object,
-    x: React.PropTypes.number,
-    y: React.PropTypes.number
+    position: PropTypes.object
   };
 
   renderLabel(props) {
@@ -26,8 +25,8 @@ export default class PointLabel extends React.Component {
       defaults({}, component.props.events, props.events) : props.events;
     const events = Helpers.getPartialEvents(baseEvents, props.index, props);
     const labelProps = {
-      x: component && component.props.x || props.x,
-      y: component && component.props.y || props.y - labelStyle.padding,
+      x: component && component.props.x || props.position.x,
+      y: component && component.props.y || props.position.y - labelStyle.padding,
       dy: component && component.props.dy,
       datum: props.datum,
       text: labelText,

--- a/src/components/victory-scatter/victory-scatter.jsx
+++ b/src/components/victory-scatter/victory-scatter.jsx
@@ -34,8 +34,7 @@ export default class VictoryScatter extends React.Component {
   static defaultTransitions = {
     onExit: {
       duration: 600,
-      before: (datum) => ({ opacity: datum.opacity || 1 }),
-      after: () => ({ opacity: 0 })
+      before: () => ({ opacity: 0 })
     },
     onEnter: {
       duration: 600,
@@ -46,10 +45,10 @@ export default class VictoryScatter extends React.Component {
 
   static propTypes = {
     /**
-     * The animate prop specifies props for victory-animation to use. It this prop is
-     * not given, the scatter plot will not tween between changing data / style props.
-     * Large datasets might animate slowly due to the inherent limits of svg rendering.
-     * @examples {delay: 5, duration: 500, onEnd: () => alert("woo!")}
+     * The animate prop specifies props for VictoryAnimation to use. The animate prop should
+     * also be used to specify enter and exit transition configurations with the `onExit`
+     * and `onEnter` namespaces respectively.
+     * @examples {duration: 500, onEnd: () => {}, onEnter: {duration: 500, before: () => ({y: 0})})}
      */
     animate: PropTypes.object,
     /**
@@ -82,6 +81,18 @@ export default class VictoryScatter extends React.Component {
      */
 
     data: PropTypes.array,
+    /**
+     * The dataComponent prop takes an entire, HTML-complete data component which will be used to
+     * create points for each datum in the scatter plot. The new element created from the passed
+     * dataComponent will have the property datum set by the scatter for the point it renders;
+     * properties position (x, y), size and symbol are calculated by the scatter for the datum;
+     * a key and index property set corresponding to the location of the datum in the data
+     * provided to the scatter; style calculated by the scatter based on the scatter's
+     * styles and the datum; and all the remaining properties from the scatter's data
+     * at the index of the datum. If a dataComponent is not provided, VictoryScatter's
+     * Point component will be used.
+     */
+    dataComponent: PropTypes.element,
     /**
      * The domain prop describes the range of values your chart will include. This prop can be
      * given as a array of the minimum and maximum expected values for your chart,
@@ -118,7 +129,8 @@ export default class VictoryScatter extends React.Component {
       parent: PropTypes.object
     }),
     /**
-     * The height props specifies the height of the chart container element in pixels
+     * The height props specifies the height the svg viewBox of the chart container.
+     * This value should be given as a number of pixels
      */
     height: CustomPropTypes.nonNegative,
     /**
@@ -151,18 +163,6 @@ export default class VictoryScatter extends React.Component {
       })
     ]),
     /**
-     * The dataComponent prop takes an entire, HTML-complete data component which will be used to
-     * create points for each datum in the scatter plot. The new element created from the passed
-     * dataComponent will have the property datum set by the scatter for the point it renders;
-     * properties position (x, y), size and symbol are calculated by the scatter for the datum;
-     * a key and index property set corresponding to the location of the datum in the data
-     * provided to the scatter; style calculated by the scatter based on the scatter's
-     * styles and the datum; and all the remaining properties from the scatter's data
-     * at the index of the datum. If a dataComponent is not provided, VictoryScatter's
-     * Point component will be used.
-     */
-    dataComponent: PropTypes.element,
-    /**
      * The samples prop specifies how many individual points to plot when plotting
      * y as a function of x. Samples is ignored if x props are provided instead.
      */
@@ -194,11 +194,11 @@ export default class VictoryScatter extends React.Component {
      */
     standalone: PropTypes.bool,
     /**
-     * The style prop specifies styles for your scatter plot. VictoryScatter relies on Radium,
-     * so valid Radium style objects should work for this prop. Height, width, and
-     * padding should be specified via the height, width, and padding props, as they
-     * are used to calculate the alignment of components within chart.
-     * @examples {parent: {margin: 50}, data: {fill: "red"}, labels: {padding: 20}}
+     * The style prop specifies styles for your VictoryScatter. Any valid inline style properties
+     * will be applied. Height, width, and padding should be specified via the height,
+     * width, and padding props, as they are used to calculate the alignment of
+     * components within chart.
+     * @examples {data: {fill: "red"}, labels: {fontSize: 12}}
      */
     style: PropTypes.shape({
       parent: PropTypes.object,
@@ -215,7 +215,8 @@ export default class VictoryScatter extends React.Component {
       PropTypes.func
     ]),
     /**
-     * The width props specifies the width of the chart container element in pixels
+     * The width props specifies the width of the svg viewBox of the chart container
+     * This value should be given as a number of pixels
      */
     width: CustomPropTypes.nonNegative,
     /**

--- a/src/components/victory-scatter/victory-scatter.jsx
+++ b/src/components/victory-scatter/victory-scatter.jsx
@@ -377,7 +377,7 @@ export default class VictoryScatter extends React.Component {
     const z = props.bubbleProperty || "z";
     const calculatedProps = {data, scale, style, z};
     return data.map((datum, index) => {
-        return this.renderPoint(datum, index, calculatedProps);
+      return this.renderPoint(datum, index, calculatedProps);
     });
   }
 

--- a/src/components/victory-scatter/victory-scatter.jsx
+++ b/src/components/victory-scatter/victory-scatter.jsx
@@ -377,9 +377,7 @@ export default class VictoryScatter extends React.Component {
     const z = props.bubbleProperty || "z";
     const calculatedProps = {data, scale, style, z};
     return data.map((datum, index) => {
-      const deadNodes = this.props.deadNodes || [];
-      return (deadNodes.indexOf(`${index}`) !== -1) ?
-        null : this.renderPoint(datum, index, calculatedProps);
+        return this.renderPoint(datum, index, calculatedProps);
     });
   }
 
@@ -397,7 +395,7 @@ export default class VictoryScatter extends React.Component {
       ];
       return (
         <VictoryTransition animate={this.props.animate} animationWhitelist={whitelist}>
-          <VictoryScatter {...this.props} deadNodes={this.props.deadNodes}/>
+          <VictoryScatter {...this.props}/>
         </VictoryTransition>
       );
     }

--- a/src/components/victory-scatter/victory-scatter.jsx
+++ b/src/components/victory-scatter/victory-scatter.jsx
@@ -7,7 +7,7 @@ import PointLabel from "./point-label";
 import Scale from "../../helpers/scale";
 import Domain from "../../helpers/domain";
 import Data from "../../helpers/data";
-import { PropTypes as CustomPropTypes, Helpers, VictoryAnimation } from "victory-core";
+import { PropTypes as CustomPropTypes, Helpers, VictoryTransition } from "victory-core";
 import ScatterHelpers from "./helper-methods";
 
 const defaultStyles = {
@@ -33,13 +33,13 @@ export default class VictoryScatter extends React.Component {
   static defaultTransitions = {
     onExit: {
       duration: 600,
-      before: (datum) => ({ opacity: "opacity" in datum ? datum.opacity : 1 }),
+      before: (datum) => ({ opacity: datum.opacity || 1 }),
       after: () => ({ opacity: 0 })
     },
     onEnter: {
       duration: 600,
       before: () => ({ opacity: 0 }),
-      after: (datum) => ({ opacity: "opacity" in datum ? datum.opacity : 1 })
+      after: (datum) => ({ opacity: datum.opacity || 1 })
     }
   };
 
@@ -389,15 +389,14 @@ export default class VictoryScatter extends React.Component {
       // Do less work by having `VictoryAnimation` tween only values that
       // make sense to tween. In the future, allow customization of animated
       // prop whitelist/blacklist?
-      const animateData = pick(this.props, [
+      const whitelist = [
         "data", "domain", "height", "maxBubbleSize", "padding", "samples", "size",
         "style", "width", "x", "y"
-      ]);
-
+      ];
       return (
-        <VictoryAnimation {...this.props.animate} data={animateData}>
-          {(props) => <VictoryScatter {...this.props} {...props} animate={null}/>}
-        </VictoryAnimation>
+        <VictoryTransition animate={this.props.animate} animationWhitelist={whitelist}>
+          <VictoryScatter {...this.props}/>
+        </VictoryTransition>
       );
     }
     const style = Helpers.getStyles(

--- a/src/components/victory-scatter/victory-scatter.jsx
+++ b/src/components/victory-scatter/victory-scatter.jsx
@@ -377,7 +377,9 @@ export default class VictoryScatter extends React.Component {
     const z = props.bubbleProperty || "z";
     const calculatedProps = {data, scale, style, z};
     return data.map((datum, index) => {
-      return this.renderPoint(datum, index, calculatedProps);
+      const deadNodes = this.props.deadNodes || [];
+      return (deadNodes.indexOf(`${index}`) !== -1) ?
+        null : this.renderPoint(datum, index, calculatedProps);
     });
   }
 
@@ -395,10 +397,11 @@ export default class VictoryScatter extends React.Component {
       ];
       return (
         <VictoryTransition animate={this.props.animate} animationWhitelist={whitelist}>
-          <VictoryScatter {...this.props}/>
+          <VictoryScatter {...this.props} deadNodes={this.props.deadNodes}/>
         </VictoryTransition>
       );
     }
+
     const style = Helpers.getStyles(
       this.props.style, defaultStyles, this.props.height, this.props.width);
     const group = <g style={style.parent}>{this.renderData(this.props, style)}</g>;

--- a/src/components/victory-scatter/victory-scatter.jsx
+++ b/src/components/victory-scatter/victory-scatter.jsx
@@ -41,7 +41,7 @@ export default class VictoryScatter extends React.Component {
       before: () => ({ opacity: 0 }),
       after: (datum) => ({ opacity: "opacity" in datum ? datum.opacity : 1 })
     }
-  }
+  };
 
   static propTypes = {
     /**

--- a/src/components/victory-stack/victory-stack.jsx
+++ b/src/components/victory-stack/victory-stack.jsx
@@ -1,7 +1,9 @@
 import assign from "lodash/assign";
+import defaults from "lodash/defaults";
 import uniq from "lodash/uniq";
+import partialRight from "lodash/partialRight";
 import React, { PropTypes } from "react";
-import { PropTypes as CustomPropTypes, Helpers, Log } from "victory-core";
+import { PropTypes as CustomPropTypes, Helpers, Log, Transitions } from "victory-core";
 import Scale from "../../helpers/scale";
 import Data from "../../helpers/data";
 import Wrapper from "../../helpers/wrapper";
@@ -189,6 +191,30 @@ export default class VictoryStack extends React.Component {
   static getDomain = Wrapper.getStackedDomain.bind(Wrapper);
   static getData = Wrapper.getData.bind(Wrapper);
 
+  componentWillReceiveProps(nextProps) {
+    if (!this.props.animate || this.props.animate.parentTransitions) {
+      return;
+    }
+    if (this.props.animate.state){
+      this.setState(this.props.animate.state);
+    } else {
+      const {
+        nodesWillExit,
+        nodesWillEnter,
+        childrenTransitions,
+        nodesShouldEnter
+      } = Transitions.getInitialTransitionState(this.props.children, nextProps.children);
+
+      this.setState({
+        nodesWillExit,
+        nodesWillEnter,
+        childrenTransitions,
+        nodesShouldEnter,
+        oldProps: nodesWillExit ? this.props : null
+      });
+    }
+  }
+
   getCalculatedProps(props, childComponents, style) {
     const horizontal = props.horizontal || props.children.every(
       (component) => component.props.horizontal
@@ -220,16 +246,16 @@ export default class VictoryStack extends React.Component {
     return {datasets, categories, range, domain, horizontal, scale, style, colorScale};
   }
 
-  addLayoutData(datasets, index, calculatedProps) {
+  addLayoutData(props, calculatedProps, datasets, index,) { // eslint-disable-line max-params
     return datasets[index].map((datum) => {
       return assign(datum, {
         yOffset: Wrapper.getY0(datum, index, calculatedProps),
-        xOffset: this.props.xOffset
+        xOffset: props.xOffset
       });
     });
   }
 
-  getLabels(index, props, datasets) {
+  getLabels(props, datasets, index) {
     if (!props.labels) {
       return undefined;
     }
@@ -250,17 +276,31 @@ export default class VictoryStack extends React.Component {
     };
   }
 
+  getAnimationProps(props, child, index) {
+    let getTransitions = props.animate && props.animate.getTransitions;
+    let parentState = props.animate && props.animate.parentState || this.state;
+    if (!getTransitions) {
+      const getTransitionProps = Transitions.getTransitionPropsFactory(
+        props,
+        this.state,
+        (newState) => this.setState(newState)
+      );
+      getTransitions = partialRight(getTransitionProps, index);
+    }
+    return defaults({getTransitions, parentState}, props.animate, child.props.animate);
+  }
+
   // the old ones were bad
   getNewChildren(props, childComponents, calculatedProps) {
     const { datasets } = calculatedProps;
     const childProps = this.getChildProps(props, calculatedProps);
     return childComponents.map((child, index) => {
-      const data = this.addLayoutData(datasets, index, calculatedProps);
+      const data = this.addLayoutData(props, calculatedProps, datasets, index);
       const style = Wrapper.getChildStyle(child, index, calculatedProps);
       return React.cloneElement(child, assign({
-        animate: child.props.animate || props.animate,
+        animate: this.getAnimationProps(props, child, index),
         key: index,
-        labels: this.getLabels(index, props, datasets) || child.props.labels,
+        labels: this.getLabels(props, datasets, index) || child.props.labels,
         labelComponent: props.labelComponent || child.props.labelComponent,
         style,
         data
@@ -269,9 +309,11 @@ export default class VictoryStack extends React.Component {
   }
 
   render() {
+    const props = this.state && this.state.nodesWillExit ?
+      this.state.oldProps : this.props;
     const style = Helpers.getStyles(
-      this.props.style, defaultStyles, this.props.height, this.props.width);
-    const childComponents = React.Children.toArray(this.props.children);
+      props.style, defaultStyles, props.height, props.width);
+    const childComponents = React.Children.toArray(props.children);
     const types = uniq(childComponents.map((child) => child.type.role));
     if (types.length > 1) {
       Log.warn("Only components of the same type can be stacked");
@@ -279,12 +321,12 @@ export default class VictoryStack extends React.Component {
     if (types.some((type) => type === "group-wrapper")) {
       Log.warn("It is not possible to stack groups.");
     }
-    const calculatedProps = this.getCalculatedProps(this.props, childComponents, style);
+    const calculatedProps = this.getCalculatedProps(props, childComponents, style);
     const group = (
       <g style={style.parent}>
-        {this.getNewChildren(this.props, childComponents, calculatedProps)}
+        {this.getNewChildren(props, childComponents, calculatedProps)}
       </g>
     );
-    return this.props.standalone ? <svg style={style.parent}>{group}</svg> : group;
+    return props.standalone ? <svg style={style.parent}>{group}</svg> : group;
   }
 }

--- a/src/components/victory-stack/victory-stack.jsx
+++ b/src/components/victory-stack/victory-stack.jsx
@@ -195,11 +195,11 @@ export default class VictoryStack extends React.Component {
     if (!this.props.animate || this.props.animate.parentTransitions) {
       return;
     }
-    if (this.props.animate.state){
-      this.setState(this.props.animate.state);
+    if (this.props.animate.parentState) {
+      this.setState(this.props.animate.parentState);
     } else {
-      const oldChildren = this.getFlatChildren(this.props)
-      const nextChildren = this.getFlatChildren(nextProps)
+      const oldChildren = Wrapper.flattenChildren(this.props);
+      const nextChildren = Wrapper.flattenChildren(nextProps);
 
       const {
         nodesWillExit,
@@ -249,7 +249,7 @@ export default class VictoryStack extends React.Component {
     return {datasets, categories, range, domain, horizontal, scale, style, colorScale};
   }
 
-  addLayoutData(props, calculatedProps, datasets, index,) { // eslint-disable-line max-params
+  addLayoutData(props, calculatedProps, datasets, index) { // eslint-disable-line max-params
     return datasets[index].map((datum) => {
       return assign(datum, {
         yOffset: Wrapper.getY0(datum, index, calculatedProps),
@@ -281,7 +281,7 @@ export default class VictoryStack extends React.Component {
 
   getAnimationProps(props, child, index) {
     let getTransitions = props.animate && props.animate.getTransitions;
-    let parentState = props.animate && props.animate.parentState || this.state;
+    const parentState = props.animate && props.animate.parentState || this.state;
     if (!getTransitions) {
       const getTransitionProps = Transitions.getTransitionPropsFactory(
         props,

--- a/src/components/victory-stack/victory-stack.jsx
+++ b/src/components/victory-stack/victory-stack.jsx
@@ -18,11 +18,14 @@ export default class VictoryStack extends React.Component {
 
   static propTypes = {
     /**
-     * The animate prop specifies props for victory-animation to use. If this prop is
-     * given, all children defined in chart will pass the options specified in this prop to
-     * victory-animation, unless they have animation props of their own specified.
-     * Large datasets might animate slowly due to the inherent limits of svg rendering.
-     * @examples {duration: 500, onEnd: () => alert("woo!")}
+     * The animate prop specifies props for VictoryAnimation to use. If this prop is
+     * given, all children of VictoryStack will pass the options specified in this prop to
+     * VictoryTransition and VictoryAnimation. Child animation props will be added for any
+     * values not provided via the animation prop for VictoryStack. The animate prop should
+     * also be used to specify enter and exit transition configurations with the `onExit`
+     * and `onEnter` namespaces respectively. VictoryStack will coodrinate transitions between all
+     * of its child components so that animation stays in sync
+     * @examples {duration: 500, onEnd: () => {}, onEnter: {duration: 500, before: () => ({y: 0})})}
      */
     animate: PropTypes.object,
     /**
@@ -42,7 +45,8 @@ export default class VictoryStack extends React.Component {
       })
     ]),
     /**
-     * If you're not passing children to VictoryStack... you're probably doing it wrong.
+     * VictoryStack is a wrapper component that controls the layout and animation behaviors of its
+     * children. VictoryStack creates a stacked layout for  VictoryArea, or VictoryBar components.
      */
     children: PropTypes.oneOfType([
       PropTypes.arrayOf(PropTypes.node),
@@ -91,7 +95,8 @@ export default class VictoryStack extends React.Component {
       CustomPropTypes.nonNegative
     ]),
     /**
-     * The height props specifies the height of the chart container element in pixels
+     * The height props specifies the height the svg viewBox of the chart container.
+     * This value should be given as a number of pixels
      */
     height: CustomPropTypes.nonNegative,
     /**
@@ -168,7 +173,8 @@ export default class VictoryStack extends React.Component {
       labels: PropTypes.object
     }),
     /**
-     * The width props specifies the width of the chart container element in pixels
+     * The width props specifies the width of the svg viewBox of the chart container
+     * This value should be given as a number of pixels
      */
     width: CustomPropTypes.nonNegative,
     /**

--- a/src/components/victory-stack/victory-stack.jsx
+++ b/src/components/victory-stack/victory-stack.jsx
@@ -191,6 +191,11 @@ export default class VictoryStack extends React.Component {
   static getDomain = Wrapper.getStackedDomain.bind(Wrapper);
   static getData = Wrapper.getData.bind(Wrapper);
 
+  componentDidMount() {
+    const children = this.getFlatChildren(this.props);
+    this.setState({deadNodes: this.props.deadNodes || children.map((child) => [])});
+  }
+
   componentWillReceiveProps(nextProps) {
     if (!this.props.animate || this.props.animate.parentTransitions) {
       return;
@@ -198,12 +203,15 @@ export default class VictoryStack extends React.Component {
     if (this.props.animate.state){
       this.setState(this.props.animate.state);
     } else {
+      const oldChildren = this.getFlatChildren(this.props)
+      const nextChildren = this.getFlatChildren(nextProps)
+
       const {
         nodesWillExit,
         nodesWillEnter,
         childrenTransitions,
         nodesShouldEnter
-      } = Transitions.getInitialTransitionState(this.props.children, nextProps.children);
+      } = Transitions.getInitialTransitionState(oldChildren, nextChildren);
 
       this.setState({
         nodesWillExit,
@@ -213,6 +221,23 @@ export default class VictoryStack extends React.Component {
         oldProps: nodesWillExit ? this.props : null
       });
     }
+    if (this.props.deadNodes) {
+      this.setState({deadNodes: this.props.deadNodes})
+    }
+  }
+
+  getFlatChildren(props) {
+    const allFlat = ([first, ...rest]) => {
+      if (typeof first === "undefined") {
+        return [];
+      } else if (first.props.children) {
+        return [...allFlat(React.Children.toArray(first.props.children)), ...allFlat(rest)];
+      } else {
+        return [first, ...allFlat(rest)];
+      }
+    }
+    const children = React.Children.toArray(props.children);
+    return allFlat(children);
   }
 
   getCalculatedProps(props, childComponents, style) {
@@ -290,10 +315,20 @@ export default class VictoryStack extends React.Component {
     return defaults({getTransitions, parentState}, props.animate, child.props.animate);
   }
 
+  getDeadNodes(child, index) {
+    const deadNodes = this.state && this.state.deadNodes || [];
+    // if (child.type.role === "group-wrapper") {
+    //   const children = this.getFlatChildren(child.props.children);
+    //   return deadNodes.slice(index + 1, index + children.length + 2);
+    // }
+    return deadNodes[index]
+  }
+
   // the old ones were bad
   getNewChildren(props, childComponents, calculatedProps) {
     const { datasets } = calculatedProps;
     const childProps = this.getChildProps(props, calculatedProps);
+    const deadNodes = this.state && this.state.deadNodes || [];
     return childComponents.map((child, index) => {
       const data = this.addLayoutData(props, calculatedProps, datasets, index);
       const style = Wrapper.getChildStyle(child, index, calculatedProps);
@@ -303,7 +338,8 @@ export default class VictoryStack extends React.Component {
         labels: this.getLabels(props, datasets, index) || child.props.labels,
         labelComponent: props.labelComponent || child.props.labelComponent,
         style,
-        data
+        data,
+        deadNodes: this.getDeadNodes(child, index)
       }, childProps));
     });
   }

--- a/src/components/victory-stack/victory-stack.jsx
+++ b/src/components/victory-stack/victory-stack.jsx
@@ -191,11 +191,6 @@ export default class VictoryStack extends React.Component {
   static getDomain = Wrapper.getStackedDomain.bind(Wrapper);
   static getData = Wrapper.getData.bind(Wrapper);
 
-  componentDidMount() {
-    const children = this.getFlatChildren(this.props);
-    this.setState({deadNodes: this.props.deadNodes || children.map((child) => [])});
-  }
-
   componentWillReceiveProps(nextProps) {
     if (!this.props.animate || this.props.animate.parentTransitions) {
       return;
@@ -221,23 +216,6 @@ export default class VictoryStack extends React.Component {
         oldProps: nodesWillExit ? this.props : null
       });
     }
-    if (this.props.deadNodes) {
-      this.setState({deadNodes: this.props.deadNodes})
-    }
-  }
-
-  getFlatChildren(props) {
-    const allFlat = ([first, ...rest]) => {
-      if (typeof first === "undefined") {
-        return [];
-      } else if (first.props.children) {
-        return [...allFlat(React.Children.toArray(first.props.children)), ...allFlat(rest)];
-      } else {
-        return [first, ...allFlat(rest)];
-      }
-    }
-    const children = React.Children.toArray(props.children);
-    return allFlat(children);
   }
 
   getCalculatedProps(props, childComponents, style) {
@@ -315,20 +293,10 @@ export default class VictoryStack extends React.Component {
     return defaults({getTransitions, parentState}, props.animate, child.props.animate);
   }
 
-  getDeadNodes(child, index) {
-    const deadNodes = this.state && this.state.deadNodes || [];
-    // if (child.type.role === "group-wrapper") {
-    //   const children = this.getFlatChildren(child.props.children);
-    //   return deadNodes.slice(index + 1, index + children.length + 2);
-    // }
-    return deadNodes[index]
-  }
-
   // the old ones were bad
   getNewChildren(props, childComponents, calculatedProps) {
     const { datasets } = calculatedProps;
     const childProps = this.getChildProps(props, calculatedProps);
-    const deadNodes = this.state && this.state.deadNodes || [];
     return childComponents.map((child, index) => {
       const data = this.addLayoutData(props, calculatedProps, datasets, index);
       const style = Wrapper.getChildStyle(child, index, calculatedProps);
@@ -338,8 +306,7 @@ export default class VictoryStack extends React.Component {
         labels: this.getLabels(props, datasets, index) || child.props.labels,
         labelComponent: props.labelComponent || child.props.labelComponent,
         style,
-        data,
-        deadNodes: this.getDeadNodes(child, index)
+        data
       }, childProps));
     });
   }

--- a/src/helpers/wrapper.js
+++ b/src/helpers/wrapper.js
@@ -16,6 +16,20 @@ export default {
     });
   },
 
+  flattenChildren(props) {
+    const allFlat = ([first, ...rest]) => {
+      if (typeof first === "undefined") {
+        return [];
+      } else if (first.props.children) {
+        return [...allFlat(React.Children.toArray(first.props.children)), ...allFlat(rest)];
+      } else {
+        return [first, ...allFlat(rest)];
+      }
+    };
+    const children = React.Children.toArray(props.children);
+    return allFlat(children);
+  },
+
   getDomainFromChildren(props, axis) {
     const childComponents = React.Children.toArray(props.children);
     let domain;

--- a/src/helpers/wrapper.js
+++ b/src/helpers/wrapper.js
@@ -1,10 +1,11 @@
 import defaults from "lodash/defaults";
 import uniq from "lodash/uniq";
 import flatten from "lodash/flatten";
+import partialRight from "lodash/partialRight";
 import React from "react";
 import Data from "./data";
 import Domain from "./domain";
-import { Style } from "victory-core";
+import { Style, Transitions, Collection } from "victory-core";
 
 
 export default {
@@ -16,18 +17,52 @@ export default {
     });
   },
 
-  flattenChildren(props) {
-    const allFlat = ([first, ...rest]) => {
-      if (typeof first === "undefined") {
-        return [];
-      } else if (first.props.children) {
-        return [...allFlat(React.Children.toArray(first.props.children)), ...allFlat(rest)];
-      } else {
-        return [first, ...allFlat(rest)];
-      }
+  setAnimationState(nextProps) {
+    if (!this.props.animate) {
+      return;
+    }
+    if (this.props.animate.parentState) {
+      this.setState(this.props.animate.parentState);
+    } else {
+      const oldChildren = React.Children.toArray(this.props.children);
+      const nextChildren = React.Children.toArray(nextProps.children);
+      const {
+        nodesWillExit,
+        nodesWillEnter,
+        childrenTransitions,
+        nodesShouldEnter
+      } = Transitions.getInitialTransitionState(oldChildren, nextChildren);
+
+      this.setState({
+        nodesWillExit,
+        nodesWillEnter,
+        childrenTransitions,
+        nodesShouldEnter,
+        oldProps: nodesWillExit ? this.props : null
+      });
+    }
+  },
+
+  getAnimationProps(props, child, index) {
+    const getFilteredState = () => {
+      let childrenTransitions = this.state && this.state.childrenTransitions;
+      childrenTransitions = Collection.isArrayOfArrays(childrenTransitions) ?
+        childrenTransitions[index] : childrenTransitions;
+      return defaults({childrenTransitions}, this.state);
     };
-    const children = React.Children.toArray(props.children);
-    return allFlat(children);
+
+    let getTransitions = props.animate && props.animate.getTransitions;
+    const state = getFilteredState();
+    const parentState = props.animate && props.animate.parentState || state;
+    if (!getTransitions) {
+      const getTransitionProps = Transitions.getTransitionPropsFactory(
+        props,
+        state,
+        (newState) => this.setState(newState)
+      );
+      getTransitions = partialRight(getTransitionProps, index);
+    }
+    return defaults({getTransitions, parentState}, props.animate, child.props.animate);
   },
 
   getDomainFromChildren(props, axis) {


### PR DESCRIPTION
Adds default transitions for all chart types
works with https://github.com/FormidableLabs/victory-core/pull/43

TODOS
- [x] fix chart demos
- [x] support transitions in stand alone components (i.e. VictoryBar used outside of chart)
- [x] support and coordinate transitions for groups and stacks
- [x] fix exit transition bug
