### PR TITLE
Fix victory bar transitions

### DIFF
--- a/demo/components/victory-chart-demo.jsx
+++ b/demo/components/victory-chart-demo.jsx
@@ -19,7 +19,8 @@ class App extends React.Component {
       lineData: this.getData(),
       numericBarData: this.getNumericBarData(),
       barData: this.getBarData(),
-      lineStyle: this.getStyles()
+      lineStyle: this.getStyles(),
+      barTransitionData: this.getBarTransitionData()
     };
   }
 
@@ -70,6 +71,13 @@ class App extends React.Component {
     });
   }
 
+  getBarTransitionData() {
+    const bars = _.random(6, 10);
+    return _.map(_.range(bars), (bar) => {
+      return { x: bar, y: _.random(2, 10) };
+    });
+  }
+
   getScatterData() {
     const colors =
       ["violet", "cornflowerblue", "gold", "orange", "turquoise", "tomato", "greenyellow"];
@@ -104,7 +112,8 @@ class App extends React.Component {
         lineData: this.getData(),
         barData: this.getBarData(),
         numericBarData: this.getNumericBarData(),
-        lineStyle: this.getStyles()
+        lineStyle: this.getStyles(),
+        barTransitionData: this.getBarTransitionData()
       });
     }, UPDATE_INTERVAL);
   }
@@ -130,6 +139,12 @@ class App extends React.Component {
 
           <VictoryChart>
             <VictoryBar/>
+          </VictoryChart>
+
+          <VictoryChart animate={{ duration: 800 }}>
+            <VictoryBar
+              data={this.state.barTransitionData}
+            />
           </VictoryChart>
 
           <VictoryChart scale={"linear"}>

--- a/src/components/victory-bar/victory-bar.jsx
+++ b/src/components/victory-bar/victory-bar.jsx
@@ -36,6 +36,20 @@ const defaultData = [
 
 export default class VictoryBar extends React.Component {
   static role = "bar";
+
+  static defaultTransitions = {
+    onExit: {
+      duration: 600,
+      before: () => ({}),
+      after: () => ({ y: 0 })
+    },
+    onEnter: {
+      duration: 600,
+      before: () => ({ y: 0 }),
+      after: () => ({})
+    }
+  }
+
   static propTypes = {
     /**
      * The animate prop specifies props for victory-animation to use. It this prop is

--- a/src/components/victory-chart/victory-chart.jsx
+++ b/src/components/victory-chart/victory-chart.jsx
@@ -260,12 +260,13 @@ export default class VictoryChart extends React.Component {
 
   render() {
     const style = this.getStyles(this.props);
-    const childComponents = this.state && this.state.nodesWillExit ?
-      ChartHelpers.getChildComponents(this.state.oldProps, defaultAxes) :
-      ChartHelpers.getChildComponents(this.props, defaultAxes);
+    const propsToRender = this.state && this.state.nodesWillExit ?
+      this.state.oldProps :
+      this.props;
+    const childComponents = ChartHelpers.getChildComponents(propsToRender, defaultAxes);
     const group = (
       <g style={style.parent}>
-        {this.getNewChildren(this.props, childComponents, style)}
+        {this.getNewChildren(propsToRender, childComponents, style)}
       </g>
     );
     return this.props.standalone ?


### PR DESCRIPTION
Along with the changes [here](https://github.com/FormidableLabs/victory-core/pull/44), this fixes transitions for `VictoryBar`, and corrects an oversight in `VictoryChart` that didn't cause issues with `VictoryScatter` transitions.

- Use `oldProps` for `getNewChildren` (which effected domain calculations) when rendering the exit transition.
- Gives `VictoryBar` some default transitions.
- Adds a demo of `VictoryBar` plus transitions to the demo page.

I noticed that [this line](https://github.com/FormidableLabs/victory-chart/blob/347e1ab748dc7b8c0becab72072402257ec98627/demo/components/victory-chart-demo.jsx#L187) is throwing tons of errors in the demo page - something along the lines of `getFullYear is not a function`.  I haven't checked yet whether this is happening master - it seems unrelated to the changes I've made here, but want to confirm before this is merged in.

- [ ] The accompanying `victory-core` PR should be merged and the reference updated here before this PR is merged.

![bar transitions](https://cloud.githubusercontent.com/assets/5016978/14303212/765e1e04-fb5d-11e5-8a39-e8e65317bc89.gif)

@boygirl @kenwheeler 