### PR TITLE
null animation should be respected

### DIFF
--- a/src/helpers/wrapper.js
+++ b/src/helpers/wrapper.js
@@ -46,6 +46,9 @@ export default {
   },
 
   getAnimationProps(props, child, index) {
+    if (!props.animate) {
+      return child.props.animate;
+    }
     const getFilteredState = () => {
       let childrenTransitions = this.state && this.state.childrenTransitions;
       childrenTransitions = Collection.isArrayOfArrays(childrenTransitions) ?


### PR DESCRIPTION
don't add `parentState` if the group should not animate