### PR TITLE
Allow axis prop control

### DIFF
--- a/demo/components/victory-chart-demo.js
+++ b/demo/components/victory-chart-demo.js
@@ -174,6 +174,8 @@ class App extends React.Component {
           </VictoryChart>
 
           <VictoryChart style={chartStyle} scale={"linear"}>
+            <VictoryAxis/>
+            <VictoryAxis dependentAxis crossAxis={false}/>
             <VictoryLine
               style={{data:
                 {stroke: "red", strokeWidth: 4}

--- a/src/components/victory-chart/victory-chart.js
+++ b/src/components/victory-chart/victory-chart.js
@@ -160,14 +160,15 @@ export default class VictoryChart extends React.Component {
       child.props.tickFormat || ChartHelpers.getTickFormat(child, axis, calculatedProps);
     const offsetY = axis === "y" ? undefined : axisOffset.y;
     const offsetX = axis === "x" ? undefined : axisOffset.x;
+    const crossAxis = child.props.crossAxis === false ? false : true;
     return {
       domain: domain[axis],
       scale: scale[axis],
       tickValues,
       tickFormat,
-      offsetY,
-      offsetX,
-      crossAxis: true
+      offsetY: child.props.offsetY || offsetY,
+      offsetX: child.props.offsetX || offsetX,
+      crossAxis
     };
   }
 

--- a/test/client/spec/components/victory-chart/victory-chart.spec.js
+++ b/test/client/spec/components/victory-chart/victory-chart.spec.js
@@ -5,6 +5,7 @@
 import React from "react";
 import { shallow, mount } from "enzyme";
 import VictoryChart from "src/components/victory-chart/victory-chart";
+import VictoryAxis from "src/components/victory-axis/victory-axis";
 
 describe("components/victory-chart", () => {
   describe("default component rendering", () => {
@@ -36,6 +37,38 @@ describe("components/victory-chart", () => {
       );
       wrapper.find("svg").simulate("click");
       expect(clickHandler.called).to.equal(true);
+    });
+  });
+
+  describe("axis rendering", () => {
+    it("renders two axes by default", () => {
+      const wrapper = shallow(
+        <VictoryChart/>
+      );
+      const axes = wrapper.find(VictoryAxis);
+      expect(axes).to.have.lengthOf(2);
+    });
+
+    it("renders one axis if one axis is given", () => {
+      const wrapper = shallow(
+        <VictoryChart>
+          <VictoryAxis/>
+        </VictoryChart>
+      );
+      const axes = wrapper.find(VictoryAxis);
+      expect(axes).to.have.lengthOf(1);
+    });
+
+    it("allows axis to control the crossAxis, and offset props", () => {
+      const wrapper = shallow(
+        <VictoryChart>
+          <VictoryAxis crossAxis={false} offsetX={50} offsetY={50}/>
+        </VictoryChart>
+      );
+      const axes = wrapper.find(VictoryAxis);
+      expect(axes.prop("crossAxis")).to.equal(false);
+      expect(axes.prop("offsetX")).to.equal(50);
+      expect(axes.prop("offsetY")).to.equal(50);
     });
   });
 });


### PR DESCRIPTION
allows users to define `crossAxis`, `offsetX` and `offsetY` props on `VictoryAxis` when it is a child of `VictoryChart`