### PR TITLE
Static chart methods

### DIFF
--- a/demo/components/victory-bar-demo.js
+++ b/demo/components/victory-bar-demo.js
@@ -2,6 +2,23 @@
 import React from "react";
 import { random, range } from "lodash";
 import {VictoryBar, VictoryChart, VictoryGroup, VictoryStack} from "../../src/index";
+import {VictoryLabel} from "victory-core";
+
+class CustomLabel extends React.Component {
+  static propTypes = {
+    ...VictoryLabel.propTypes,
+    offset: React.PropTypes.number
+  };
+
+  renderLabel() {
+    const {offset, x} = this.props;
+    return <VictoryLabel {...this.props} x={x + offset}/>
+  }
+
+  render() {
+    return this.renderLabel();
+  }
+}
 
 export default class App extends React.Component {
   constructor() {
@@ -90,6 +107,16 @@ export default class App extends React.Component {
     return (
       <div className="demo">
         <h1>VictoryBar</h1>
+          <VictoryStack colorScale="warm" style={{parent: parentStyle}}>
+            <VictoryBar
+              labelComponent={<CustomLabel offset={25}/>}
+              data={[{x: "a", y: 2, label: "WOW"}, {x: "b", y: 3, label: "COOL"}]}
+            />
+            <VictoryBar
+              data={[{x: "c", y: 2}, {x: "d", y: 3}]}
+            />
+          </VictoryStack>
+
         <VictoryBar
           style={{
             parent: parentStyle,

--- a/demo/components/victory-bar-demo.js
+++ b/demo/components/victory-bar-demo.js
@@ -7,12 +7,13 @@ import {VictoryLabel} from "victory-core";
 class CustomLabel extends React.Component {
   static propTypes = {
     ...VictoryLabel.propTypes,
-    offset: React.PropTypes.number
+    offset: React.PropTypes.number,
+    x: React.PropTypes.number
   };
 
   renderLabel() {
     const {offset, x} = this.props;
-    return <VictoryLabel {...this.props} x={x + offset}/>
+    return <VictoryLabel {...this.props} x={x + offset}/>;
   }
 
   render() {

--- a/demo/components/victory-bar-demo.js
+++ b/demo/components/victory-bar-demo.js
@@ -1,23 +1,27 @@
 /*global window:false*/
 import React from "react";
-import { random, range } from "lodash";
+import { assign, random, range } from "lodash";
 import {VictoryBar, VictoryChart, VictoryGroup, VictoryStack} from "../../src/index";
-import {VictoryLabel} from "victory-core";
 
-class CustomLabel extends React.Component {
+class Wrapper extends React.Component {
   static propTypes = {
-    ...VictoryLabel.propTypes,
-    offset: React.PropTypes.number,
-    x: React.PropTypes.number
+    children: React.PropTypes.oneOfType([
+      React.PropTypes.arrayOf(React.PropTypes.node),
+      React.PropTypes.node
+    ])
   };
 
-  renderLabel() {
-    const {offset, x} = this.props;
-    return <VictoryLabel {...this.props} x={x + offset}/>;
+  renderChildren(props) {
+    const children = React.Children.toArray(props.children);
+    return children.map((child) => {
+      return React.cloneElement(child, assign({}, child.props, props));
+    });
   }
 
   render() {
-    return this.renderLabel();
+    return (
+      <g>{this.renderChildren(this.props)}</g>
+    );
   }
 }
 
@@ -108,16 +112,6 @@ export default class App extends React.Component {
     return (
       <div className="demo">
         <h1>VictoryBar</h1>
-          <VictoryStack colorScale="warm" style={{parent: parentStyle}}>
-            <VictoryBar
-              labelComponent={<CustomLabel offset={25}/>}
-              data={[{x: "a", y: 2, label: "WOW"}, {x: "b", y: 3, label: "COOL"}]}
-            />
-            <VictoryBar
-              data={[{x: "c", y: 2}, {x: "d", y: 3}]}
-            />
-          </VictoryStack>
-
         <VictoryBar
           style={{
             parent: parentStyle,
@@ -142,7 +136,7 @@ export default class App extends React.Component {
           colorScale={"warm"}
         >
           {this.state.multiTransitionData.map((data, index) => {
-            return <VictoryBar key={index} data={data}/>;
+            return <Wrapper key={index}><VictoryBar data={data}/></Wrapper>;
           })}
         </VictoryStack>
 
@@ -153,7 +147,7 @@ export default class App extends React.Component {
           colorScale={"qualitative"}
         >
           {this.state.multiTransitionData.map((data, index) => {
-            return <VictoryBar key={index} data={data}/>;
+            return <Wrapper key={index}><VictoryBar key={index} data={data}/></Wrapper>;
           })}
         </VictoryGroup>
 
@@ -232,16 +226,18 @@ export default class App extends React.Component {
         </ChartWrap>
 
           <VictoryStack colorScale="warm" style={{parent: parentStyle}}>
-            <VictoryBar
-              data={[{x: "a", y: 2}, {x: "b", y: 3}, {x: "c", y: 4}]}
-              events={{
-                data: {
-                  onClick: () => {
-                    return {data: {style: {fill: "cyan"}}};
+            <Wrapper>
+              <VictoryBar
+                data={[{x: "a", y: 2}, {x: "b", y: 3}, {x: "c", y: 4}]}
+                events={{
+                  data: {
+                    onClick: () => {
+                      return {data: {style: {fill: "cyan"}}};
+                    }
                   }
-                }
-              }}
-            />
+                }}
+              />
+            </Wrapper>
             <VictoryBar
               data={[{x: "c", y: 2}, {x: "d", y: 3}, {x: "e", y: 4}]}
               events={{

--- a/demo/components/victory-chart-demo.js
+++ b/demo/components/victory-chart-demo.js
@@ -1,6 +1,6 @@
 /*global window:false */
 import React from "react";
-import { random, range } from "lodash";
+import { random, range, omit } from "lodash";
 import {
   VictoryChart, VictoryLine, VictoryAxis, VictoryBar, VictoryArea,
   VictoryScatter, VictoryStack, VictoryGroup
@@ -19,17 +19,17 @@ class Wrapper extends React.Component {
     ])
   };
 
-
-  renderChildren(props) {
-    const children = React.Children.toArray(props.children);
-    return children.map((child, index) => {
-      return React.cloneElement(child, assign({}, props, child.props));
+  renderChildren() {
+    const props = omit(this.props, "children");
+    const children = React.Children.toArray(this.props.children);
+    return children.map((child) => {
+      return React.cloneElement(child, assign({}, child.props, props));
     });
   }
 
   render() {
     return (
-      <g>{this.renderChildren(this.props)}</g>
+      <g>{this.renderChildren()}</g>
     );
   }
 }
@@ -194,8 +194,10 @@ class App extends React.Component {
           <VictoryChart style={chartStyle}/>
 
           <VictoryChart style={chartStyle}>
-            <VictoryLabel x={150} y={150}>WOW</VictoryLabel>
-            <VictoryScatter/>
+            <Wrapper>
+              <VictoryLabel text={"WOW"} x={150} y={150}/>
+              <VictoryScatter/>
+            </Wrapper>
           </VictoryChart>
 
           <VictoryChart style={chartStyle}>
@@ -208,6 +210,7 @@ class App extends React.Component {
 
           <VictoryChart style={chartStyle} scale={"linear"}>
             <VictoryAxis/>
+            <VictoryAxis orientation={"top"}/>
             <VictoryAxis dependentAxis crossAxis={false}/>
             <Wrapper>
               <VictoryLine
@@ -304,7 +307,7 @@ class App extends React.Component {
           >
             <VictoryStack>
               {this.state.barData.map((data, index) => {
-                return <VictoryBar data={data} key={index}/>;
+                return <Wrapper key={index}><VictoryBar data={data}/></Wrapper>;
               })}
             </VictoryStack>
           </VictoryChart>

--- a/demo/components/victory-chart-demo.js
+++ b/demo/components/victory-chart-demo.js
@@ -5,6 +5,7 @@ import {
   VictoryChart, VictoryLine, VictoryAxis, VictoryBar, VictoryArea,
   VictoryScatter, VictoryStack, VictoryGroup
 } from "../../src/index";
+import { VictoryLabel } from "victory-core";
 
 
 const UPDATE_INTERVAL = 3000;
@@ -161,6 +162,7 @@ class App extends React.Component {
           <VictoryChart style={chartStyle}/>
 
           <VictoryChart style={chartStyle}>
+            <VictoryLabel x={150} y={150}>WOW</VictoryLabel>
             <VictoryScatter/>
           </VictoryChart>
 
@@ -335,16 +337,16 @@ class App extends React.Component {
           <VictoryChart style={chartStyle}>
             <VictoryStack colorScale={"qualitative"}>
               <VictoryArea
-                data={[{x: 1, y: 2}, {x: 2, y: 3}, {x: 3, y: 5}, {x: 4, y: 4}, {x: 5, y: 7}]}
+                data={[{x: "a", y: 2}, {x: "b", y: 3}, {x: "c", y: 5}, {x: "d", y: 4}, {x: "e", y: 7}]}
               />
               <VictoryArea
-                data={[{x: 1, y: 1}, {x: 2, y: 4}, {x: 3, y: 5}, {x: 4, y: 7}, {x: 5, y: 5}]}
+                data={[{x: "a", y: 1}, {x: "b", y: 4}, {x: "c", y: 5}, {x: "d", y: 7}, {x: "e", y: 5}]}
               />
               <VictoryArea
-                data={[{x: 1, y: 3}, {x: 2, y: 2}, {x: 3, y: 6}, {x: 4, y: 2}, {x: 5, y: 6}]}
+                data={[{x: "a", y: 3}, {x: "b", y: 2}, {x: "c", y: 6}, {x: "d", y: 2}, {x: "e", y: 6}]}
               />
               <VictoryArea
-                data={[{x: 1, y: 2}, {x: 2, y: 3}, {x: 3, y: 3}, {x: 4, y: 4}, {x: 5, y: 7}]}
+                data={[{x: "a", y: 2}, {x: "b", y: 3}, {x: "c", y: 3}, {x: "d", y: 4}, {x: "e", y: 7}]}
               />
             </VictoryStack>
           </VictoryChart>

--- a/demo/components/victory-chart-demo.js
+++ b/demo/components/victory-chart-demo.js
@@ -6,9 +6,33 @@ import {
   VictoryScatter, VictoryStack, VictoryGroup
 } from "../../src/index";
 import { VictoryLabel } from "victory-core";
+import { assign } from "lodash";
 
 
 const UPDATE_INTERVAL = 3000;
+
+class Wrapper extends React.Component {
+  static propTypes = {
+    children: React.PropTypes.oneOfType([
+      React.PropTypes.arrayOf(React.PropTypes.node),
+      React.PropTypes.node
+    ])
+  };
+
+
+  renderChildren(props) {
+    const children = React.Children.toArray(props.children);
+    return children.map((child, index) => {
+      return React.cloneElement(child, assign({}, props, child.props));
+    });
+  }
+
+  render() {
+    return (
+      <g>{this.renderChildren(this.props)}</g>
+    );
+  }
+}
 
 class App extends React.Component {
   constructor(props) {
@@ -146,6 +170,14 @@ class App extends React.Component {
         <h1>VictoryChart</h1>
         <div style={containerStyle}>
           <VictoryChart style={chartStyle} animate={{ duration: 1500 }}>
+          <Wrapper>
+            <VictoryBar
+              data={this.state.barTransitionData}
+            />
+            </Wrapper>
+          </VictoryChart>
+
+          <VictoryChart style={chartStyle} animate={{ duration: 1500 }}>
             <VictoryBar
               data={this.state.barTransitionData}
             />
@@ -177,12 +209,14 @@ class App extends React.Component {
           <VictoryChart style={chartStyle} scale={"linear"}>
             <VictoryAxis/>
             <VictoryAxis dependentAxis crossAxis={false}/>
-            <VictoryLine
-              style={{data:
-                {stroke: "red", strokeWidth: 4}
-              }}
-              y={(data) => Math.sin(2 * Math.PI * data.x)}
-            />
+            <Wrapper>
+              <VictoryLine
+                style={{data:
+                  {stroke: "red", strokeWidth: 4}
+                }}
+                y={(data) => Math.sin(2 * Math.PI * data.x)}
+              />
+            </Wrapper>
             <VictoryLine
               style={{data:
                 {stroke: "blue", strokeWidth: 4}
@@ -259,8 +293,10 @@ class App extends React.Component {
           <VictoryChart style={chartStyle}>
             <VictoryAxis dependentAxis orientation="right"/>
             <VictoryAxis orientation="top"/>
-            <VictoryLine y={(d) => 0.5 * d.x + 0.5} style={{data: {stroke: "red"}}}/>
-            <VictoryScatter y={(d) => d.x * d.x} style={{data: {stroke: "red"}}}/>
+            <Wrapper>
+              <VictoryLine y={(d) => 0.5 * d.x + 0.5} style={{data: {stroke: "red"}}}/>
+              <VictoryScatter y={(d) => d.x * d.x} style={{data: {stroke: "red"}}}/>
+            </Wrapper>
           </VictoryChart>
 
           <VictoryChart style={chartStyle} animate={{duration: 2000}}
@@ -337,16 +373,24 @@ class App extends React.Component {
           <VictoryChart style={chartStyle}>
             <VictoryStack colorScale={"qualitative"}>
               <VictoryArea
-                data={[{x: "a", y: 2}, {x: "b", y: 3}, {x: "c", y: 5}, {x: "d", y: 4}, {x: "e", y: 7}]}
+                data={[
+                  {x: "a", y: 2}, {x: "b", y: 3}, {x: "c", y: 5}, {x: "d", y: 4}, {x: "e", y: 7}
+                ]}
               />
               <VictoryArea
-                data={[{x: "a", y: 1}, {x: "b", y: 4}, {x: "c", y: 5}, {x: "d", y: 7}, {x: "e", y: 5}]}
+                data={[
+                  {x: "a", y: 1}, {x: "b", y: 4}, {x: "c", y: 5}, {x: "d", y: 7}, {x: "e", y: 5}
+                ]}
               />
               <VictoryArea
-                data={[{x: "a", y: 3}, {x: "b", y: 2}, {x: "c", y: 6}, {x: "d", y: 2}, {x: "e", y: 6}]}
+                data={[
+                  {x: "a", y: 3}, {x: "b", y: 2}, {x: "c", y: 6}, {x: "d", y: 2}, {x: "e", y: 6}
+                ]}
               />
               <VictoryArea
-                data={[{x: "a", y: 2}, {x: "b", y: 3}, {x: "c", y: 3}, {x: "d", y: 4}, {x: "e", y: 7}]}
+                data={[
+                  {x: "a", y: 2}, {x: "b", y: 3}, {x: "c", y: 3}, {x: "d", y: 4}, {x: "e", y: 7}
+                ]}
               />
             </VictoryStack>
           </VictoryChart>

--- a/demo/components/victory-chart-demo.js
+++ b/demo/components/victory-chart-demo.js
@@ -20,7 +20,7 @@ class Wrapper extends React.Component {
   };
 
   renderChildren() {
-    const props = omit(this.props, "children");
+    const props = omit(this.props, ["children", "style"]);
     const children = React.Children.toArray(this.props.children);
     return children.map((child) => {
       return React.cloneElement(child, assign({}, child.props, props));
@@ -29,7 +29,10 @@ class Wrapper extends React.Component {
 
   render() {
     return (
-      <g>{this.renderChildren()}</g>
+      <g>
+        <VictoryLabel text={"WRAPPED"} x={50} y={50}/>
+        {this.renderChildren()}
+      </g>
     );
   }
 }
@@ -186,7 +189,7 @@ class App extends React.Component {
           <VictoryChart style={chartStyle} animate={{duration: 1000}}>
             <VictoryStack colorScale={"warm"}>
               {this.state.multiBarTransitionData.map((data, index) => {
-                return <VictoryBar key={index} data={data}/>;
+                return <Wrapper key={index}><VictoryBar data={data}/></Wrapper>;
               })}
             </VictoryStack>
           </VictoryChart>
@@ -209,9 +212,8 @@ class App extends React.Component {
           </VictoryChart>
 
           <VictoryChart style={chartStyle} scale={"linear"}>
-            <VictoryAxis/>
-            <VictoryAxis orientation={"top"}/>
-            <VictoryAxis dependentAxis crossAxis={false}/>
+            <Wrapper><VictoryAxis/></Wrapper>
+            <Wrapper><VictoryAxis dependentAxis crossAxis={false}/></Wrapper>
             <Wrapper>
               <VictoryLine
                 style={{data:
@@ -296,10 +298,8 @@ class App extends React.Component {
           <VictoryChart style={chartStyle}>
             <VictoryAxis dependentAxis orientation="right"/>
             <VictoryAxis orientation="top"/>
-            <Wrapper>
               <VictoryLine y={(d) => 0.5 * d.x + 0.5} style={{data: {stroke: "red"}}}/>
               <VictoryScatter y={(d) => d.x * d.x} style={{data: {stroke: "red"}}}/>
-            </Wrapper>
           </VictoryChart>
 
           <VictoryChart style={chartStyle} animate={{duration: 2000}}

--- a/src/components/victory-axis/helper-methods.js
+++ b/src/components/victory-axis/helper-methods.js
@@ -7,11 +7,14 @@ import { Helpers } from "victory-core";
 export default {
   // exposed for use by VictoryChart
   getDomain(props, axis) {
-    if (axis && axis !== this.getAxis(props)) {
+    const inherentAxis = this.getAxis(props);
+    if (axis && axis !== inherentAxis) {
       return undefined;
     }
-    if (props.domain) {
+    if (Array.isArray(props.domain)) {
       return props.domain;
+    } else if (props.domain && props.domain[inherentAxis]) {
+      return props.domain[inherentAxis];
     } else if (props.tickValues) {
       return Domain.getDomainFromTickValues(props);
     }

--- a/src/components/victory-axis/victory-axis.js
+++ b/src/components/victory-axis/victory-axis.js
@@ -297,7 +297,7 @@ export default class VictoryAxis extends React.Component {
   };
 
   static getDomain = AxisHelpers.getDomain.bind(AxisHelpers);
-  static getAxis = AxisHelpers.getAxis.bind(AxisHelpers);
+  static getAxis = Axis.getAxis.bind(Axis);
   static getScale = AxisHelpers.getScale.bind(AxisHelpers);
   static getStyles = getStyles;
 

--- a/src/components/victory-axis/victory-axis.js
+++ b/src/components/victory-axis/victory-axis.js
@@ -118,7 +118,13 @@ export default class VictoryAxis extends React.Component {
      * If this value is not given it will be calculated based on the scale or tickValues.
      * @examples [-1, 1]
      */
-    domain: CustomPropTypes.domain,
+    domain: PropTypes.oneOfType([
+      CustomPropTypes.domain,
+      PropTypes.shape({
+        x: CustomPropTypes.domain,
+        y: CustomPropTypes.domain
+      })
+    ]),
     /**
      * The events prop attaches arbitrary event handlers to data and label elements
      * Event handlers are called with their corresponding events, corresponding component props,

--- a/src/components/victory-chart/helper-methods.js
+++ b/src/components/victory-chart/helper-methods.js
@@ -4,7 +4,7 @@ import Data from "../../helpers/data";
 import Domain from "../../helpers/domain";
 import Wrapper from "../../helpers/wrapper";
 import React from "react";
-import { Collection, Log } from "victory-core";
+import { Collection, Helpers, Log } from "victory-core";
 
 const identity = (x) => x;
 
@@ -38,13 +38,6 @@ export default {
       );
     }
     return childComponents;
-  },
-
-  getDataComponents(childComponents) {
-    return childComponents.filter((child) => {
-      const role = child.type && child.type.role;
-      return role !== "axis";
-    });
   },
 
   getDomain(props, childComponents, axis) {
@@ -122,10 +115,10 @@ export default {
   },
 
   createStringMap(childComponents, axis) {
-    const getStringsFromChildren = (children, axis) => {
+    const getStringsFromChildren = (children) => {
       return children.reduce((memo, child) => {
         if (child.props && child.props.data) {
-          return memo.concat(Data.getStringsFromData(child.props, axis));
+          return memo.concat(Helpers.getStringsFromData(child.props, axis));
         } else if (child.type && isFunction(child.type.getData)) {
           const data = flatten(child.type.getData(child.props));
           const attr = axis === "x" ? "xName" : "yName";
@@ -133,7 +126,7 @@ export default {
             return datum[attr] ? prev.concat(datum[attr]) : prev;
           }, []));
         } else if (child.props && child.props.children) {
-          return memo.concat(getStringsFromChildren(React.Children.toArray(child.props.children), axis));
+          return memo.concat(getStringsFromChildren(React.Children.toArray(child.props.children)));
         }
         return memo;
       }, []);

--- a/src/components/victory-chart/helper-methods.js
+++ b/src/components/victory-chart/helper-methods.js
@@ -15,8 +15,8 @@ export default {
     }
 
     const axisComponents = {
-      dependent: Axis.getAxisComponentsWithParent(props, "dependent", childComponents),
-      independent: Axis.getAxisComponentsWithParent(props, "independent", childComponents)
+      dependent: Axis.getAxisComponentsWithParent(childComponents, "dependent"),
+      independent: Axis.getAxisComponentsWithParent(childComponents, "independent")
     };
 
     if (axisComponents.dependent.length === 0 && axisComponents.independent.length === 0) {
@@ -53,7 +53,7 @@ export default {
   getDomain(props, axis, childComponents) {
     childComponents = childComponents || React.Children.toArray(props.children);
     const domain = Wrapper.getDomain(props, axis, childComponents);
-    const orientations = Axis.getAxisOrientations(props);
+    const orientations = Axis.getAxisOrientations(childComponents);
     return Domain.orientDomain(domain, orientations, axis);
   },
 

--- a/src/components/victory-chart/helper-methods.js
+++ b/src/components/victory-chart/helper-methods.js
@@ -14,22 +14,22 @@ export default {
       return [defaultAxes.independent, defaultAxes.dependent];
     }
 
-    const axisComponents = Axis.findAxisComponents(childComponents);
+    const axisComponents = {
+      dependent: Axis.getAxisComponentsWithParent(props, "dependent", childComponents),
+      independent: Axis.getAxisComponentsWithParent(props, "independent", childComponents)
+    };
 
-    if (axisComponents.length === 0) {
+    if (axisComponents.dependent.length === 0 && axisComponents.independent.length === 0) {
       return childComponents.concat(defaultAxes.independent, defaultAxes.dependent);
     }
-    const dependentAxes = axisComponents.filter((component) => component.props.dependentAxis);
-    const independentAxes = axisComponents.filter((component) => !component.props.dependentAxis);
-    if (dependentAxes.length > 1 || independentAxes.length > 1) {
+    if (axisComponents.dependent.length > 1 || axisComponents.independent.length > 1) {
       const msg = `Only one VictoryAxis component of each axis type is allowed when ` +
         `using the VictoryChart wrapper. Only the first axis will be used. Please compose ` +
         `multi-axis charts manually`;
       Log.warn(msg);
       const dataComponents = this.getDataComponents(childComponents);
-
       return Collection.removeUndefined(
-        dataComponents.concat(independentAxes[0], dependentAxes[0])
+        dataComponents.concat(axisComponents.dependent[0], axisComponents.independent[0])
       );
     }
     return childComponents;

--- a/src/components/victory-chart/victory-chart.js
+++ b/src/components/victory-chart/victory-chart.js
@@ -187,12 +187,12 @@ export default class VictoryChart extends React.Component {
   getCalculatedProps(props, childComponents) {
     const horizontal = childComponents.some((component) => component.props.horizontal);
     const axisComponents = {
-      x: Axis.getAxisComponent(childComponents, "x"),
-      y: Axis.getAxisComponent(childComponents, "y")
+      x: Axis.getAxisComponent(props, "x", childComponents),
+      y: Axis.getAxisComponent(props, "y", childComponents)
     };
     const domain = {
-      x: ChartHelpers.getDomain(props, childComponents, "x"),
-      y: ChartHelpers.getDomain(props, childComponents, "y")
+      x: ChartHelpers.getDomain(props, "x", childComponents),
+      y: ChartHelpers.getDomain(props, "y", childComponents)
     };
     const range = {
       x: Helpers.getRange(props, "x"),
@@ -212,12 +212,12 @@ export default class VictoryChart extends React.Component {
     };
     // TODO: check
     const categories = {
-      x: Wrapper.getCategories(childComponents, props, "x"),
-      y: Wrapper.getCategories(childComponents, props, "y")
+      x: Wrapper.getCategories(props, "x", childComponents),
+      y: Wrapper.getCategories(props, "y", childComponents)
     };
     const stringMap = {
-      x: ChartHelpers.createStringMap(childComponents, "x"),
-      y: ChartHelpers.createStringMap(childComponents, "y")
+      x: ChartHelpers.createStringMap(props, "x", childComponents),
+      y: ChartHelpers.createStringMap(props, "y", childComponents)
     };
     return {axisComponents, categories, domain, horizontal, scale, stringMap};
   }

--- a/src/components/victory-chart/victory-chart.js
+++ b/src/components/victory-chart/victory-chart.js
@@ -187,8 +187,8 @@ export default class VictoryChart extends React.Component {
   getCalculatedProps(props, childComponents) {
     const horizontal = childComponents.some((component) => component.props.horizontal);
     const axisComponents = {
-      x: Axis.getAxisComponent(props, "x", childComponents),
-      y: Axis.getAxisComponent(props, "y", childComponents)
+      x: Axis.getAxisComponent(childComponents, "x"),
+      y: Axis.getAxisComponent(childComponents, "y")
     };
     const domain = {
       x: ChartHelpers.getDomain(props, "x", childComponents),

--- a/src/components/victory-chart/victory-chart.js
+++ b/src/components/victory-chart/victory-chart.js
@@ -173,9 +173,9 @@ export default class VictoryChart extends React.Component {
   }
 
   getChildProps(child, props, calculatedProps) {
-    const type = child.type && child.type.role;
-    if (type === "axis") {
-      return this.getAxisProps(child, props, calculatedProps);
+    const axisChild = Axis.findAxisComponents([child]);
+    if (axisChild.length > 0) {
+      return this.getAxisProps(axisChild[0], props, calculatedProps);
     }
     return {
       domain: calculatedProps.domain,

--- a/src/components/victory-group/victory-group.js
+++ b/src/components/victory-group/victory-group.js
@@ -2,7 +2,6 @@ import { assign, uniq } from "lodash";
 import React, { PropTypes } from "react";
 import { PropTypes as CustomPropTypes, Helpers, Log } from "victory-core";
 import Scale from "../../helpers/scale";
-import Data from "../../helpers/data";
 import Wrapper from "../../helpers/wrapper";
 
 const defaultStyles = {
@@ -205,10 +204,7 @@ export default class VictoryGroup extends React.Component {
     const horizontal = props.horizontal || childComponents.every(
       (component) => component.props.horizontal
     );
-    const datasets = childComponents.map((child) => {
-      const getData = child.type.getData || Data.getData;
-      return getData(child.props);
-    });
+    const datasets = Wrapper.getDataFromChildren(props);
     const domain = {
       x: Wrapper.getDomainFromChildren(props, "x", datasets),
       y: Wrapper.getDomainFromChildren(props, "y", datasets)

--- a/src/components/victory-group/victory-group.js
+++ b/src/components/victory-group/victory-group.js
@@ -192,7 +192,7 @@ export default class VictoryGroup extends React.Component {
     standalone: true
   };
 
-  static getDomain = Wrapper.getDomainFromChildren.bind(Wrapper);
+  static getDomain = Wrapper.getDomain.bind(Wrapper);
   static getData = Wrapper.getData.bind(Wrapper);
 
   componentWillReceiveProps(nextProps) {
@@ -206,8 +206,8 @@ export default class VictoryGroup extends React.Component {
     );
     const datasets = Wrapper.getDataFromChildren(props);
     const domain = {
-      x: Wrapper.getDomainFromChildren(props, "x", datasets),
-      y: Wrapper.getDomainFromChildren(props, "y", datasets)
+      x: Wrapper.getDomain(props, "x", childComponents),
+      y: Wrapper.getDomain(props, "y", childComponents)
     };
     const range = {
       x: Helpers.getRange(props, "x"),

--- a/src/components/victory-stack/victory-stack.js
+++ b/src/components/victory-stack/victory-stack.js
@@ -282,9 +282,6 @@ export default class VictoryStack extends React.Component {
     const style = Helpers.getStyles(props.style, defaultStyles, "auto", "100%");
     const childComponents = React.Children.toArray(props.children);
     const types = uniq(childComponents.map((child) => child.type.role));
-    if (types.length > 1) {
-      Log.warn("Only components of the same type can be stacked");
-    }
     if (types.some((type) => type === "group-wrapper")) {
       Log.warn("It is not possible to stack groups.");
     }

--- a/src/components/victory-stack/victory-stack.js
+++ b/src/components/victory-stack/victory-stack.js
@@ -2,7 +2,6 @@ import { assign, uniq } from "lodash";
 import React, { PropTypes } from "react";
 import { PropTypes as CustomPropTypes, Helpers, Log } from "victory-core";
 import Scale from "../../helpers/scale";
-import Data from "../../helpers/data";
 import Wrapper from "../../helpers/wrapper";
 
 const defaultStyles = {
@@ -203,9 +202,7 @@ export default class VictoryStack extends React.Component {
     const horizontal = props.horizontal || childComponents.every(
       (component) => component.props.horizontal
     );
-    const datasets = childComponents.map((child) => {
-      return child.type.getData(child.props) || Data.getData(child.props);
-    });
+    const datasets = Wrapper.getDataFromChildren(props);
     const domain = {
       x: Wrapper.getStackedDomain(props, "x", datasets),
       y: Wrapper.getStackedDomain(props, "y", datasets)

--- a/src/helpers/axis.js
+++ b/src/helpers/axis.js
@@ -1,23 +1,84 @@
 import { Collection } from "victory-core";
+import { identity } from "lodash";
 import React from "react";
 
 export default {
+  getAxisType(component) {
+    if (!component.type || component.type.role !== "axis") {
+      return undefined;
+    }
+    return component.props.dependentAxis ? "dependent" : "independent";
+  },
 
+  getAxis(props, flipped) {
+    if (props.orientation) {
+      const vertical = {top: "x", bottom: "x", left: "y", right: "y"};
+      return vertical[props.orientation];
+    }
+    const axisType = props.dependentAxis ? "dependent" : "independent";
+    const flippedAxis = { dependent: "x", independent: "y"};
+    const normalAxis = { independent: "x", dependent: "y"};
+    return flipped ? flippedAxis[axisType] : normalAxis[axisType];
+  },
+
+  /**
+   * Returns a single AxisComponent of the desired axis type (x or y)
+   * @param {Object} props: the props object.
+   * @param {String} axis: desired axis either "x" or "y".
+   * @param {Array} childComponents: an optional array of children.
+   * @returns {ReactComponent} an AxisComponent of the desired type or undefined
+   */
   getAxisComponent(props, axis, childComponents) {
     childComponents = childComponents || React.Children.toArray(props.children);
     const getAxis = (component) => {
       const flipped = childComponents.some((child) => child.props.horizontal);
       return component.type.getAxis(component.props, flipped);
     };
-    const axisComponents = this.findAxisComponents(childComponents);
+    const axisComponents = this.findAxisComponentsByType(childComponents);
     return axisComponents.filter((component) => getAxis(component) === axis)[0];
   },
 
-  findAxisComponents(childComponents) {
+
+  /**
+   * Returns a single AxisComponent of the desired axis type (x or y)
+   * @param {Object} props: the props object.
+   * @param {String} axis: desired axis either "x" or "y".
+   * @param {Array} childComponents: an optional array of children.
+   * @returns {ReactComponent} an AxisComponent of the desired type or undefined
+   */
+  findAxisComponentsByType(props, type, childComponents) {
+    childComponents = childComponents || React.Children.toArray(childComponents);
+    const predicate = (child) => {
+      return type === "dependent" ? child.props.dependentAxis : !child.props.dependentAxis;
+    };
+    return this.findAxisComponents(childComponents, predicate);
+  },
+
+  /**
+   * Returns a single AxisComponent of the desired axis type (x or y)
+   * @param {Object} props: the props object.
+   * @param {String} axis: desired axis either "x" or "y".
+   * @param {Array} childComponents: an optional array of children.
+   * @returns {ReactComponent} an AxisComponent of the desired type or undefined
+   */
+  findAxisComponentsByAxis(props, axis, childComponents) {
+    childComponents = childComponents || React.Children.toArray(childComponents);
+    const predicate = (child) => {
+      const childAxis = child.type.getAxis(child.props);
+      return axis === childAxis;
+    };
+    return this.findAxisComponents(childComponents, predicate);
+  },
+
+  findAxisComponents(childComponents, predicate) {
+    predicate = predicate || identity;
     const findAxes = (children) => {
       return children.reduce((memo, child) => {
         if (child.type && child.type.role === "axis") {
-          return memo.concat(child);
+          if (predicate(child)) {
+            return memo.concat(child);
+          }
+          return memo;
         } else if (child.props && child.props.children) {
           return memo.concat(findAxes(React.Children.toArray(child.props.children)));
         }
@@ -26,6 +87,38 @@ export default {
     };
 
     return findAxes(childComponents);
+  },
+
+  /**
+   * Returns all AxisComponents of the desired axis type (x or y) along with any
+   * parent components excluding VictoryChart
+   * @param {Object} props: the props object.
+   * @param {String} type: desired axis either "dependent" or "independent".
+   * @param {Array} childComponents: an optional array of children.
+   * @returns {ReactComponent} an AxisComponent of the desired type or undefined
+   */
+  getAxisComponentsWithParent(props, type, childComponents) {
+    childComponents = childComponents || React.Children.toArray(childComponents);
+    const matchesType = (child) => {
+      return type === "dependent" ? child.props.dependentAxis : !child.props.dependentAxis;
+    };
+
+    const findAxisComponents = (children) => {
+      return children.reduce((memo, child) => {
+        if (child.type && child.type.role === "axis") {
+          if (matchesType(child)) {
+            return memo.concat(child);
+          }
+          return memo;
+        } else if (child.props && child.props.children) {
+          const childAxis = findAxisComponents(React.Children.toArray(child.props.children));
+          return childAxis.length > 0 ? memo.concat(child) : memo;
+        }
+        return memo;
+      }, []);
+    };
+
+    return findAxisComponents(childComponents);
   },
 
   getOrientation(component, axis) {

--- a/src/helpers/axis.js
+++ b/src/helpers/axis.js
@@ -1,22 +1,31 @@
 import { Collection } from "victory-core";
+import React from "react";
 
 export default {
-  getAxisType(component) {
-    if (!component.type || component.type.role !== "axis") {
-      return undefined;
-    }
-    return component.props.dependentAxis ? "dependent" : "independent";
-  },
 
-  getAxisComponent(childComponents, axis) {
+  getAxisComponent(props, axis, childComponents) {
+    childComponents = childComponents || React.Children.toArray(props.children);
     const getAxis = (component) => {
       const flipped = childComponents.some((child) => child.props.horizontal);
       return component.type.getAxis(component.props, flipped);
     };
-    const axisComponents = childComponents.filter((component) => {
-      return component.type.role === "axis" && getAxis(component) === axis;
-    });
-    return axisComponents[0];
+    const axisComponents = this.findAxisComponents(childComponents);
+    return axisComponents.filter((component) => getAxis(component) === axis)[0];
+  },
+
+  findAxisComponents(childComponents) {
+    const findAxes = (children) => {
+      return children.reduce((memo, child) => {
+        if (child.type && child.type.role === "axis") {
+          return memo.concat(child);
+        } else if (child.props && child.props.children) {
+          return memo.concat(findAxes(React.Children.toArray(child.props.children)));
+        }
+        return memo;
+      }, []);
+    };
+
+    return findAxes(childComponents);
   },
 
   getOrientation(component, axis) {
@@ -32,10 +41,10 @@ export default {
       typicalOrientations[axis] : flippedOrientations[axis];
   },
 
-  getAxisOrientations(childComponents) {
+  getAxisOrientations(props) {
     return {
-      x: this.getOrientation(this.getAxisComponent(childComponents, "x"), "x"),
-      y: this.getOrientation(this.getAxisComponent(childComponents, "y"), "y")
+      x: this.getOrientation(this.getAxisComponent(props, "x"), "x"),
+      y: this.getOrientation(this.getAxisComponent(props, "y"), "y")
     };
   },
 

--- a/src/helpers/axis.js
+++ b/src/helpers/axis.js
@@ -3,13 +3,12 @@ import { identity } from "lodash";
 import React from "react";
 
 export default {
-  getAxisType(component) {
-    if (!component.type || component.type.role !== "axis") {
-      return undefined;
-    }
-    return component.props.dependentAxis ? "dependent" : "independent";
-  },
-
+  /**
+   * Returns the axis (x or y) of a particular axis component
+   * @param {Object} props: the props object.
+   * @param {Boolean} flipped: true when the axis component is in an atypical orientation
+   * @returns {String} the dimension appropriate for the axis given its props
+   */
   getAxis(props, flipped) {
     if (props.orientation) {
       const vertical = {top: "x", bottom: "x", left: "y", right: "y"};
@@ -22,63 +21,32 @@ export default {
   },
 
   /**
-   * Returns a single AxisComponent of the desired axis type (x or y)
-   * @param {Object} props: the props object.
+   * Returns a single axis component of the desired axis type (x or y)
+   * @param {Array} childComponents: an array of children
    * @param {String} axis: desired axis either "x" or "y".
-   * @param {Array} childComponents: an optional array of children.
-   * @returns {ReactComponent} an AxisComponent of the desired type or undefined
+   * @returns {ReactComponent} an axis component of the desired axis or undefined
    */
-  getAxisComponent(props, axis, childComponents) {
-    childComponents = childComponents || React.Children.toArray(props.children);
-    const getAxis = (component) => {
+  getAxisComponent(childComponents, axis) {
+    const matchesAxis = (component) => {
       const flipped = childComponents.some((child) => child.props.horizontal);
-      return component.type.getAxis(component.props, flipped);
+      const type = component.type.getAxis(component.props, flipped);
+      return type === axis;
     };
-    const axisComponents = this.findAxisComponentsByType(childComponents);
-    return axisComponents.filter((component) => getAxis(component) === axis)[0];
-  },
-
-
-  /**
-   * Returns a single AxisComponent of the desired axis type (x or y)
-   * @param {Object} props: the props object.
-   * @param {String} axis: desired axis either "x" or "y".
-   * @param {Array} childComponents: an optional array of children.
-   * @returns {ReactComponent} an AxisComponent of the desired type or undefined
-   */
-  findAxisComponentsByType(props, type, childComponents) {
-    childComponents = childComponents || React.Children.toArray(childComponents);
-    const predicate = (child) => {
-      return type === "dependent" ? child.props.dependentAxis : !child.props.dependentAxis;
-    };
-    return this.findAxisComponents(childComponents, predicate);
+    return this.findAxisComponents(childComponents, matchesAxis)[0];
   },
 
   /**
-   * Returns a single AxisComponent of the desired axis type (x or y)
-   * @param {Object} props: the props object.
-   * @param {String} axis: desired axis either "x" or "y".
-   * @param {Array} childComponents: an optional array of children.
-   * @returns {ReactComponent} an AxisComponent of the desired type or undefined
+   * Returns all axis components that pass a given predicate
+   * @param {Array} childComponents: an array of children
+   * @param {Function} predicate: a predicate function that will be called with each
+   * @returns {Array} all axis components that pass the given predicate or []
    */
-  findAxisComponentsByAxis(props, axis, childComponents) {
-    childComponents = childComponents || React.Children.toArray(childComponents);
-    const predicate = (child) => {
-      const childAxis = child.type.getAxis(child.props);
-      return axis === childAxis;
-    };
-    return this.findAxisComponents(childComponents, predicate);
-  },
-
   findAxisComponents(childComponents, predicate) {
     predicate = predicate || identity;
     const findAxes = (children) => {
       return children.reduce((memo, child) => {
-        if (child.type && child.type.role === "axis") {
-          if (predicate(child)) {
-            return memo.concat(child);
-          }
-          return memo;
+        if (child.type && child.type.role === "axis" && predicate(child)) {
+          return memo.concat(child);
         } else if (child.props && child.props.children) {
           return memo.concat(findAxes(React.Children.toArray(child.props.children)));
         }
@@ -90,26 +58,21 @@ export default {
   },
 
   /**
-   * Returns all AxisComponents of the desired axis type (x or y) along with any
+   * Returns all axis components of the desired axis type (x or y) along with any
    * parent components excluding VictoryChart
-   * @param {Object} props: the props object.
-   * @param {String} type: desired axis either "dependent" or "independent".
    * @param {Array} childComponents: an optional array of children.
-   * @returns {ReactComponent} an AxisComponent of the desired type or undefined
+   * @param {String} type: desired axis either "dependent" or "independent".
+   * @returns {ReactComponent} an axis component of the desired type or undefined
    */
-  getAxisComponentsWithParent(props, type, childComponents) {
-    childComponents = childComponents || React.Children.toArray(childComponents);
+  getAxisComponentsWithParent(childComponents, type) {
     const matchesType = (child) => {
       return type === "dependent" ? child.props.dependentAxis : !child.props.dependentAxis;
     };
 
     const findAxisComponents = (children) => {
       return children.reduce((memo, child) => {
-        if (child.type && child.type.role === "axis") {
-          if (matchesType(child)) {
-            return memo.concat(child);
-          }
-          return memo;
+        if (child.type && child.type.role === "axis" && matchesType(child)) {
+          return memo.concat(child);
         } else if (child.props && child.props.children) {
           const childAxis = findAxisComponents(React.Children.toArray(child.props.children));
           return childAxis.length > 0 ? memo.concat(child) : memo;
@@ -121,6 +84,11 @@ export default {
     return findAxisComponents(childComponents);
   },
 
+  /**
+   * @param {ReactComponent} component: a victory axis component.
+   * @param {String} axis: desired axis either "x" or "y".
+   * @returns {String} the orientation of the axis ("top", "bottom", "left", or "right")
+   */
   getOrientation(component, axis) {
     const typicalOrientations = {x: "bottom", y: "left"};
     const flippedOrientations = {x: "left", y: "bottom"};
@@ -134,19 +102,31 @@ export default {
       typicalOrientations[axis] : flippedOrientations[axis];
   },
 
-  getAxisOrientations(props) {
+  /**
+   * @param {Array} childComponents: an array of children
+   * @returns {Object} an object with orientations specified for x and y
+   */
+  getAxisOrientations(childComponents) {
     return {
-      x: this.getOrientation(this.getAxisComponent(props, "x"), "x"),
-      y: this.getOrientation(this.getAxisComponent(props, "y"), "y")
+      x: this.getOrientation(this.getAxisComponent(childComponents, "x"), "x"),
+      y: this.getOrientation(this.getAxisComponent(childComponents, "y"), "y")
     };
   },
 
+  /**
+   * @param {Object} props: axis component props
+   * @returns {Boolean} true when the axis is vertical
+   */
   isVertical(props) {
     const orientation = props.orientation || (props.dependentAxis ? "left" : "bottom");
     const vertical = {top: false, bottom: false, left: true, right: true};
     return vertical[orientation];
   },
 
+  /**
+   * @param {Object} props: axis component props
+   * @returns {Boolean} true when tickValues contain strings
+   */
   stringTicks(props) {
     return props.tickValues !== undefined && Collection.containsStrings(props.tickValues);
   }

--- a/src/helpers/data.js
+++ b/src/helpers/data.js
@@ -48,7 +48,7 @@ export default {
   },
 
   getCategories(props, axis) {
-    if (!props.categories) {
+    if (!props || !props.categories) {
       return undefined;
     }
     return Array.isArray(props.categories) ? props.categories : props.categories[axis];

--- a/src/helpers/data.js
+++ b/src/helpers/data.js
@@ -1,18 +1,13 @@
-import { assign, defaults, uniq } from "lodash";
+import { assign, uniq } from "lodash";
 import { Helpers, Collection } from "victory-core";
 import Scale from "./scale";
-import React from "react";
 
 export default {
   // String Data
-  createStringMap(props, axis, hasMultipleDatasets = false) {
+  createStringMap(props, axis) {
     const stringsFromAxes = this.getStringsFromAxes(props, axis);
     const stringsFromCategories = this.getStringsFromCategories(props, axis);
-    const stringsFromData = hasMultipleDatasets ?
-      props.data.reduce((prev, dataset) => {
-        return prev.concat(Helpers.getStringsFromData(defaults({}, {data: dataset}, props), axis));
-      }, [])
-      : this.getStringsFromData(props, axis);
+    const stringsFromData = Helpers.getStringsFromData(props, axis);
 
     const allStrings = uniq([...stringsFromAxes, ...stringsFromCategories, ...stringsFromData]);
     return allStrings.length === 0 ? null :
@@ -31,47 +26,17 @@ export default {
   },
 
   getStringsFromCategories(props, axis) {
-    const childComponents = props.children && React.Children.toArray(props.children);
-    if (!props.categories && !props.children) {
+    if (!props.categories) {
       return [];
     }
-
-    const getCategoryStrings = (childProps) => {
-      const categories = this.getCategories(childProps, axis);
-      return categories && categories.filter((val) => typeof val === "string");
-    };
-
-    const categories = props.categories ?
-      getCategoryStrings(props) : childComponents.map((child) => getCategoryStrings(child.props));
-
-    return categories ? Collection.removeUndefined(categories) : [];
+    const categories = this.getCategories(props, axis);
+    const categoryStrings = categories && categories.filter((val) => typeof val === "string");
+    return categoryStrings ? Collection.removeUndefined(categoryStrings) : [];
   },
 
   getCategories(props, axis) {
-    if (!props || !props.categories) {
-      return undefined;
-    }
-    return Array.isArray(props.categories) ? props.categories : props.categories[axis];
-  },
-
-  getStringsFromData(props, axis) {
-    const childComponents = props.children && React.Children.toArray(props.children);
-    if (!props.data && !props.children) {
-      return [];
-    }
-
-    const getStrings = (childProps) => {
-      const accessor = Helpers.createAccessor(
-        typeof childProps[axis] !== "undefined" ? childProps[axis] : axis
-      );
-      return childProps.data ? childProps.data.reduce((prev, curr) => {
-        const datum = accessor(curr);
-        return typeof datum === "string" && prev.indexOf(datum) === -1 ? prev.concat(datum) : prev;
-      }, []) : undefined;
-    };
-
-    return props.data ?
-      getStrings(props) : childComponents.map((child) => getStrings(child.props));
+    return props.categories && !Array.isArray(props.categories) ?
+      props.categories[axis] : props.categories;
   },
 
   // for components that take single datasets
@@ -79,7 +44,7 @@ export default {
     if (props.data) {
       return this.formatData(props.data, props);
     }
-    const data = this.generateData(props);
+    const data = (props.x || props.y) && this.generateData(props);
     return this.formatData(data, props);
   },
 

--- a/src/helpers/wrapper.js
+++ b/src/helpers/wrapper.js
@@ -194,7 +194,7 @@ export default {
 
   getStringsFromChildren(props, axis, childComponents) {
     childComponents = childComponents || React.Children.toArray(props.children);
-    const axisComponent = Axis.getAxisComponent(props, axis, childComponents);
+    const axisComponent = Axis.getAxisComponent(childComponents, axis);
     const axisStrings = axisComponent ? Data.getStringsFromAxes(axisComponent.props, axis) : [];
     const categoryStrings = this.getStringsFromCategories(childComponents, axis);
     const dataStrings = this.getStringsFromData(childComponents, axis);

--- a/test/client/spec/helpers/axis.spec.js
+++ b/test/client/spec/helpers/axis.spec.js
@@ -3,24 +3,11 @@
 
 import Axis from "src/helpers/axis";
 import React from "react";
-import { VictoryAxis, VictoryBar, VictoryLine } from "src/index";
+import { VictoryAxis, VictoryBar } from "src/index";
 
 describe("helpers/axis", () => {
   const getVictoryAxis = (props) => React.createElement(VictoryAxis, props);
   const getVictoryBar = (props) => React.createElement(VictoryBar, props);
-  const getVictoryLine = (props) => React.createElement(VictoryLine, props);
-
-  describe("getAxisType", () => {
-    it("returns dependent or independent for an axis component", () => {
-      const child = getVictoryAxis({dependentAxis: true});
-      expect(Axis.getAxisType(child)).to.equal("dependent");
-    });
-
-    it("returns undefined for other components", () => {
-      const child = getVictoryLine({});
-      expect(Axis.getAxisType(child)).to.be.undefined;
-    });
-  });
 
   describe("isVertical", () => {
     it("returns true when the orientation is vertical", () => {
@@ -53,8 +40,9 @@ describe("helpers/axis", () => {
     });
 
     it("returns the independent axis when called with 'x'", () => {
+      const props = {};
       const childComponents = [dependentAxis, independentAxis, bar];
-      const componentResult = Axis.getAxisComponent(childComponents, "x");
+      const componentResult = Axis.getAxisComponent(props, "x", childComponents);
       expect(dependentAxis.type.getAxis).calledWith(dependentAxis.props, false)
         .and.returned("y");
       expect(independentAxis.type.getAxis).calledWith(independentAxis.props, false)
@@ -63,8 +51,9 @@ describe("helpers/axis", () => {
     });
 
     it("returns the dependent axis when called with 'x' and flipped data", () => {
+      const props = {};
       const childComponents = [dependentAxis, independentAxis, horizontalBar];
-      const componentResult = Axis.getAxisComponent(childComponents, "x");
+      const componentResult = Axis.getAxisComponent(props, "x", childComponents);
       expect(dependentAxis.type.getAxis).calledWith(dependentAxis.props, true)
         .and.returned("x");
       expect(independentAxis.type.getAxis).calledWith(independentAxis.props, true)

--- a/test/client/spec/helpers/axis.spec.js
+++ b/test/client/spec/helpers/axis.spec.js
@@ -40,9 +40,8 @@ describe("helpers/axis", () => {
     });
 
     it("returns the independent axis when called with 'x'", () => {
-      const props = {};
       const childComponents = [dependentAxis, independentAxis, bar];
-      const componentResult = Axis.getAxisComponent(props, "x", childComponents);
+      const componentResult = Axis.getAxisComponent(childComponents, "x");
       expect(dependentAxis.type.getAxis).calledWith(dependentAxis.props, false)
         .and.returned("y");
       expect(independentAxis.type.getAxis).calledWith(independentAxis.props, false)
@@ -51,9 +50,8 @@ describe("helpers/axis", () => {
     });
 
     it("returns the dependent axis when called with 'x' and flipped data", () => {
-      const props = {};
       const childComponents = [dependentAxis, independentAxis, horizontalBar];
-      const componentResult = Axis.getAxisComponent(props, "x", childComponents);
+      const componentResult = Axis.getAxisComponent(childComponents, "x");
       expect(dependentAxis.type.getAxis).calledWith(dependentAxis.props, true)
         .and.returned("x");
       expect(independentAxis.type.getAxis).calledWith(independentAxis.props, true)

--- a/test/client/spec/helpers/data.spec.js
+++ b/test/client/spec/helpers/data.spec.js
@@ -2,6 +2,7 @@
 /* global sinon */
 
 import Data from "src/helpers/data";
+import { Helpers } from "victory-core";
 
 describe("helpers/data", () => {
   describe("createStringMap", () => {
@@ -10,7 +11,7 @@ describe("helpers/data", () => {
       sandbox = sinon.sandbox.create();
       sandbox.spy(Data, "getStringsFromAxes");
       sandbox.spy(Data, "getStringsFromCategories");
-      sandbox.spy(Data, "getStringsFromData");
+      sandbox.spy(Helpers, "getStringsFromData");
     });
     afterEach(() => {
       sandbox.restore();
@@ -38,8 +39,8 @@ describe("helpers/data", () => {
     it("returns a string map from strings in data", () => {
       const props = {data};
       const stringMap = Data.createStringMap(props, "x");
-      expect(Data.getStringsFromData).calledWith(props, "x");
-      expect(Data.getStringsFromData).to.have.returned(["one", "red", "cat"]);
+      expect(Helpers.getStringsFromData).calledWith(props, "x");
+      expect(Helpers.getStringsFromData).to.have.returned(["one", "red", "cat"]);
       expect(stringMap).to.eql({ one: 1, red: 2, cat: 3 });
     });
 
@@ -47,47 +48,11 @@ describe("helpers/data", () => {
       const props = {tickValues, data};
       const stringMap = Data.createStringMap(props, "x");
       expect(Data.getStringsFromAxes).to.have.returned(["one", "two", "three"]);
-      expect(Data.getStringsFromData).to.have.returned(["one", "red", "cat"]);
+      expect(Helpers.getStringsFromData).to.have.returned(["one", "red", "cat"]);
       expect(stringMap).to.eql({ one: 1, two: 2, three: 3, red: 4, cat: 5 });
     });
   });
 
-  describe("getStringsFromData", () => {
-    let sandbox;
-    beforeEach(() => {
-      sandbox = sinon.sandbox.create();
-      sandbox.spy(Data, "getStringsFromData");
-    });
-    afterEach(() => {
-      sandbox.restore();
-    });
-
-    it("returns an array of strings from a data prop", () => {
-      const props = {data: [{x: "one", y: 1}, {x: "red", y: 2}, {x: "cat", y: 3}]};
-      const dataStrings = Data.getStringsFromData(props, "x");
-      expect(dataStrings).to.eql(["one", "red", "cat"]);
-    });
-
-    it("returns an array of strings from array-type data", () => {
-      const props = {data: [["one", 1], ["red", 2], ["cat", 3]], x: 0, y: 1};
-      const dataStrings = Data.getStringsFromData(props, "x");
-      expect(dataStrings).to.eql(["one", "red", "cat"]);
-    });
-
-    it("only returns strings, if data is mixed", () => {
-      const props = {data: [{x: 1, y: 1}, {x: "three", y: 3}]};
-      expect(Data.getStringsFromData(props, "x")).to.eql(["three"]);
-    });
-
-    it("returns an empty array when no strings are present", () => {
-      const props = {data: [{x: 1, y: 1}, {x: 3, y: 3}]};
-      expect(Data.getStringsFromData(props, "x")).to.eql([]);
-    });
-
-    it("returns an empty array when the data prop is undefined", () => {
-      expect(Data.getStringsFromData({}, "x")).to.eql([]);
-    });
-  });
 
   describe("getStringsFromAxes", () => {
     it("returns an array of strings when tickValues is an array", () => {

--- a/test/client/spec/helpers/wrapper.spec.js
+++ b/test/client/spec/helpers/wrapper.spec.js
@@ -1,7 +1,16 @@
 /* eslint no-unused-expressions: 0 */
+/* global sinon */
+
 import Wrapper from "src/helpers/wrapper";
+import React from "react";
+import { VictoryAxis, VictoryLine } from "src/index";
+import Domain from "src/helpers/domain";
+
 
 describe("helpers/wrapper", () => {
+  const getVictoryLine = (props) => React.createElement(VictoryLine, props);
+  const getVictoryAxis = (props) => React.createElement(VictoryAxis, props);
+
   describe("getY0", () => {
     const data = [
       [{x: 1, y: 0}, {x: 2, y: 0}, {x: 3, y: 0}],
@@ -21,6 +30,83 @@ describe("helpers/wrapper", () => {
     it("returns the sum of the previous data sets only when data is the same sign", () => {
       const result = Wrapper.getY0({x: 2, y: -2}, 3, {datasets: mixedData});
       expect(result).to.eql(-1);
+    });
+  });
+
+  describe("getDomain", () => {
+    const victoryLine = getVictoryLine({domain: [0, 3]});
+    const xAxis = getVictoryAxis({dependentAxis: false});
+    const yAxis = getVictoryAxis({dependentAxis: true});
+    const childComponents = [victoryLine, xAxis, yAxis];
+    let sandbox;
+    beforeEach(() => {
+      sandbox = sinon.sandbox.create();
+      sandbox.spy(Wrapper, "getDomainFromChildren");
+      sandbox.spy(Domain, "padDomain");
+      sandbox.spy(victoryLine.type, "getDomain");
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it("calculates a domain from props", () => {
+      const props = {domain: {x: [1, 2], y: [2, 3]}};
+      const domainResultX = Wrapper.getDomain(props, "x", childComponents);
+      expect(Domain.padDomain).calledWith([1, 2], props, "x").and.returned([1, 2]);
+      expect(victoryLine.type.getDomain).notCalled;
+      expect(domainResultX).to.eql([1, 2]);
+    });
+
+    it("calculates a domain from child components", () => {
+      const props = {children: childComponents};
+      const domainResultX = Wrapper.getDomain(props, "x", childComponents);
+      expect(Wrapper.getDomainFromChildren).calledWith(childComponents, "x");
+      expect(victoryLine.type.getDomain).calledWith(victoryLine.props);
+      expect(Domain.padDomain).calledWith(victoryLine.props.domain, props, "x")
+        .and.returned(victoryLine.props.domain);
+      expect(domainResultX).to.eql(victoryLine.props.domain);
+    });
+  });
+
+  describe("getStringsFromData", () => {
+    let sandbox;
+    beforeEach(() => {
+      sandbox = sinon.sandbox.create();
+      sandbox.spy(Wrapper, "getStringsFromData");
+    });
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it("returns an array of strings from a data prop", () => {
+      const props = {data: [{x: "one", y: 1}, {x: "red", y: 2}, {x: "cat", y: 3}]};
+      const childComponents = [getVictoryLine(props)];
+      const dataStrings = Wrapper.getStringsFromData(childComponents, "x");
+      expect(dataStrings).to.eql(["one", "red", "cat"]);
+    });
+
+    it("returns an array of strings from array-type data", () => {
+      const props = {data: [["one", 1], ["red", 2], ["cat", 3]], x: 0, y: 1};
+      const childComponents = [getVictoryLine(props)];
+      const dataStrings = Wrapper.getStringsFromData(childComponents, "x");
+      expect(dataStrings).to.eql(["one", "red", "cat"]);
+    });
+
+    it("only returns strings, if data is mixed", () => {
+      const props = {data: [{x: 1, y: 1}, {x: "three", y: 3}]};
+      const childComponents = [getVictoryLine(props)];
+      expect(Wrapper.getStringsFromData(childComponents, "x")).to.eql(["three"]);
+    });
+
+    it("returns an empty array when no strings are present", () => {
+      const props = {data: [{x: 1, y: 1}, {x: 3, y: 3}]};
+      const childComponents = [getVictoryLine(props)];
+      expect(Wrapper.getStringsFromData(childComponents, "x")).to.eql([]);
+    });
+
+    it("returns an empty array when no children are given", () => {
+      expect(Wrapper.getStringsFromData([], "x")).to.eql([]);
     });
   });
 


### PR DESCRIPTION
This PR addresses issues related to wrapping victory components and having their static methods etc. become unavailable for `VictoryChart`, `VictoryGroup` and `VictoryStack` to use