### PR TITLE
adding VectorEffect to axes, gridlines, tick marks, line chart lines

### DIFF
--- a/src/components/victory-axis/axis-line.js
+++ b/src/components/victory-axis/axis-line.js
@@ -15,6 +15,7 @@ export default class AxisLine extends React.Component {
     return (
       <line
         x1={x1} x2={x2} y1={y1} y2={y2} style={style}
+        vectorEffect="non-scaling-stroke"
         {...events}
       />
     );

--- a/src/components/victory-axis/grid.js
+++ b/src/components/victory-axis/grid.js
@@ -21,6 +21,7 @@ export default class GridLine extends React.Component {
         x2={x2}
         y2={y2}
         style={style}
+        vectorEffect="non-scaling-stroke"
       />
     );
   }

--- a/src/components/victory-axis/tick.js
+++ b/src/components/victory-axis/tick.js
@@ -21,6 +21,7 @@ export default class Tick extends React.Component {
         x2={x2}
         y2={y2}
         style={style}
+        vectorEffect="non-scaling-stroke"
       />
     );
   }

--- a/src/components/victory-line/line-segment.js
+++ b/src/components/victory-line/line-segment.js
@@ -26,7 +26,7 @@ export default class LineSegment extends React.Component {
       .y((d) => yScale(d.y));
     const path = lineFunction(data);
     return (
-      <path style={style} d={path} {...events}/>
+      <path style={style} d={path} {...events} vectorEffect="non-scaling-stroke"/>
     );
   }
 }


### PR DESCRIPTION
Ok! Third time is hopefully the charm. I applied vectorEffect="non-scaling-stroke" to axis lines, grid lines, tick marks, and lines for line charts. Seems to be working great. We still need to figure out if/how we are going to handle text scaling, but that may make sense as a separate issue? If this all looks good I'll close the open PR for this on victory-core.

fixes [FormidableLabs/victory#238 ](www.github.com/formidablelabs/victory/issues/238)