### PR TITLE
adding aria support to charts in victory-chart

### DIFF
--- a/demo/components/victory-area-demo.js
+++ b/demo/components/victory-area-demo.js
@@ -101,8 +101,6 @@ export default class App extends React.Component {
         <VictoryArea
           style={style} animate={{duration: 1000}}
           data={this.state.areaTransitionData}
-          title="What a great title!"
-          desc="And a descriptive description!"
         />
 
         <VictoryStack

--- a/demo/components/victory-area-demo.js
+++ b/demo/components/victory-area-demo.js
@@ -101,6 +101,8 @@ export default class App extends React.Component {
         <VictoryArea
           style={style} animate={{duration: 1000}}
           data={this.state.areaTransitionData}
+          title="What a great title!"
+          desc="And a descriptive description!"
         />
 
         <VictoryStack

--- a/demo/components/victory-area-demo.js
+++ b/demo/components/victory-area-demo.js
@@ -2,6 +2,7 @@
 import React from "react";
 import { merge, random, range } from "lodash";
 import {VictoryArea, VictoryStack, VictoryGroup} from "../../src/index";
+import { VictoryContainer } from "victory-core";
 
 export default class App extends React.Component {
   constructor() {
@@ -101,19 +102,36 @@ export default class App extends React.Component {
         <VictoryArea
           style={style} animate={{duration: 1000}}
           data={this.state.areaTransitionData}
+          containerComponent={
+            <VictoryContainer
+              title="Area Chart"
+              desc="This is an animated area chart that displays data."
+            />
+          }
         />
 
         <VictoryStack
           style={style}
           animate={{duration: 1000}}
           colorScale={"warm"}
+          containerComponent={
+            <VictoryContainer
+              desc="This is an animated area chart that displays data in a range of colors."
+            />
+          }
         >
           {this.state.multiTransitionData.map((data, index) => {
-            return <VictoryArea key={index} data={data} interpolation={"basis"}/>;
+            return (
+              <VictoryArea
+                key={index}
+                data={data}
+                interpolation={"basis"}
+              />
+            );
           })}
         </VictoryStack>
 
-        <VictoryArea style={style}/>
+        <VictoryArea style={style} />
 
         <VictoryArea
           style={{parent: style.parent, data: this.state.style}}

--- a/demo/components/victory-axis-demo.js
+++ b/demo/components/victory-axis-demo.js
@@ -3,6 +3,7 @@ import React from "react";
 import {VictoryAxis} from "../../src/index";
 import {VictoryLabel} from "victory-core";
 import { merge, random, range } from "lodash";
+import { VictoryContainer } from "victory-core";
 
 export default class App extends React.Component {
   constructor() {
@@ -73,6 +74,12 @@ export default class App extends React.Component {
             tickValues={this.state.tickValues}
             tickFormat={["first", "second", "third", "fourth", "fifth"]}
             animate={{duration: 2000}}
+            containerComponent={
+              <VictoryContainer
+                title="Axis Example"
+                desc="This is an example of an animating axis."
+              />
+            }
           />
         </div>
         <div>
@@ -84,6 +91,11 @@ export default class App extends React.Component {
               axis: {strokeWidth: 4},
               grid: {stroke: "black", strokeWidth: 5}
             }}
+            containerComponent={
+              <VictoryContainer
+                title="Time Scale Axis Example"
+              />
+            }
             events={[
               {
                 target: "grid",

--- a/demo/components/victory-bar-demo.js
+++ b/demo/components/victory-bar-demo.js
@@ -3,6 +3,7 @@ import React from "react";
 import {VictoryBar, VictoryChart, VictoryGroup, VictoryStack } from "../../src/index";
 import { VictorySharedEvents } from "victory-core";
 import { assign, random, range, merge } from "lodash";
+import { VictoryContainer } from "victory-core";
 
 class Wrapper extends React.Component {
   static propTypes = {
@@ -128,6 +129,12 @@ export default class App extends React.Component {
               duration: 500
             }
           }}
+          containerComponent={
+              <VictoryContainer
+                title="Bar Chart"
+                desc="This is an animated bar chart that displays data with labels."
+              />
+            }
           events={[{
             target: "data",
             eventHandlers: {

--- a/demo/components/victory-chart-demo.js
+++ b/demo/components/victory-chart-demo.js
@@ -5,7 +5,7 @@ import {
   VictoryChart, VictoryLine, VictoryAxis, VictoryBar, VictoryArea,
   VictoryScatter, VictoryStack, VictoryGroup
 } from "../../src/index";
-import { VictoryLabel } from "victory-core";
+import { VictoryLabel, VictoryContainer } from "victory-core";
 import { assign } from "lodash";
 
 
@@ -172,7 +172,15 @@ class App extends React.Component {
       <div className="demo">
         <h1>VictoryChart</h1>
         <div style={containerStyle}>
-          <VictoryChart style={chartStyle} animate={{ duration: 1500 }}>
+          <VictoryChart
+            style={chartStyle}
+            animate={{ duration: 1500 }}
+            containerComponent={
+              <VictoryContainer
+                desc="This is an example of a bar chart wrapped in Victory Chart."
+              />
+            }
+          >
           <Wrapper>
             <VictoryBar
               data={this.state.barTransitionData}

--- a/demo/components/victory-line-demo.js
+++ b/demo/components/victory-line-demo.js
@@ -4,6 +4,7 @@ import { merge, random, range } from "lodash";
 import {VictoryLine} from "../../src/index";
 import LineSegment from "../../src/components/victory-line/line-segment";
 import Point from "../../src/components/victory-scatter/point";
+import { VictoryContainer } from "victory-core";
 
 class PointedLine extends React.Component {
   static propTypes = {
@@ -118,6 +119,12 @@ export default class App extends React.Component {
             style={{parent: parentStyle, data: this.state.style}}
             data={this.state.transitionData}
             animate={{duration: 800}}
+            containerComponent={
+              <VictoryContainer
+                title="Line Chart"
+                desc="This is a line chart for displaying data."
+              />
+            }
           />
 
         <VictoryLine

--- a/demo/components/victory-scatter-demo.js
+++ b/demo/components/victory-scatter-demo.js
@@ -98,6 +98,7 @@ export default class App extends React.Component {
   render() {
     return (
       <div className="demo">
+      <VictoryContainer />
         <h1>VictoryScatter</h1>
         <VictoryScatter
           style={style}
@@ -111,6 +112,7 @@ export default class App extends React.Component {
               <VictoryContainer
                 title="Scatter Chart"
                 desc="This is a scatter chart with cat data points!"
+                style={{border: "1px solid red"}}
               />
             }
         />

--- a/demo/components/victory-scatter-demo.js
+++ b/demo/components/victory-scatter-demo.js
@@ -5,6 +5,7 @@ import {VictoryScatter} from "../../src/index";
 import {VictoryLabel} from "victory-core";
 import bubbleData from "./bubble-data.js";
 import symbolData from "./symbol-data.js";
+import { VictoryContainer } from "victory-core";
 
 const getData = () => {
   const colors =
@@ -106,6 +107,12 @@ export default class App extends React.Component {
           animate={{duration: 2000}}
           data={this.state.data}
           dataComponent={<CatPoint />}
+          containerComponent={
+              <VictoryContainer
+                title="Scatter Chart"
+                desc="This is a scatter chart with cat data points!"
+              />
+            }
         />
 
         <VictoryScatter

--- a/src/components/victory-area/victory-area.js
+++ b/src/components/victory-area/victory-area.js
@@ -283,7 +283,19 @@ export default class VictoryArea extends React.Component {
       PropTypes.string,
       PropTypes.arrayOf(PropTypes.string),
       PropTypes.arrayOf(PropTypes.func)
-    ])
+    ]),
+    /**
+     * The title prop allows the user to specify a title for their chart for accessibility purposes.
+     * This more descriptive this is, the better it is for screen readers.
+     * This prop will default to "Area Chart".
+     */
+     title: PropTypes.string,
+     /**
+     * The desc prop allows the user to specify a description of their chart for accessibility purposes.
+     * This more descriptive this is, the better it is for screen readers.
+     * This prop will default to "This is an area chart that displays data."
+     */
+     desc: PropTypes.string
   };
 
   static defaultProps = {
@@ -297,7 +309,9 @@ export default class VictoryArea extends React.Component {
     interpolation: "linear",
     width: 450,
     x: "x",
-    y: "y"
+    y: "y",
+    title: "Area Chart",
+    desc: "This is an area chart that displays data."
   };
 
   static getDomain = Domain.getDomainWithZero.bind(Domain);
@@ -376,12 +390,16 @@ export default class VictoryArea extends React.Component {
       "auto",
       "100%"
     );
-    const group = <g style={style.parent}>{this.renderArea(this.props)}</g>;
+    const group = <g role="presentation" style={style.parent}>{this.renderArea(this.props)}</g>;
     return this.props.standalone ?
       <svg
         style={style.parent}
         viewBox={`0 0 ${this.props.width} ${this.props.height}`}
+        role="img"
+        aria-labelledby="title desc"
       >
+        <title  id="title">{this.props.title}</title>
+        <desc id="desc">{this.props.desc}</desc>
         {group}
       </svg> :
       group;

--- a/src/components/victory-area/victory-area.js
+++ b/src/components/victory-area/victory-area.js
@@ -3,7 +3,8 @@ import React, { PropTypes } from "react";
 import Data from "../../helpers/data";
 import Domain from "../../helpers/domain";
 import {
-  PropTypes as CustomPropTypes, Helpers, Events, VictoryTransition, VictoryLabel
+  PropTypes as CustomPropTypes, Helpers, Events, VictoryTransition, VictoryLabel,
+  VictoryContainer
 } from "victory-core";
 import Area from "./area";
 import AreaHelpers from "./helper-methods";
@@ -285,17 +286,20 @@ export default class VictoryArea extends React.Component {
       PropTypes.arrayOf(PropTypes.func)
     ]),
     /**
-     * The title prop allows the user to specify a title for their chart for accessibility purposes.
-     * This more descriptive this is, the better it is for screen readers.
-     * This prop will default to "Area Chart".
+     * The containerComponent prop takes an entire component which will be used to surround
+     * a nested chart component unless the standalone prop is set to true.
+     * The container component will be provided the following properties calculated by
+     * the chart component it surrounds: height, width, a child component (the chart itself) and style.
+     * Props that are not provided by the child chart component include title and desc, both of which
+     * are intended to add accessibility to Victory components. The more descriptive these props
+     * are, the more accessible your data will be for people using screen readers.
+     * Any of these props may be overridden by passing in props to the supplied component,
+     * or modified or ignored within the custom component itself. If a dataComponent is
+     * not provided, VictoryChart will use the default VictoryContainer component.
+     * @example <VictoryContainer title="Chart of Dog Breeds" desc="This chart shows how
+     * popular each dog breed is by percentage in Seattle." />
      */
-     title: PropTypes.string,
-     /**
-     * The desc prop allows the user to specify a description of their chart for accessibility purposes.
-     * This more descriptive this is, the better it is for screen readers.
-     * This prop will default to "This is an area chart that displays data."
-     */
-     desc: PropTypes.string
+    containerComponent: PropTypes.element
   };
 
   static defaultProps = {
@@ -310,8 +314,7 @@ export default class VictoryArea extends React.Component {
     width: 450,
     x: "x",
     y: "y",
-    title: "Area Chart",
-    desc: "This is an area chart that displays data."
+    containerComponent: <VictoryContainer />
   };
 
   static getDomain = Domain.getDomainWithZero.bind(Domain);
@@ -392,16 +395,10 @@ export default class VictoryArea extends React.Component {
     );
     const group = <g role="presentation" style={style.parent}>{this.renderArea(this.props)}</g>;
     return this.props.standalone ?
-      <svg
-        style={style.parent}
-        viewBox={`0 0 ${this.props.width} ${this.props.height}`}
-        role="img"
-        aria-labelledby="title desc"
-      >
-        <title  id="title">{this.props.title}</title>
-        <desc id="desc">{this.props.desc}</desc>
-        {group}
-      </svg> :
+      React.cloneElement(
+        this.props.containerComponent,
+        Object.assign({height: this.props.height, width: this.props.width, style: style.parent}, this.props.containerComponent.props),
+        group) :
       group;
   }
 }

--- a/src/components/victory-area/victory-area.js
+++ b/src/components/victory-area/victory-area.js
@@ -289,8 +289,9 @@ export default class VictoryArea extends React.Component {
      * The containerComponent prop takes an entire component which will be used to surround
      * a nested chart component unless the standalone prop is set to true.
      * The container component will be provided the following properties calculated by
-     * the chart component it surrounds: height, width, a child component (the chart itself) and style.
-     * Props that are not provided by the child chart component include title and desc, both of which
+     * the chart component it surrounds: height, width, a child component
+     * (the chart itself) and style. Props that are not provided by the
+     * child chart component include title and desc, both of which
      * are intended to add accessibility to Victory components. The more descriptive these props
      * are, the more accessible your data will be for people using screen readers.
      * Any of these props may be overridden by passing in props to the supplied component,
@@ -397,7 +398,10 @@ export default class VictoryArea extends React.Component {
     return this.props.standalone ?
       React.cloneElement(
         this.props.containerComponent,
-        Object.assign({height: this.props.height, width: this.props.width, style: style.parent}, this.props.containerComponent.props),
+        Object.assign({
+          height: this.props.height,
+          width: this.props.width,
+          style: style.parent}, this.props.containerComponent.props),
         group) :
       group;
   }

--- a/src/components/victory-area/victory-area.js
+++ b/src/components/victory-area/victory-area.js
@@ -192,7 +192,7 @@ export default class VictoryArea extends React.Component {
      * by passing in props to the supplied component, or modified or ignored within
      * the custom component itself. If labelComponent is omitted, a new VictoryLabel
      * will be created with props described above. This labelComponent prop should be used to
-     * provide a series label for VictoryLine. If individual labels are required for each
+     * provide a series label for VictoryArea. If individual labels are required for each
      * data point, they should be created by composing VictoryArea with VictoryScatter
      */
     labelComponent: PropTypes.element,
@@ -286,17 +286,17 @@ export default class VictoryArea extends React.Component {
       PropTypes.arrayOf(PropTypes.func)
     ]),
     /**
-     * The containerComponent prop takes an entire component which will be used to surround
-     * a nested chart component unless the standalone prop is set to true.
-     * The container component will be provided the following properties calculated by
-     * the chart component it surrounds: height, width, a child component
+     * The containerComponent prop takes an entire component which will be used to
+     * create a container element for standalone charts.
+     * The new element created from the passed containerComponent wil be provided with
+     * these props from VictoryArea: height, width, children
      * (the chart itself) and style. Props that are not provided by the
      * child chart component include title and desc, both of which
      * are intended to add accessibility to Victory components. The more descriptive these props
      * are, the more accessible your data will be for people using screen readers.
      * Any of these props may be overridden by passing in props to the supplied component,
      * or modified or ignored within the custom component itself. If a dataComponent is
-     * not provided, VictoryChart will use the default VictoryContainer component.
+     * not provided, VictoryArea will use the default VictoryContainer component.
      * @example <VictoryContainer title="Chart of Dog Breeds" desc="This chart shows how
      * popular each dog breed is by percentage in Seattle." />
      */

--- a/src/components/victory-axis/victory-axis.js
+++ b/src/components/victory-axis/victory-axis.js
@@ -297,12 +297,12 @@ export default class VictoryAxis extends React.Component {
      */
     width: CustomPropTypes.nonNegative,
     /**
-     * The containerComponent prop takes an entire component which will be used to surround
-     * a nested chart component unless the standalone prop is set to true.
-     * The container component will be provided the following properties calculated by
-     * the chart component it surrounds: height, width, a child component (the chart itself)
-     * and style. Props that are not provided by the child
-     * chart component include title and desc, both of which
+     * The containerComponent prop takes an entire component which will be used to
+     * create a container element for standalone charts.
+     * The new element created from the passed containerComponent wil be provided with
+     * these props from VictoryAxis: height, width, children
+     * (the chart itself) and style. Props that are not provided by the
+     * child chart component include title and desc, both of which
      * are intended to add accessibility to Victory components. The more descriptive these props
      * are, the more accessible your data will be for people using screen readers.
      * Any of these props may be overridden by passing in props to the supplied component,

--- a/src/components/victory-axis/victory-axis.js
+++ b/src/components/victory-axis/victory-axis.js
@@ -1,7 +1,8 @@
 import { defaults, isFunction, partialRight, omit } from "lodash";
 import React, { PropTypes } from "react";
 import {
-  PropTypes as CustomPropTypes, Helpers, Events, VictoryTransition, VictoryLabel
+  PropTypes as CustomPropTypes, Helpers, Events, VictoryTransition, VictoryLabel,
+  VictoryContainer
 } from "victory-core";
 import AxisLine from "./axis-line";
 import GridLine from "./grid";
@@ -294,7 +295,22 @@ export default class VictoryAxis extends React.Component {
      * The width props specifies the width of the svg viewBox of the chart container
      * This value should be given as a number of pixels
      */
-    width: CustomPropTypes.nonNegative
+    width: CustomPropTypes.nonNegative,
+    /**
+     * The containerComponent prop takes an entire component which will be used to surround
+     * a nested chart component unless the standalone prop is set to true.
+     * The container component will be provided the following properties calculated by
+     * the chart component it surrounds: height, width, a child component (the chart itself) and style.
+     * Props that are not provided by the child chart component include title and desc, both of which
+     * are intended to add accessibility to Victory components. The more descriptive these props
+     * are, the more accessible your data will be for people using screen readers.
+     * Any of these props may be overridden by passing in props to the supplied component,
+     * or modified or ignored within the custom component itself. If a dataComponent is
+     * not provided, VictoryAxis will use the default VictoryContainer component.
+     * @example <VictoryContainer title="Chart of Dog Breeds" desc="This chart shows how
+     * popular each dog breed is by percentage in Seattle." />
+     */
+    containerComponent: PropTypes.element
   };
 
   static defaultProps = {
@@ -308,7 +324,8 @@ export default class VictoryAxis extends React.Component {
     scale: "linear",
     standalone: true,
     tickCount: 5,
-    width: 450
+    width: 450,
+    containerComponent: <VictoryContainer />
   };
 
   static getDomain = AxisHelpers.getDomain.bind(AxisHelpers);
@@ -443,12 +460,10 @@ export default class VictoryAxis extends React.Component {
       </g>
     );
     return this.props.standalone ? (
-      <svg
-        style={style.parent}
-        viewBox={`0 0 ${this.props.width} ${this.props.height}`}
-      >
-        {group}
-      </svg>
-    ) : group;
+      React.cloneElement(
+        this.props.containerComponent,
+        Object.assign({height: this.props.height, width: this.props.width, style: style.parent}, this.props.containerComponent.props),
+        group) 
+      ): group;
   }
 }

--- a/src/components/victory-axis/victory-axis.js
+++ b/src/components/victory-axis/victory-axis.js
@@ -300,8 +300,9 @@ export default class VictoryAxis extends React.Component {
      * The containerComponent prop takes an entire component which will be used to surround
      * a nested chart component unless the standalone prop is set to true.
      * The container component will be provided the following properties calculated by
-     * the chart component it surrounds: height, width, a child component (the chart itself) and style.
-     * Props that are not provided by the child chart component include title and desc, both of which
+     * the chart component it surrounds: height, width, a child component (the chart itself)
+     * and style. Props that are not provided by the child
+     * chart component include title and desc, both of which
      * are intended to add accessibility to Victory components. The more descriptive these props
      * are, the more accessible your data will be for people using screen readers.
      * Any of these props may be overridden by passing in props to the supplied component,
@@ -462,8 +463,11 @@ export default class VictoryAxis extends React.Component {
     return this.props.standalone ? (
       React.cloneElement(
         this.props.containerComponent,
-        Object.assign({height: this.props.height, width: this.props.width, style: style.parent}, this.props.containerComponent.props),
-        group) 
-      ): group;
+        Object.assign({
+          height: this.props.height,
+          width: this.props.width,
+          style: style.parent}, this.props.containerComponent.props),
+        group)
+      ) : group;
   }
 }

--- a/src/components/victory-bar/victory-bar.js
+++ b/src/components/victory-bar/victory-bar.js
@@ -292,12 +292,12 @@ export default class VictoryBar extends React.Component {
       PropTypes.arrayOf(PropTypes.string)
     ]),
     /**
-     * The containerComponent prop takes an entire component which will be used to surround
-     * a nested chart component unless the standalone prop is set to true.
-     * The container component will be provided the following properties calculated by
-     * the chart component it surrounds: height, width, a child component (the chart itself)
-     * and style. Props that are not provided by the child
-     * chart component include title and desc, both of which
+     * The containerComponent prop takes an entire component which will be used to
+     * create a container element for standalone charts.
+     * The new element created from the passed containerComponent wil be provided with
+     * these props from VictoryBar: height, width, children
+     * (the chart itself) and style. Props that are not provided by the
+     * child chart component include title and desc, both of which
      * are intended to add accessibility to Victory components. The more descriptive these props
      * are, the more accessible your data will be for people using screen readers.
      * Any of these props may be overridden by passing in props to the supplied component,

--- a/src/components/victory-bar/victory-bar.js
+++ b/src/components/victory-bar/victory-bar.js
@@ -1,7 +1,8 @@
 import { defaults, isFunction, partialRight } from "lodash";
 import React, { PropTypes } from "react";
 import {
-  PropTypes as CustomPropTypes, Helpers, Events, VictoryTransition, VictoryLabel
+  PropTypes as CustomPropTypes, Helpers, Events, VictoryTransition, VictoryLabel,
+  VictoryContainer
 } from "victory-core";
 import Bar from "./bar";
 import BarHelpers from "./helper-methods";
@@ -291,17 +292,20 @@ export default class VictoryBar extends React.Component {
       PropTypes.arrayOf(PropTypes.string)
     ]),
     /**
-     * The title prop allows the user to specify a title for their chart for accessibility purposes.
-     * This more descriptive this is, the better it is for screen readers.
-     * This prop will default to "Bar Chart".
+     * The containerComponent prop takes an entire component which will be used to surround
+     * a nested chart component unless the standalone prop is set to true.
+     * The container component will be provided the following properties calculated by
+     * the chart component it surrounds: height, width, a child component (the chart itself) and style.
+     * Props that are not provided by the child chart component include title and desc, both of which
+     * are intended to add accessibility to Victory components. The more descriptive these props
+     * are, the more accessible your data will be for people using screen readers.
+     * Any of these props may be overridden by passing in props to the supplied component,
+     * or modified or ignored within the custom component itself. If a dataComponent is
+     * not provided, VictoryBar will use the default VictoryContainer component.
+     * @example <VictoryContainer title="Chart of Dog Breeds" desc="This chart shows how
+     * popular each dog breed is by percentage in Seattle." />
      */
-     title: PropTypes.string,
-     /**
-     * The desc prop allows the user to specify a description of their chart for accessibility purposes.
-     * This more descriptive this is, the better it is for screen readers.
-     * This prop will default to "This is a bar chart that displays data."
-     */
-     desc: PropTypes.string
+    containerComponent: PropTypes.element
   };
 
   static defaultProps = {
@@ -315,8 +319,7 @@ export default class VictoryBar extends React.Component {
     width: 450,
     x: "x",
     y: "y",
-    title: "Bar Chart",
-    desc: "This is a bar chart that displays data."
+    containerComponent: <VictoryContainer/>
   };
 
   static getDomain = Domain.getDomainWithZero.bind(Domain);
@@ -395,16 +398,10 @@ export default class VictoryBar extends React.Component {
     const style = Helpers.getStyles(this.props.style, defaultStyles, "auto", "100%");
     const group = <g style={style.parent} role="presentation">{this.renderData(this.props)}</g>;
     return this.props.standalone ?
-      <svg
-        style={style.parent}
-        viewBox={`0 0 ${this.props.width} ${this.props.height}`}
-        role="img"
-        aria-labelledby="title desc"
-      >
-        <title id="title">{this.props.title}</title>
-        <desc id="desc">{this.props.desc}</desc>
-        {group}
-      </svg> :
+      React.cloneElement(
+        this.props.containerComponent,
+        Object.assign({height: this.props.height, width: this.props.width, style: style.parent}, this.props.containerComponent.props),
+        group) :
       group;
   }
 }

--- a/src/components/victory-bar/victory-bar.js
+++ b/src/components/victory-bar/victory-bar.js
@@ -295,8 +295,9 @@ export default class VictoryBar extends React.Component {
      * The containerComponent prop takes an entire component which will be used to surround
      * a nested chart component unless the standalone prop is set to true.
      * The container component will be provided the following properties calculated by
-     * the chart component it surrounds: height, width, a child component (the chart itself) and style.
-     * Props that are not provided by the child chart component include title and desc, both of which
+     * the chart component it surrounds: height, width, a child component (the chart itself)
+     * and style. Props that are not provided by the child
+     * chart component include title and desc, both of which
      * are intended to add accessibility to Victory components. The more descriptive these props
      * are, the more accessible your data will be for people using screen readers.
      * Any of these props may be overridden by passing in props to the supplied component,
@@ -400,7 +401,10 @@ export default class VictoryBar extends React.Component {
     return this.props.standalone ?
       React.cloneElement(
         this.props.containerComponent,
-        Object.assign({height: this.props.height, width: this.props.width, style: style.parent}, this.props.containerComponent.props),
+        Object.assign({
+          height: this.props.height,
+          width: this.props.width,
+          style: style.parent}, this.props.containerComponent.props),
         group) :
       group;
   }

--- a/src/components/victory-bar/victory-bar.js
+++ b/src/components/victory-bar/victory-bar.js
@@ -289,7 +289,19 @@ export default class VictoryBar extends React.Component {
       CustomPropTypes.allOfType([CustomPropTypes.integer, CustomPropTypes.nonNegative]),
       PropTypes.string,
       PropTypes.arrayOf(PropTypes.string)
-    ])
+    ]),
+    /**
+     * The title prop allows the user to specify a title for their chart for accessibility purposes.
+     * This more descriptive this is, the better it is for screen readers.
+     * This prop will default to "Bar Chart".
+     */
+     title: PropTypes.string,
+     /**
+     * The desc prop allows the user to specify a description of their chart for accessibility purposes.
+     * This more descriptive this is, the better it is for screen readers.
+     * This prop will default to "This is a bar chart that displays data."
+     */
+     desc: PropTypes.string
   };
 
   static defaultProps = {
@@ -302,7 +314,9 @@ export default class VictoryBar extends React.Component {
     standalone: true,
     width: 450,
     x: "x",
-    y: "y"
+    y: "y",
+    title: "Bar Chart",
+    desc: "This is a bar chart that displays data."
   };
 
   static getDomain = Domain.getDomainWithZero.bind(Domain);
@@ -379,12 +393,16 @@ export default class VictoryBar extends React.Component {
       );
     }
     const style = Helpers.getStyles(this.props.style, defaultStyles, "auto", "100%");
-    const group = <g style={style.parent}>{this.renderData(this.props)}</g>;
+    const group = <g style={style.parent} role="presentation">{this.renderData(this.props)}</g>;
     return this.props.standalone ?
       <svg
         style={style.parent}
         viewBox={`0 0 ${this.props.width} ${this.props.height}`}
+        role="img"
+        aria-labelledby="title desc"
       >
+        <title id="title">{this.props.title}</title>
+        <desc id="desc">{this.props.desc}</desc>
         {group}
       </svg> :
       group;

--- a/src/components/victory-chart/victory-chart.js
+++ b/src/components/victory-chart/victory-chart.js
@@ -181,15 +181,16 @@ export default class VictoryChart extends React.Component {
      */
     width: CustomPropTypes.nonNegative,
     /**
-     * The containerComponent prop takes an entire component which will be used to surround
-     * a nested chart component unless the standalone prop is set to true.
-     * The container component will be provided the following properties calculated by
-     * the chart component it surrounds: height, width, a child component (the chart itself) and
-     * style. Props that are not provided by the child chart component include title and desc,
-     * both of which are intended to add accessibility to Victory components. The more
-     * descriptive these props are, the more accessible your data will be for people using
-     * screen readers. Any of these props may be overridden by passing in props to the supplied
-     * component, or modified or ignored within the custom component itself. If a dataComponent is
+     * The containerComponent prop takes an entire component which will be used to
+     * create a container element for standalone charts.
+     * The new element created from the passed containerComponent wil be provided with
+     * these props from VictoryChart: height, width, children
+     * (the chart itself) and style. Props that are not provided by the
+     * child chart component include title and desc, both of which
+     * are intended to add accessibility to Victory components. The more descriptive these props
+     * are, the more accessible your data will be for people using screen readers.
+     * Any of these props may be overridden by passing in props to the supplied component,
+     * or modified or ignored within the custom component itself. If a dataComponent is
      * not provided, VictoryChart will use the default VictoryContainer component.
      * @example <VictoryContainer title="Chart of Dog Breeds" desc="This chart shows how
      * popular each dog breed is by percentage in Seattle." />

--- a/src/components/victory-chart/victory-chart.js
+++ b/src/components/victory-chart/victory-chart.js
@@ -1,6 +1,6 @@
 import { defaults } from "lodash";
 import React, { PropTypes } from "react";
-import { PropTypes as CustomPropTypes, Helpers, VictorySharedEvents } from "victory-core";
+import { PropTypes as CustomPropTypes, Helpers, VictorySharedEvents, VictoryContainer } from "victory-core";
 import VictoryAxis from "../victory-axis/victory-axis";
 import ChartHelpers from "./helper-methods";
 import Axis from "../../helpers/axis";
@@ -178,14 +178,30 @@ export default class VictoryChart extends React.Component {
      * The width props specifies the width of the svg viewBox of the chart container
      * This value should be given as a number of pixels
      */
-    width: CustomPropTypes.nonNegative
+    width: CustomPropTypes.nonNegative,
+    /**
+     * The containerComponent prop takes an entire component which will be used to surround
+     * a nested chart component unless the standalone prop is set to true.
+     * The container component will be provided the following properties calculated by
+     * the chart component it surrounds: height, width, a child component (the chart itself) and style.
+     * Props that are not provided by the child chart component include title and desc, both of which
+     * are intended to add accessibility to Victory components. The more descriptive these props
+     * are, the more accessible your data will be for people using screen readers.
+     * Any of these props may be overridden by passing in props to the supplied component,
+     * or modified or ignored within the custom component itself. If a dataComponent is
+     * not provided, VictoryChart will use the default VictoryContainer component.
+     * @example <VictoryContainer title="Chart of Dog Breeds" desc="This chart shows how
+     * popular each dog breed is by percentage in Seattle." />
+     */
+    containerComponent: PropTypes.element
   };
 
   static defaultProps = {
     height: 300,
     width: 450,
     padding: 50,
-    standalone: true
+    standalone: true,
+    containerComponent: <VictoryContainer />
   };
 
   componentWillReceiveProps(nextProps) {
@@ -315,12 +331,10 @@ export default class VictoryChart extends React.Component {
     );
 
     return this.props.standalone ?
-      <svg
-        style={style.parent}
-        viewBox={`0 0 ${props.width} ${props.height}`}
-      >
-        {group}
-      </svg> :
+      React.cloneElement(
+        this.props.containerComponent,
+        Object.assign({height: this.props.height, width: this.props.width, style: style.parent}, this.props.containerComponent.props),
+        group) :
       group;
   }
 }

--- a/src/components/victory-chart/victory-chart.js
+++ b/src/components/victory-chart/victory-chart.js
@@ -1,6 +1,7 @@
 import { defaults } from "lodash";
 import React, { PropTypes } from "react";
-import { PropTypes as CustomPropTypes, Helpers, VictorySharedEvents, VictoryContainer } from "victory-core";
+import { PropTypes as CustomPropTypes, Helpers, VictorySharedEvents,
+ VictoryContainer } from "victory-core";
 import VictoryAxis from "../victory-axis/victory-axis";
 import ChartHelpers from "./helper-methods";
 import Axis from "../../helpers/axis";
@@ -183,12 +184,12 @@ export default class VictoryChart extends React.Component {
      * The containerComponent prop takes an entire component which will be used to surround
      * a nested chart component unless the standalone prop is set to true.
      * The container component will be provided the following properties calculated by
-     * the chart component it surrounds: height, width, a child component (the chart itself) and style.
-     * Props that are not provided by the child chart component include title and desc, both of which
-     * are intended to add accessibility to Victory components. The more descriptive these props
-     * are, the more accessible your data will be for people using screen readers.
-     * Any of these props may be overridden by passing in props to the supplied component,
-     * or modified or ignored within the custom component itself. If a dataComponent is
+     * the chart component it surrounds: height, width, a child component (the chart itself) and
+     * style. Props that are not provided by the child chart component include title and desc,
+     * both of which are intended to add accessibility to Victory components. The more
+     * descriptive these props are, the more accessible your data will be for people using
+     * screen readers. Any of these props may be overridden by passing in props to the supplied
+     * component, or modified or ignored within the custom component itself. If a dataComponent is
      * not provided, VictoryChart will use the default VictoryContainer component.
      * @example <VictoryContainer title="Chart of Dog Breeds" desc="This chart shows how
      * popular each dog breed is by percentage in Seattle." />
@@ -333,7 +334,10 @@ export default class VictoryChart extends React.Component {
     return this.props.standalone ?
       React.cloneElement(
         this.props.containerComponent,
-        Object.assign({height: this.props.height, width: this.props.width, style: style.parent}, this.props.containerComponent.props),
+        Object.assign({
+          height: this.props.height,
+          width: this.props.width,
+          style: style.parent}, this.props.containerComponent.props),
         group) :
       group;
   }

--- a/src/components/victory-group/victory-group.js
+++ b/src/components/victory-group/victory-group.js
@@ -1,6 +1,6 @@
 import { uniq } from "lodash";
 import React, { PropTypes } from "react";
-import { PropTypes as CustomPropTypes, Helpers, Log, VictorySharedEvents } from "victory-core";
+import { PropTypes as CustomPropTypes, Helpers, Log, VictorySharedEvents, VictoryContainer } from "victory-core";
 import Scale from "../../helpers/scale";
 import Wrapper from "../../helpers/wrapper";
 
@@ -241,7 +241,22 @@ export default class VictoryGroup extends React.Component {
      * The width props specifies the width of the svg viewBox of the chart container
      * This value should be given as a number of pixels
      */
-    width: CustomPropTypes.nonNegative
+    width: CustomPropTypes.nonNegative,
+    /**
+     * The containerComponent prop takes an entire component which will be used to surround
+     * a nested chart component unless the standalone prop is set to true.
+     * The container component will be provided the following properties calculated by
+     * the chart component it surrounds: height, width, a child component (the chart itself) and style.
+     * Props that are not provided by the child chart component include title and desc, both of which
+     * are intended to add accessibility to Victory components. The more descriptive these props
+     * are, the more accessible your data will be for people using screen readers.
+     * Any of these props may be overridden by passing in props to the supplied component,
+     * or modified or ignored within the custom component itself. If a dataComponent is
+     * not provided, VictoryGroup will use the default VictoryContainer component.
+     * @example <VictoryContainer title="Chart of Dog Breeds" desc="This chart shows how
+     * popular each dog breed is by percentage in Seattle." />
+     */
+    containerComponent: PropTypes.element
   };
 
   static defaultProps = {
@@ -250,7 +265,8 @@ export default class VictoryGroup extends React.Component {
     height: 300,
     width: 450,
     padding: 50,
-    standalone: true
+    standalone: true,
+    containerComponent: <VictoryContainer/>
   };
 
   static getDomain = Wrapper.getDomain.bind(Wrapper);
@@ -384,9 +400,10 @@ export default class VictoryGroup extends React.Component {
       </g>
     );
     return this.props.standalone ?
-      <svg style={style.parent} viewBox={`0 0 ${props.width} ${props.height}`}>
-        {group}
-      </svg> :
+      React.cloneElement(
+        this.props.containerComponent,
+        Object.assign({height: this.props.height, width: this.props.width, style: style.parent}, this.props.containerComponent.props),
+        group) :
       group;
   }
 }

--- a/src/components/victory-group/victory-group.js
+++ b/src/components/victory-group/victory-group.js
@@ -246,8 +246,9 @@ export default class VictoryGroup extends React.Component {
      * The containerComponent prop takes an entire component which will be used to surround
      * a nested chart component unless the standalone prop is set to true.
      * The container component will be provided the following properties calculated by
-     * the chart component it surrounds: height, width, a child component (the chart itself) and style.
-     * Props that are not provided by the child chart component include title and desc, both of which
+     * the chart component it surrounds: height, width, a child component (the chart itself)
+     * and style. Props that are not provided by the child
+     * chart component include title and desc, both of which
      * are intended to add accessibility to Victory components. The more descriptive these props
      * are, the more accessible your data will be for people using screen readers.
      * Any of these props may be overridden by passing in props to the supplied component,
@@ -402,7 +403,10 @@ export default class VictoryGroup extends React.Component {
     return this.props.standalone ?
       React.cloneElement(
         this.props.containerComponent,
-        Object.assign({height: this.props.height, width: this.props.width, style: style.parent}, this.props.containerComponent.props),
+        Object.assign({
+          height: this.props.height,
+          width: this.props.width,
+          style: style.parent}, this.props.containerComponent.props),
         group) :
       group;
   }

--- a/src/components/victory-group/victory-group.js
+++ b/src/components/victory-group/victory-group.js
@@ -244,12 +244,12 @@ export default class VictoryGroup extends React.Component {
      */
     width: CustomPropTypes.nonNegative,
     /**
-     * The containerComponent prop takes an entire component which will be used to surround
-     * a nested chart component unless the standalone prop is set to true.
-     * The container component will be provided the following properties calculated by
-     * the chart component it surrounds: height, width, a child component (the chart itself)
-     * and style. Props that are not provided by the child
-     * chart component include title and desc, both of which
+     * The containerComponent prop takes an entire component which will be used to
+     * create a container element for standalone charts.
+     * The new element created from the passed containerComponent wil be provided with
+     * these props from VictoryGroup: height, width, children
+     * (the chart itself) and style. Props that are not provided by the
+     * child chart component include title and desc, both of which
      * are intended to add accessibility to Victory components. The more descriptive these props
      * are, the more accessible your data will be for people using screen readers.
      * Any of these props may be overridden by passing in props to the supplied component,

--- a/src/components/victory-group/victory-group.js
+++ b/src/components/victory-group/victory-group.js
@@ -1,6 +1,7 @@
 import { uniq } from "lodash";
 import React, { PropTypes } from "react";
-import { PropTypes as CustomPropTypes, Helpers, Log, VictorySharedEvents, VictoryContainer } from "victory-core";
+import { PropTypes as CustomPropTypes, Helpers, Log, VictorySharedEvents,
+  VictoryContainer } from "victory-core";
 import Scale from "../../helpers/scale";
 import Wrapper from "../../helpers/wrapper";
 

--- a/src/components/victory-line/victory-line.js
+++ b/src/components/victory-line/victory-line.js
@@ -5,7 +5,8 @@ import LineHelpers from "./helper-methods";
 import Domain from "../../helpers/domain";
 import Data from "../../helpers/data";
 import {
-  PropTypes as CustomPropTypes, Helpers, Events, VictoryTransition, VictoryLabel
+  PropTypes as CustomPropTypes, Helpers, Events, VictoryTransition, VictoryLabel,
+  VictoryContainer
 } from "victory-core";
 
 const defaultStyles = {
@@ -299,17 +300,20 @@ export default class VictoryLine extends React.Component {
       PropTypes.arrayOf(PropTypes.string)
     ]),
     /**
-     * The title prop allows the user to specify a title for their chart for accessibility purposes.
-     * This more descriptive this is, the better it is for screen readers.
-     * This prop will default to "Line Chart".
+     * The containerComponent prop takes an entire component which will be used to surround
+     * a nested chart component unless the standalone prop is set to true.
+     * The container component will be provided the following properties calculated by
+     * the chart component it surrounds: height, width, a child component (the chart itself) and style.
+     * Props that are not provided by the child chart component include title and desc, both of which
+     * are intended to add accessibility to Victory components. The more descriptive these props
+     * are, the more accessible your data will be for people using screen readers.
+     * Any of these props may be overridden by passing in props to the supplied component,
+     * or modified or ignored within the custom component itself. If a dataComponent is
+     * not provided, VictoryChart will use the default VictoryContainer component.
+     * @example <VictoryContainer title="Chart of Dog Breeds" desc="This chart shows how
+     * popular each dog breed is by percentage in Seattle." />
      */
-     title: PropTypes.string,
-     /**
-     * The desc prop allows the user to specify a description of their chart for accessibility purposes.
-     * This more descriptive this is, the better it is for screen readers.
-     * This prop will default to "This is a line chart that displays data."
-     */
-     desc: PropTypes.string
+    containerComponent: PropTypes.element
   };
 
   static defaultProps = {
@@ -324,8 +328,7 @@ export default class VictoryLine extends React.Component {
     y: "y",
     dataComponent: <LineSegment/>,
     labelComponent: <VictoryLabel/>,
-    title: "Line Chart",
-    desc: "This is a line chart that displays data."
+    containerComponent: <VictoryContainer/>
   };
 
   static getDomain = Domain.getDomain.bind(Domain);
@@ -419,16 +422,10 @@ export default class VictoryLine extends React.Component {
 
     const group = <g role="presentation" style={style.parent}>{this.renderData(this.props)}</g>;
     return this.props.standalone ?
-      <svg
-        style={style.parent}
-        viewBox={`0 0 ${this.props.width} ${this.props.height}`}
-        role="img"
-        aria-labelledby="title desc"
-      >
-        <title id="title">{this.props.title}</title>
-        <desc id="desc">{this.props.desc}</desc>
-        {group}
-      </svg> :
+      React.cloneElement(
+        this.props.containerComponent,
+        Object.assign({height: this.props.height, width: this.props.width, style: style.parent}, this.props.containerComponent.props),
+        group) :
       group;
   }
 }

--- a/src/components/victory-line/victory-line.js
+++ b/src/components/victory-line/victory-line.js
@@ -297,7 +297,19 @@ export default class VictoryLine extends React.Component {
       CustomPropTypes.allOfType([CustomPropTypes.integer, CustomPropTypes.nonNegative]),
       PropTypes.string,
       PropTypes.arrayOf(PropTypes.string)
-    ])
+    ]),
+    /**
+     * The title prop allows the user to specify a title for their chart for accessibility purposes.
+     * This more descriptive this is, the better it is for screen readers.
+     * This prop will default to "Line Chart".
+     */
+     title: PropTypes.string,
+     /**
+     * The desc prop allows the user to specify a description of their chart for accessibility purposes.
+     * This more descriptive this is, the better it is for screen readers.
+     * This prop will default to "This is a line chart that displays data."
+     */
+     desc: PropTypes.string
   };
 
   static defaultProps = {
@@ -311,7 +323,9 @@ export default class VictoryLine extends React.Component {
     x: "x",
     y: "y",
     dataComponent: <LineSegment/>,
-    labelComponent: <VictoryLabel/>
+    labelComponent: <VictoryLabel/>,
+    title: "Line Chart",
+    desc: "This is a line chart that displays data."
   };
 
   static getDomain = Domain.getDomain.bind(Domain);
@@ -403,12 +417,16 @@ export default class VictoryLine extends React.Component {
       "100%"
     );
 
-    const group = <g style={style.parent}>{this.renderData(this.props)}</g>;
+    const group = <g role="presentation" style={style.parent}>{this.renderData(this.props)}</g>;
     return this.props.standalone ?
       <svg
         style={style.parent}
         viewBox={`0 0 ${this.props.width} ${this.props.height}`}
+        role="img"
+        aria-labelledby="title desc"
       >
+        <title id="title">{this.props.title}</title>
+        <desc id="desc">{this.props.desc}</desc>
         {group}
       </svg> :
       group;

--- a/src/components/victory-line/victory-line.js
+++ b/src/components/victory-line/victory-line.js
@@ -303,13 +303,14 @@ export default class VictoryLine extends React.Component {
      * The containerComponent prop takes an entire component which will be used to surround
      * a nested chart component unless the standalone prop is set to true.
      * The container component will be provided the following properties calculated by
-     * the chart component it surrounds: height, width, a child component (the chart itself) and style.
-     * Props that are not provided by the child chart component include title and desc, both of which
+     * the chart component it surrounds: height, width, a child component (the chart itself)
+     * and style. Props that are not provided by the child
+     * chart component include title and desc, both of which
      * are intended to add accessibility to Victory components. The more descriptive these props
      * are, the more accessible your data will be for people using screen readers.
      * Any of these props may be overridden by passing in props to the supplied component,
      * or modified or ignored within the custom component itself. If a dataComponent is
-     * not provided, VictoryChart will use the default VictoryContainer component.
+     * not provided, VictoryLine will use the default VictoryContainer component.
      * @example <VictoryContainer title="Chart of Dog Breeds" desc="This chart shows how
      * popular each dog breed is by percentage in Seattle." />
      */
@@ -424,7 +425,10 @@ export default class VictoryLine extends React.Component {
     return this.props.standalone ?
       React.cloneElement(
         this.props.containerComponent,
-        Object.assign({height: this.props.height, width: this.props.width, style: style.parent}, this.props.containerComponent.props),
+        Object.assign({
+          height: this.props.height,
+          width: this.props.width,
+          style: style.parent}, this.props.containerComponent.props),
         group) :
       group;
   }

--- a/src/components/victory-line/victory-line.js
+++ b/src/components/victory-line/victory-line.js
@@ -300,12 +300,12 @@ export default class VictoryLine extends React.Component {
       PropTypes.arrayOf(PropTypes.string)
     ]),
     /**
-     * The containerComponent prop takes an entire component which will be used to surround
-     * a nested chart component unless the standalone prop is set to true.
-     * The container component will be provided the following properties calculated by
-     * the chart component it surrounds: height, width, a child component (the chart itself)
-     * and style. Props that are not provided by the child
-     * chart component include title and desc, both of which
+     * The containerComponent prop takes an entire component which will be used to
+     * create a container element for standalone charts.
+     * The new element created from the passed containerComponent wil be provided with
+     * these props from VictoryLine: height, width, children
+     * (the chart itself) and style. Props that are not provided by the
+     * child chart component include title and desc, both of which
      * are intended to add accessibility to Victory components. The more descriptive these props
      * are, the more accessible your data will be for people using screen readers.
      * Any of these props may be overridden by passing in props to the supplied component,

--- a/src/components/victory-scatter/victory-scatter.js
+++ b/src/components/victory-scatter/victory-scatter.js
@@ -309,7 +309,19 @@ export default class VictoryScatter extends React.Component {
       CustomPropTypes.allOfType([CustomPropTypes.integer, CustomPropTypes.nonNegative]),
       PropTypes.string,
       PropTypes.arrayOf(PropTypes.string)
-    ])
+    ]),
+    /**
+     * The title prop allows the user to specify a title for their chart for accessibility purposes.
+     * This more descriptive this is, the better it is for screen readers.
+     * This prop will default to "Scatter Chart".
+     */
+     title: PropTypes.string,
+     /**
+     * The desc prop allows the user to specify a description of their chart for accessibility purposes.
+     * This more descriptive this is, the better it is for screen readers.
+     * This prop will default to "This is a scatter chart that displays data."
+     */
+     desc: PropTypes.string
   };
 
   static defaultProps = {
@@ -324,7 +336,9 @@ export default class VictoryScatter extends React.Component {
     x: "x",
     y: "y",
     dataComponent: <Point/>,
-    labelComponent: <VictoryLabel/>
+    labelComponent: <VictoryLabel/>,
+    title: "Scatter Chart",
+    desc: "This is a scatter chart that displays data."
   };
 
   static getDomain = Domain.getDomain.bind(Domain);
@@ -414,12 +428,16 @@ export default class VictoryScatter extends React.Component {
       "100%"
     );
 
-    const group = <g style={style.parent}>{this.renderData(this.props)}</g>;
+    const group = <g role="presentation" style={style.parent}>{this.renderData(this.props)}</g>;
     return this.props.standalone ?
       <svg
         style={style.parent}
         viewBox={`0 0 ${this.props.width} ${this.props.height}`}
+        role="img"
+        aria-labelledby="title desc"
       >
+        <title id="title">{this.props.title}</title>
+        <desc id="desc">{this.props.desc}</desc>
         {group}
       </svg> :
       group;

--- a/src/components/victory-scatter/victory-scatter.js
+++ b/src/components/victory-scatter/victory-scatter.js
@@ -4,7 +4,8 @@ import Point from "./point";
 import Domain from "../../helpers/domain";
 import Data from "../../helpers/data";
 import {
-  PropTypes as CustomPropTypes, Helpers, Events, VictoryTransition, VictoryLabel
+  PropTypes as CustomPropTypes, Helpers, Events, VictoryTransition, VictoryLabel,
+  VictoryContainer
 } from "victory-core";
 import ScatterHelpers from "./helper-methods";
 
@@ -311,17 +312,20 @@ export default class VictoryScatter extends React.Component {
       PropTypes.arrayOf(PropTypes.string)
     ]),
     /**
-     * The title prop allows the user to specify a title for their chart for accessibility purposes.
-     * This more descriptive this is, the better it is for screen readers.
-     * This prop will default to "Scatter Chart".
+     * The containerComponent prop takes an entire component which will be used to surround
+     * a nested chart component unless the standalone prop is set to true.
+     * The container component will be provided the following properties calculated by
+     * the chart component it surrounds: height, width, a child component (the chart itself) and style.
+     * Props that are not provided by the child chart component include title and desc, both of which
+     * are intended to add accessibility to Victory components. The more descriptive these props
+     * are, the more accessible your data will be for people using screen readers.
+     * Any of these props may be overridden by passing in props to the supplied component,
+     * or modified or ignored within the custom component itself. If a dataComponent is
+     * not provided, VictoryChart will use the default VictoryContainer component.
+     * @example <VictoryContainer title="Chart of Dog Breeds" desc="This chart shows how
+     * popular each dog breed is by percentage in Seattle." />
      */
-     title: PropTypes.string,
-     /**
-     * The desc prop allows the user to specify a description of their chart for accessibility purposes.
-     * This more descriptive this is, the better it is for screen readers.
-     * This prop will default to "This is a scatter chart that displays data."
-     */
-     desc: PropTypes.string
+    containerComponent: PropTypes.element
   };
 
   static defaultProps = {
@@ -337,8 +341,7 @@ export default class VictoryScatter extends React.Component {
     y: "y",
     dataComponent: <Point/>,
     labelComponent: <VictoryLabel/>,
-    title: "Scatter Chart",
-    desc: "This is a scatter chart that displays data."
+    containerComponent: <VictoryContainer/>
   };
 
   static getDomain = Domain.getDomain.bind(Domain);
@@ -430,16 +433,10 @@ export default class VictoryScatter extends React.Component {
 
     const group = <g role="presentation" style={style.parent}>{this.renderData(this.props)}</g>;
     return this.props.standalone ?
-      <svg
-        style={style.parent}
-        viewBox={`0 0 ${this.props.width} ${this.props.height}`}
-        role="img"
-        aria-labelledby="title desc"
-      >
-        <title id="title">{this.props.title}</title>
-        <desc id="desc">{this.props.desc}</desc>
-        {group}
-      </svg> :
+      React.cloneElement(
+        this.props.containerComponent,
+        Object.assign({height: this.props.height, width: this.props.width, style: style.parent}, this.props.containerComponent.props),
+        group) :
       group;
   }
 }

--- a/src/components/victory-scatter/victory-scatter.js
+++ b/src/components/victory-scatter/victory-scatter.js
@@ -312,17 +312,17 @@ export default class VictoryScatter extends React.Component {
       PropTypes.arrayOf(PropTypes.string)
     ]),
     /**
-     * The containerComponent prop takes an entire component which will be used to surround
-     * a nested chart component unless the standalone prop is set to true.
-     * The container component will be provided the following properties calculated by
-     * the chart component it surrounds: height, width, a child component (the chart itself)
-     * and style. Props that are not provided by the child
-     * chart component include title and desc, both of which
+     * The containerComponent prop takes an entire component which will be used to
+     * create a container element for standalone charts.
+     * The new element created from the passed containerComponent wil be provided with
+     * these props from VictoryScatter: height, width, children
+     * (the chart itself) and style. Props that are not provided by the
+     * child chart component include title and desc, both of which
      * are intended to add accessibility to Victory components. The more descriptive these props
      * are, the more accessible your data will be for people using screen readers.
      * Any of these props may be overridden by passing in props to the supplied component,
      * or modified or ignored within the custom component itself. If a dataComponent is
-     * not provided, VictoryGroup will use the default VictoryContainer component.
+     * not provided, VictoryScatter will use the default VictoryContainer component.
      * @example <VictoryContainer title="Chart of Dog Breeds" desc="This chart shows how
      * popular each dog breed is by percentage in Seattle." />
      */

--- a/src/components/victory-scatter/victory-scatter.js
+++ b/src/components/victory-scatter/victory-scatter.js
@@ -315,13 +315,14 @@ export default class VictoryScatter extends React.Component {
      * The containerComponent prop takes an entire component which will be used to surround
      * a nested chart component unless the standalone prop is set to true.
      * The container component will be provided the following properties calculated by
-     * the chart component it surrounds: height, width, a child component (the chart itself) and style.
-     * Props that are not provided by the child chart component include title and desc, both of which
+     * the chart component it surrounds: height, width, a child component (the chart itself)
+     * and style. Props that are not provided by the child
+     * chart component include title and desc, both of which
      * are intended to add accessibility to Victory components. The more descriptive these props
      * are, the more accessible your data will be for people using screen readers.
      * Any of these props may be overridden by passing in props to the supplied component,
      * or modified or ignored within the custom component itself. If a dataComponent is
-     * not provided, VictoryChart will use the default VictoryContainer component.
+     * not provided, VictoryGroup will use the default VictoryContainer component.
      * @example <VictoryContainer title="Chart of Dog Breeds" desc="This chart shows how
      * popular each dog breed is by percentage in Seattle." />
      */
@@ -435,7 +436,10 @@ export default class VictoryScatter extends React.Component {
     return this.props.standalone ?
       React.cloneElement(
         this.props.containerComponent,
-        Object.assign({height: this.props.height, width: this.props.width, style: style.parent}, this.props.containerComponent.props),
+        Object.assign({
+          height: this.props.height,
+          width: this.props.width,
+          style: style.parent}, this.props.containerComponent.props),
         group) :
       group;
   }

--- a/src/components/victory-stack/victory-stack.js
+++ b/src/components/victory-stack/victory-stack.js
@@ -243,12 +243,12 @@ export default class VictoryStack extends React.Component {
      */
     xOffset: PropTypes.number,
     /**
-     * The containerComponent prop takes an entire component which will be used to surround
-     * a nested chart component unless the standalone prop is set to true.
-     * The container component will be provided the following properties calculated by
-     * the chart component it surrounds: height, width, a child component (the chart itself)
-     * and style. Props that are not provided by the child
-     * chart component include title and desc, both of which
+     * The containerComponent prop takes an entire component which will be used to
+     * create a container element for standalone charts.
+     * The new element created from the passed containerComponent wil be provided with
+     * these props from VictoryStack: height, width, children
+     * (the chart itself) and style. Props that are not provided by the
+     * child chart component include title and desc, both of which
      * are intended to add accessibility to Victory components. The more descriptive these props
      * are, the more accessible your data will be for people using screen readers.
      * Any of these props may be overridden by passing in props to the supplied component,

--- a/src/components/victory-stack/victory-stack.js
+++ b/src/components/victory-stack/victory-stack.js
@@ -245,8 +245,9 @@ export default class VictoryStack extends React.Component {
      * The containerComponent prop takes an entire component which will be used to surround
      * a nested chart component unless the standalone prop is set to true.
      * The container component will be provided the following properties calculated by
-     * the chart component it surrounds: height, width, a child component (the chart itself) and style.
-     * Props that are not provided by the child chart component include title and desc, both of which
+     * the chart component it surrounds: height, width, a child component (the chart itself)
+     * and style. Props that are not provided by the child
+     * chart component include title and desc, both of which
      * are intended to add accessibility to Victory components. The more descriptive these props
      * are, the more accessible your data will be for people using screen readers.
      * Any of these props may be overridden by passing in props to the supplied component,
@@ -379,7 +380,10 @@ export default class VictoryStack extends React.Component {
     return props.standalone ?
       React.cloneElement(
         this.props.containerComponent,
-        Object.assign({height: this.props.height, width: this.props.width, style: style.parent}, this.props.containerComponent.props),
+        Object.assign({
+          height: this.props.height,
+          width: this.props.width,
+          style: style.parent}, this.props.containerComponent.props),
         group) :
       group;
   }

--- a/src/components/victory-stack/victory-stack.js
+++ b/src/components/victory-stack/victory-stack.js
@@ -1,6 +1,7 @@
 import { uniq } from "lodash";
 import React, { PropTypes } from "react";
-import { PropTypes as CustomPropTypes, Helpers, Log, VictorySharedEvents, VictoryContainer } from "victory-core";
+import { PropTypes as CustomPropTypes, Helpers, Log, VictorySharedEvents,
+  VictoryContainer } from "victory-core";
 import Scale from "../../helpers/scale";
 import Wrapper from "../../helpers/wrapper";
 

--- a/src/components/victory-stack/victory-stack.js
+++ b/src/components/victory-stack/victory-stack.js
@@ -1,6 +1,6 @@
 import { uniq } from "lodash";
 import React, { PropTypes } from "react";
-import { PropTypes as CustomPropTypes, Helpers, Log, VictorySharedEvents } from "victory-core";
+import { PropTypes as CustomPropTypes, Helpers, Log, VictorySharedEvents, VictoryContainer } from "victory-core";
 import Scale from "../../helpers/scale";
 import Wrapper from "../../helpers/wrapper";
 
@@ -240,7 +240,22 @@ export default class VictoryStack extends React.Component {
      * The xOffset prop is used for grouping stacks of bars. This prop will be set
      * by the VictoryGroup component wrapper, or can be set manually.
      */
-    xOffset: PropTypes.number
+    xOffset: PropTypes.number,
+    /**
+     * The containerComponent prop takes an entire component which will be used to surround
+     * a nested chart component unless the standalone prop is set to true.
+     * The container component will be provided the following properties calculated by
+     * the chart component it surrounds: height, width, a child component (the chart itself) and style.
+     * Props that are not provided by the child chart component include title and desc, both of which
+     * are intended to add accessibility to Victory components. The more descriptive these props
+     * are, the more accessible your data will be for people using screen readers.
+     * Any of these props may be overridden by passing in props to the supplied component,
+     * or modified or ignored within the custom component itself. If a dataComponent is
+     * not provided, VictoryStack will use the default VictoryContainer component.
+     * @example <VictoryContainer title="Chart of Dog Breeds" desc="This chart shows how
+     * popular each dog breed is by percentage in Seattle." />
+     */
+    containerComponent: PropTypes.element
   };
 
   static defaultProps = {
@@ -248,7 +263,8 @@ export default class VictoryStack extends React.Component {
     height: 300,
     width: 450,
     padding: 50,
-    standalone: true
+    standalone: true,
+    containerComponent: <VictoryContainer/>
   };
 
   static getDomain = Wrapper.getStackedDomain.bind(Wrapper);
@@ -361,9 +377,10 @@ export default class VictoryStack extends React.Component {
       </g>
     );
     return props.standalone ?
-      <svg style={style.parent} viewBox={`0 0 ${props.width} ${props.height}`}>
-        {group}
-      </svg> :
+      React.cloneElement(
+        this.props.containerComponent,
+        Object.assign({height: this.props.height, width: this.props.width, style: style.parent}, this.props.containerComponent.props),
+        group) :
       group;
   }
 }

--- a/test/client/spec/components/victory-area/victory-area.spec.js
+++ b/test/client/spec/components/victory-area/victory-area.spec.js
@@ -15,7 +15,7 @@ import Area from "src/components/victory-area/area";
 describe("components/victory-area", () => {
   describe("default component rendering", () => {
     it("renders an svg with the correct width and height", () => {
-      const wrapper = shallow(
+      const wrapper = mount(
         <VictoryArea/>
       );
       const svg = wrapper.find("svg");
@@ -24,7 +24,7 @@ describe("components/victory-area", () => {
     });
 
     it("renders an svg with the correct viewbox", () => {
-      const wrapper = shallow(
+      const wrapper = mount(
         <VictoryArea/>
       );
       const svg = wrapper.find("svg");

--- a/test/client/spec/components/victory-axis/victory-axis.spec.js
+++ b/test/client/spec/components/victory-axis/victory-axis.spec.js
@@ -15,7 +15,7 @@ import Tick from "src/components/victory-axis/tick";
 describe("components/victory-axis", () => {
   describe("default component rendering", () => {
     it("renders an svg with the correct width and height", () => {
-      const wrapper = shallow(
+      const wrapper = mount(
         <VictoryAxis/>
       );
       const svg = wrapper.find("svg");
@@ -24,7 +24,7 @@ describe("components/victory-axis", () => {
     });
 
     it("renders an svg with the correct viewBox", () => {
-      const wrapper = shallow(
+      const wrapper = mount(
         <VictoryAxis/>
       );
       const svg = wrapper.find("svg");

--- a/test/client/spec/components/victory-bar/victory-bar.spec.js
+++ b/test/client/spec/components/victory-bar/victory-bar.spec.js
@@ -16,7 +16,7 @@ import { VictoryLabel } from "victory-core";
 describe("components/victory-bar", () => {
   describe("default component rendering", () => {
     it("renders an svg with the correct width and height", () => {
-      const wrapper = shallow(
+      const wrapper = mount(
         <VictoryBar/>
       );
       const svg = wrapper.find("svg");
@@ -25,7 +25,7 @@ describe("components/victory-bar", () => {
     });
 
     it("renders an svg with the correct viewBox", () => {
-      const wrapper = shallow(
+      const wrapper = mount(
         <VictoryBar/>
       );
       const svg = wrapper.find("svg");

--- a/test/client/spec/components/victory-chart/victory-chart.spec.js
+++ b/test/client/spec/components/victory-chart/victory-chart.spec.js
@@ -2,14 +2,14 @@
  * Client tests
  */
 import React from "react";
-import { shallow } from "enzyme";
+import { shallow, mount } from "enzyme";
 import VictoryChart from "src/components/victory-chart/victory-chart";
 import VictoryAxis from "src/components/victory-axis/victory-axis";
 
 describe("components/victory-chart", () => {
   describe("default component rendering", () => {
     it("renders an svg with the correct width and height", () => {
-      const wrapper = shallow(
+      const wrapper = mount(
         <VictoryChart/>
       );
       const svg = wrapper.find("svg");
@@ -18,7 +18,7 @@ describe("components/victory-chart", () => {
     });
 
     it("renders an svg with the correct viewBox", () => {
-      const wrapper = shallow(
+      const wrapper = mount(
         <VictoryChart/>
       );
       const svg = wrapper.find("svg");

--- a/test/client/spec/components/victory-line/victory-line.spec.js
+++ b/test/client/spec/components/victory-line/victory-line.spec.js
@@ -20,7 +20,7 @@ class MyLineSegment extends React.Component {
 describe("components/victory-line", () => {
   describe("default component rendering", () => {
     it("renders an svg with the correct width and height", () => {
-      const wrapper = shallow(
+      const wrapper = mount(
         <VictoryLine/>
       );
       const svg = wrapper.find("svg");
@@ -29,7 +29,7 @@ describe("components/victory-line", () => {
     });
 
     it("renders an svg with the correct viewBox", () => {
-      const wrapper = shallow(
+      const wrapper = mount(
         <VictoryLine/>
       );
       const svg = wrapper.find("svg");

--- a/test/client/spec/components/victory-scatter/victory-scatter.spec.js
+++ b/test/client/spec/components/victory-scatter/victory-scatter.spec.js
@@ -20,7 +20,7 @@ class MyPoint extends React.Component {
 describe("components/victory-scatter", () => {
   describe("default component rendering", () => {
     it("renders an svg with the correct width and height", () => {
-      const wrapper = shallow(
+      const wrapper = mount(
         <VictoryScatter/>
       );
       const svg = wrapper.find("svg");
@@ -29,7 +29,7 @@ describe("components/victory-scatter", () => {
     });
 
     it("renders an svg with the correct viewBox", () => {
-      const wrapper = shallow(
+      const wrapper = mount(
         <VictoryScatter/>
       );
       const svg = wrapper.find("svg");

--- a/test/client/spec/components/victory-wrappers/victory-group.spec.js
+++ b/test/client/spec/components/victory-wrappers/victory-group.spec.js
@@ -4,14 +4,14 @@
 /*eslint-disable max-nested-callbacks */
 
 import React from "react";
-import { shallow } from "enzyme";
+import { mount } from "enzyme";
 import VictoryGroup from "src/components/victory-group/victory-group";
 import VictoryBar from "src/components/victory-bar/victory-bar";
 
 describe("components/victory-group", () => {
   describe("default component rendering", () => {
     it("renders an svg with the correct width and height", () => {
-      const wrapper = shallow(
+      const wrapper = mount(
         <VictoryGroup>
           <VictoryBar/>
           <VictoryBar/>
@@ -23,7 +23,7 @@ describe("components/victory-group", () => {
     });
 
     it("renders an svg with the correct viewBox", () => {
-      const wrapper = shallow(
+      const wrapper = mount(
         <VictoryGroup>
           <VictoryBar/>
           <VictoryBar/>

--- a/test/client/spec/components/victory-wrappers/victory-stack.spec.js
+++ b/test/client/spec/components/victory-wrappers/victory-stack.spec.js
@@ -4,14 +4,14 @@
 /*eslint-disable max-nested-callbacks */
 
 import React from "react";
-import { shallow } from "enzyme";
+import { mount } from "enzyme";
 import VictoryStack from "src/components/victory-stack/victory-stack";
 import VictoryBar from "src/components/victory-bar/victory-bar";
 
 describe("components/victory-stack", () => {
   describe("default component rendering", () => {
     it("renders an svg with the correct width and height", () => {
-      const wrapper = shallow(
+      const wrapper = mount(
         <VictoryStack>
           <VictoryBar/>
           <VictoryBar/>
@@ -23,7 +23,7 @@ describe("components/victory-stack", () => {
     });
 
     it("renders an svg with the correct viewBox", () => {
-      const wrapper = shallow(
+      const wrapper = mount(
         <VictoryStack>
           <VictoryBar/>
           <VictoryBar/>


### PR DESCRIPTION
This adds aria support to all of the main chart types in victory-chart, and also adds new title and desc props that default to basic information about what's on-screen. Implementations of these charts can choose to add more fleshed-out and descriptive titles and descriptions (and maybe we want to encourage them to in the docs)? I'll add this to victory-pie components as well. @paulathevalley is there anything I'm missing that I should add in?