### PR TITLE
Victory candlestick chart

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -7,6 +7,7 @@ import BarDemo from "./components/victory-bar-demo";
 import ChartDemo from "./components/victory-chart-demo";
 import LineDemo from "./components/victory-line-demo";
 import ScatterDemo from "./components/victory-scatter-demo";
+import CandlestickDemo from "./components/victory-candlestick-demo";
 import { Router, Route, Link, hashHistory } from "react-router";
 
 const content = document.getElementById("content");
@@ -27,6 +28,7 @@ const App = React.createClass({
           <li><Link to="/bar">Victory Bar Demo</Link></li>
           <li><Link to="/line">Victory Line Demo</Link></li>
           <li><Link to="/scatter">Victory Scatter Demo</Link></li>
+          <li><Link to="/candlestick">Victory Candlestick Demo</Link></li>
         </ul>
         {this.props.children}
       </div>
@@ -43,6 +45,7 @@ ReactDOM.render((
       <Route path="chart" component={ChartDemo}/>
       <Route path="line" component={LineDemo}/>
       <Route path="scatter" component={ScatterDemo}/>
+      <Route path="candlestick" component={CandlestickDemo}/>
     </Route>
   </Router>
 ), content);

--- a/demo/components/victory-candlestick-demo.js
+++ b/demo/components/victory-candlestick-demo.js
@@ -1,20 +1,20 @@
 /*global window:false */
 import React from "react";
-import { random, range } from "lodash";
+import { random, range, merge } from "lodash";
 import {VictoryCandlestick, VictoryChart} from "../../src/index";
 // import {VictoryLabel} from "victory-core";
 
 const getData = () => {
   const colors =
     ["violet", "cornflowerblue", "gold", "orange", "turquoise", "tomato", "greenyellow"];
-  const symbols = ["circle", "star", "square", "triangleUp", "triangleDown", "diamond", "plus"];
-  return range(100).map((index) => {
-    const scaledIndex = Math.floor(index % 7);
+  return range(100).map(() => {
     return {
       x: random(600),
-      y: random(600),
+      open: random(600),
+      close: random(600),
+      high: random(600),
+      low: random(600),
       size: random(15) + 3,
-      symbol: symbols[scaledIndex],
       fill: colors[random(0, 6)],
       opacity: random(0.3, 1)
     };
@@ -54,18 +54,49 @@ export default class App extends React.Component {
 
         <VictoryCandlestick
           style={{parent: style.parent}}
-          // candleColors={{positive: "purple", negative: "blue"}}
           data={[
-            {x: 50, open: 9, close: 30, high: 56, low: 7},
-            {x: 100, open: 80, close: 40, high: 120, low: 10},
+            {x: 50, open: 9, close: 30, high: 56, low: 7, label: "first"},
+            {x: 100, open: 80, close: 40, high: 120, low: 10, fill: "pink"},
             {x: 150, open: 50, close: 80, high: 90, low: 20},
             {x: 200, open: 70, close: 22, high: 70, low: 5},
             {x: 250, open: 20, close: 35, high: 50, low: 10},
             {x: 300, open: 35, close: 30, high: 40, low: 3},
             {x: 350, open: 30, close: 90, high: 95, low: 30},
-            {x: 400, open: 80, close: 81, high: 83, low: 75}
+            {x: 400, open: 80, close: 81, high: 83, low: 75, label: "last"}
           ]}
           size={8}
+          events={[{
+            target: "labels",
+            eventHandlers: {
+              onClick: () => {
+                return [
+                  {
+                    mutation: (props) => {
+                      return {
+                        style: merge({}, props.style.labels, {fill: "orange"})
+                      };
+                    }
+                  }
+                ];
+              }
+            }
+          },
+          {
+            target: "data",
+            eventHandlers: {
+              onClick: () => {
+                return [
+                  {
+                    mutation: (props) => {
+                      return {
+                        style: merge({}, props.style, {fill: "blue"})
+                      };
+                    }
+                  }
+                ];
+              }
+            }
+          }]}
         />
         <VictoryChart
           scale={{x: "time"}}
@@ -86,6 +117,13 @@ export default class App extends React.Component {
             size={8}
           />
         </VictoryChart>
+
+        <VictoryCandlestick
+          animate={{duration: 2000}}
+          data={this.state.data}
+        />
+
+        <VictoryCandlestick />
       </div>
     );
   }

--- a/demo/components/victory-candlestick-demo.js
+++ b/demo/components/victory-candlestick-demo.js
@@ -25,6 +25,17 @@ const style = {
   parent: {border: "1px solid #ccc", margin: "2%", maxWidth: "40%"}
 };
 
+const data = [
+  {x: new Date(2016, 6, 1), open: 9, close: 30, high: 56, low: 7},
+  {x: new Date(2016, 6, 2), open: 80, close: 40, high: 120, low: 10},
+  {x: new Date(2016, 6, 3), open: 50, close: 80, high: 90, low: 20},
+  {x: new Date(2016, 6, 4), open: 70, close: 22, high: 70, low: 5},
+  {x: new Date(2016, 6, 5), open: 20, close: 35, high: 50, low: 10},
+  {x: new Date(2016, 6, 6), open: 35, close: 30, high: 40, low: 3},
+  {x: new Date(2016, 6, 7), open: 30, close: 90, high: 95, low: 30},
+  {x: new Date(2016, 6, 8), open: 80, close: 81, high: 83, low: 75}
+];
+
 
 export default class App extends React.Component {
   constructor(props) {
@@ -54,16 +65,7 @@ export default class App extends React.Component {
 
         <VictoryCandlestick
           style={{parent: style.parent}}
-          data={[
-            {x: 50, open: 9, close: 30, high: 56, low: 7, label: "first"},
-            {x: 100, open: 80, close: 40, high: 120, low: 10, fill: "pink"},
-            {x: 150, open: 50, close: 80, high: 90, low: 20},
-            {x: 200, open: 70, close: 22, high: 70, low: 5},
-            {x: 250, open: 20, close: 35, high: 50, low: 10},
-            {x: 300, open: 35, close: 30, high: 40, low: 3},
-            {x: 350, open: 30, close: 90, high: 95, low: 30},
-            {x: 400, open: 80, close: 81, high: 83, low: 75, label: "last"}
-          ]}
+          data={data}
           size={8}
           events={[{
             target: "labels",
@@ -104,16 +106,7 @@ export default class App extends React.Component {
           <VictoryCandlestick
             style={{parent: style.parent}}
             candleColors={{positive: "purple", negative: "blue"}}
-            data={[
-              {x: new Date(2016, 6, 1), open: 9, close: 30, high: 56, low: 7},
-              {x: new Date(2016, 6, 2), open: 80, close: 40, high: 120, low: 10},
-              {x: new Date(2016, 6, 3), open: 50, close: 80, high: 90, low: 20},
-              {x: new Date(2016, 6, 4), open: 70, close: 22, high: 70, low: 5},
-              {x: new Date(2016, 6, 5), open: 20, close: 35, high: 50, low: 10},
-              {x: new Date(2016, 6, 6), open: 35, close: 30, high: 40, low: 3},
-              {x: new Date(2016, 6, 7), open: 30, close: 90, high: 95, low: 30},
-              {x: new Date(2016, 6, 8), open: 80, close: 81, high: 83, low: 75}
-            ]}
+            data={data}
             size={8}
           />
         </VictoryChart>

--- a/demo/components/victory-candlestick-demo.js
+++ b/demo/components/victory-candlestick-demo.js
@@ -1,7 +1,8 @@
 /*global window:false */
 import React from "react";
 import { random, range } from "lodash";
-import {VictoryCandlestick} from "../../src/index";
+import {VictoryCandlestick
+        } from "../../src/index";
 // import {VictoryLabel} from "victory-core";
 
 const getData = () => {
@@ -54,7 +55,7 @@ export default class App extends React.Component {
 
         <VictoryCandlestick
           style={{parent: style.parent}}
-          candleColors={{positive: "purple", negative: "blue"}}
+          // candleColors={{positive: "purple", negative: "blue"}}
           data={[
             {x: 50, open: 9, close: 30, high: 56, low: 7},
             {x: 100, open: 80, close: 40, high: 100, low: 10},
@@ -67,6 +68,23 @@ export default class App extends React.Component {
           ]}
           size={8}
         />
+        {/*<ChartWrap>
+                  <VictoryCandlestick
+                    style={{parent: style.parent}}
+                    candleColors={{positive: "purple", negative: "blue"}}
+                    data={[
+                      {x: 50, open: 9, close: 30, high: 56, low: 7},
+                      {x: 100, open: 80, close: 40, high: 100, low: 10},
+                      {x: 150, open: 50, close: 80, high: 90, low: 20},
+                      {x: 200, open: 70, close: 22, high: 70, low: 5},
+                      {x: 250, open: 20, close: 35, high: 50, low: 10},
+                      {x: 300, open: 35, close: 30, high: 40, low: 3},
+                      {x: 350, open: 30, close: 90, high: 95, low: 30},
+                      {x: 400, open: 80, close: 81, high: 83, low: 75}
+                    ]}
+                    size={8}
+                  />
+                </ChartWrap>*/}
       </div>
     );
   }
@@ -79,3 +97,27 @@ App.propTypes = {
 App.defaultProps = {
   data: getData()
 };
+
+// class ChartWrap extends React.Component {
+//   static propTypes = {
+//     width: React.PropTypes.number,
+//     height: React.PropTypes.number,
+//     children: React.PropTypes.any
+//   };
+//   static defaultProps = {
+//     width: 350,
+//     height: 250
+//   };
+//   // renders both a standalone chart, and a version wrapped in VictoryChart,
+//   // to test both cases at once
+//   render() {
+//     const parentStyle = {border: "1px solid #ccc", margin: "2%", maxWidth: "40%"};
+//     const props = Object.assign({}, this.props, {style: {parent: parentStyle}});
+//     return (
+//       <div>
+//         {React.cloneElement(this.props.children, props)}
+//         <VictoryChart {...props}>{this.props.children}</VictoryChart>
+//       </div>
+//     );
+//   }
+// }

--- a/demo/components/victory-candlestick-demo.js
+++ b/demo/components/victory-candlestick-demo.js
@@ -116,7 +116,9 @@ export default class App extends React.Component {
           data={this.state.data}
         />
 
-        <VictoryCandlestick/>
+        <VictoryCandlestick
+          size={1}
+        />
       </div>
     );
   }

--- a/demo/components/victory-candlestick-demo.js
+++ b/demo/components/victory-candlestick-demo.js
@@ -7,13 +7,13 @@ import {VictoryCandlestick, VictoryChart} from "../../src/index";
 const getData = () => {
   const colors =
     ["violet", "cornflowerblue", "gold", "orange", "turquoise", "tomato", "greenyellow"];
-  return range(100).map(() => {
+  return range(50).map(() => {
     return {
       x: random(600),
       open: random(600),
       close: random(600),
-      high: random(600),
-      low: random(600),
+      high: random(450, 600),
+      low: random(0, 150),
       size: random(15) + 3,
       fill: colors[random(0, 6)],
       opacity: random(0.3, 1)

--- a/demo/components/victory-candlestick-demo.js
+++ b/demo/components/victory-candlestick-demo.js
@@ -67,7 +67,9 @@ export default class App extends React.Component {
           ]}
           size={8}
         />
-        <ChartWrap>
+        <VictoryChart
+          scale={{x: "time"}}
+        >
           <VictoryCandlestick
             style={{parent: style.parent}}
             candleColors={{positive: "purple", negative: "blue"}}
@@ -83,7 +85,7 @@ export default class App extends React.Component {
             ]}
             size={8}
           />
-        </ChartWrap>
+        </VictoryChart>
       </div>
     );
   }
@@ -96,27 +98,3 @@ App.propTypes = {
 App.defaultProps = {
   data: getData()
 };
-
-class ChartWrap extends React.Component {
-  static propTypes = {
-    width: React.PropTypes.number,
-    height: React.PropTypes.number,
-    children: React.PropTypes.any
-  };
-  static defaultProps = {
-    width: 350,
-    height: 250
-  };
-  // renders both a standalone chart, and a version wrapped in VictoryChart,
-  // to test both cases at once
-  render() {
-    const parentStyle = {border: "1px solid #ccc", margin: "2%", maxWidth: "40%"};
-    const props = Object.assign({}, this.props, {style: {parent: parentStyle}});
-    return (
-      <div>
-        {React.cloneElement(this.props.children, props)}
-        <VictoryChart {...props}>{this.props.children}</VictoryChart>
-      </div>
-    );
-  }
-}

--- a/demo/components/victory-candlestick-demo.js
+++ b/demo/components/victory-candlestick-demo.js
@@ -123,7 +123,7 @@ export default class App extends React.Component {
           data={this.state.data}
         />
 
-        <VictoryCandlestick />
+        <VictoryCandlestick/>
       </div>
     );
   }

--- a/demo/components/victory-candlestick-demo.js
+++ b/demo/components/victory-candlestick-demo.js
@@ -1,8 +1,7 @@
 /*global window:false */
 import React from "react";
 import { random, range } from "lodash";
-import {VictoryCandlestick
-        } from "../../src/index";
+import {VictoryCandlestick, VictoryChart} from "../../src/index";
 // import {VictoryLabel} from "victory-core";
 
 const getData = () => {
@@ -68,23 +67,23 @@ export default class App extends React.Component {
           ]}
           size={8}
         />
-        {/*<ChartWrap>
-                  <VictoryCandlestick
-                    style={{parent: style.parent}}
-                    candleColors={{positive: "purple", negative: "blue"}}
-                    data={[
-                      {x: 50, open: 9, close: 30, high: 56, low: 7},
-                      {x: 100, open: 80, close: 40, high: 100, low: 10},
-                      {x: 150, open: 50, close: 80, high: 90, low: 20},
-                      {x: 200, open: 70, close: 22, high: 70, low: 5},
-                      {x: 250, open: 20, close: 35, high: 50, low: 10},
-                      {x: 300, open: 35, close: 30, high: 40, low: 3},
-                      {x: 350, open: 30, close: 90, high: 95, low: 30},
-                      {x: 400, open: 80, close: 81, high: 83, low: 75}
-                    ]}
-                    size={8}
-                  />
-                </ChartWrap>*/}
+        <ChartWrap>
+          <VictoryCandlestick
+            style={{parent: style.parent}}
+            candleColors={{positive: "purple", negative: "blue"}}
+            data={[
+              {x: 50, open: 9, close: 30, high: 56, low: 7},
+              {x: 100, open: 80, close: 40, high: 100, low: 10},
+              {x: 150, open: 50, close: 80, high: 90, low: 20},
+              {x: 200, open: 70, close: 22, high: 70, low: 5},
+              {x: 250, open: 20, close: 35, high: 50, low: 10},
+              {x: 300, open: 35, close: 30, high: 40, low: 3},
+              {x: 350, open: 30, close: 90, high: 95, low: 30},
+              {x: 400, open: 80, close: 81, high: 83, low: 75}
+            ]}
+            size={8}
+          />
+        </ChartWrap>
       </div>
     );
   }
@@ -98,26 +97,26 @@ App.defaultProps = {
   data: getData()
 };
 
-// class ChartWrap extends React.Component {
-//   static propTypes = {
-//     width: React.PropTypes.number,
-//     height: React.PropTypes.number,
-//     children: React.PropTypes.any
-//   };
-//   static defaultProps = {
-//     width: 350,
-//     height: 250
-//   };
-//   // renders both a standalone chart, and a version wrapped in VictoryChart,
-//   // to test both cases at once
-//   render() {
-//     const parentStyle = {border: "1px solid #ccc", margin: "2%", maxWidth: "40%"};
-//     const props = Object.assign({}, this.props, {style: {parent: parentStyle}});
-//     return (
-//       <div>
-//         {React.cloneElement(this.props.children, props)}
-//         <VictoryChart {...props}>{this.props.children}</VictoryChart>
-//       </div>
-//     );
-//   }
-// }
+class ChartWrap extends React.Component {
+  static propTypes = {
+    width: React.PropTypes.number,
+    height: React.PropTypes.number,
+    children: React.PropTypes.any
+  };
+  static defaultProps = {
+    width: 350,
+    height: 250
+  };
+  // renders both a standalone chart, and a version wrapped in VictoryChart,
+  // to test both cases at once
+  render() {
+    const parentStyle = {border: "1px solid #ccc", margin: "2%", maxWidth: "40%"};
+    const props = Object.assign({}, this.props, {style: {parent: parentStyle}});
+    return (
+      <div>
+        {React.cloneElement(this.props.children, props)}
+        <VictoryChart {...props}>{this.props.children}</VictoryChart>
+      </div>
+    );
+  }
+}

--- a/demo/components/victory-candlestick-demo.js
+++ b/demo/components/victory-candlestick-demo.js
@@ -57,7 +57,7 @@ export default class App extends React.Component {
           // candleColors={{positive: "purple", negative: "blue"}}
           data={[
             {x: 50, open: 9, close: 30, high: 56, low: 7},
-            {x: 100, open: 80, close: 40, high: 100, low: 10},
+            {x: 100, open: 80, close: 40, high: 120, low: 10},
             {x: 150, open: 50, close: 80, high: 90, low: 20},
             {x: 200, open: 70, close: 22, high: 70, low: 5},
             {x: 250, open: 20, close: 35, high: 50, low: 10},
@@ -73,7 +73,7 @@ export default class App extends React.Component {
             candleColors={{positive: "purple", negative: "blue"}}
             data={[
               {x: 50, open: 9, close: 30, high: 56, low: 7},
-              {x: 100, open: 80, close: 40, high: 100, low: 10},
+              {x: 100, open: 80, close: 40, high: 120, low: 10},
               {x: 150, open: 50, close: 80, high: 90, low: 20},
               {x: 200, open: 70, close: 22, high: 70, low: 5},
               {x: 250, open: 20, close: 35, high: 50, low: 10},

--- a/demo/components/victory-candlestick-demo.js
+++ b/demo/components/victory-candlestick-demo.js
@@ -1,0 +1,81 @@
+/*global window:false */
+import React from "react";
+import { random, range } from "lodash";
+import {VictoryCandlestick} from "../../src/index";
+// import {VictoryLabel} from "victory-core";
+
+const getData = () => {
+  const colors =
+    ["violet", "cornflowerblue", "gold", "orange", "turquoise", "tomato", "greenyellow"];
+  const symbols = ["circle", "star", "square", "triangleUp", "triangleDown", "diamond", "plus"];
+  return range(100).map((index) => {
+    const scaledIndex = Math.floor(index % 7);
+    return {
+      x: random(600),
+      y: random(600),
+      size: random(15) + 3,
+      symbol: symbols[scaledIndex],
+      fill: colors[random(0, 6)],
+      opacity: random(0.3, 1)
+    };
+  });
+};
+
+const style = {
+  parent: {border: "1px solid #ccc", margin: "2%", maxWidth: "40%"}
+};
+
+
+export default class App extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      data: props.data
+    };
+  }
+
+  componentDidMount() {
+    /* eslint-disable react/no-did-mount-set-state */
+    this.setStateInterval = window.setInterval(() => {
+      this.setState({
+        data: getData()
+      });
+    }, 2000);
+  }
+
+  componentWillUnmount() {
+    window.clearInterval(this.setStateInterval);
+  }
+
+  render() {
+    return (
+      <div className="demo">
+        <h1>Victory Candlestick</h1>
+
+        <VictoryCandlestick
+          style={{parent: style.parent}}
+          candleColors={{positive: "purple", negative: "blue"}}
+          data={[
+            {x: 50, open: 9, close: 30, high: 56, low: 7},
+            {x: 100, open: 80, close: 40, high: 100, low: 10},
+            {x: 150, open: 50, close: 80, high: 90, low: 20},
+            {x: 200, open: 70, close: 22, high: 70, low: 5},
+            {x: 250, open: 20, close: 35, high: 50, low: 10},
+            {x: 300, open: 35, close: 30, high: 40, low: 3},
+            {x: 350, open: 30, close: 90, high: 95, low: 30},
+            {x: 400, open: 80, close: 81, high: 83, low: 75}
+          ]}
+          size={8}
+        />
+      </div>
+    );
+  }
+}
+
+App.propTypes = {
+  data: React.PropTypes.arrayOf(React.PropTypes.object)
+};
+
+App.defaultProps = {
+  data: getData()
+};

--- a/demo/components/victory-candlestick-demo.js
+++ b/demo/components/victory-candlestick-demo.js
@@ -72,14 +72,14 @@ export default class App extends React.Component {
             style={{parent: style.parent}}
             candleColors={{positive: "purple", negative: "blue"}}
             data={[
-              {x: 50, open: 9, close: 30, high: 56, low: 7},
-              {x: 100, open: 80, close: 40, high: 120, low: 10},
-              {x: 150, open: 50, close: 80, high: 90, low: 20},
-              {x: 200, open: 70, close: 22, high: 70, low: 5},
-              {x: 250, open: 20, close: 35, high: 50, low: 10},
-              {x: 300, open: 35, close: 30, high: 40, low: 3},
-              {x: 350, open: 30, close: 90, high: 95, low: 30},
-              {x: 400, open: 80, close: 81, high: 83, low: 75}
+              {x: new Date(2016, 6, 1), open: 9, close: 30, high: 56, low: 7},
+              {x: new Date(2016, 6, 2), open: 80, close: 40, high: 120, low: 10},
+              {x: new Date(2016, 6, 3), open: 50, close: 80, high: 90, low: 20},
+              {x: new Date(2016, 6, 4), open: 70, close: 22, high: 70, low: 5},
+              {x: new Date(2016, 6, 5), open: 20, close: 35, high: 50, low: 10},
+              {x: new Date(2016, 6, 6), open: 35, close: 30, high: 40, low: 3},
+              {x: new Date(2016, 6, 7), open: 30, close: 90, high: 95, low: 30},
+              {x: new Date(2016, 6, 8), open: 80, close: 81, high: 83, low: 75}
             ]}
             size={8}
           />

--- a/src/components/victory-candlestick/candle.js
+++ b/src/components/victory-candlestick/candle.js
@@ -1,4 +1,5 @@
 import React, { PropTypes } from "react";
+import VictoryCandlestick from "./victory-candlestick";
 
 
 export default class Candle extends React.Component {
@@ -11,7 +12,7 @@ export default class Candle extends React.Component {
     y: PropTypes.number,
     candleHeight: PropTypes.number,
     scale: PropTypes.object,
-    // style: PropTypes.object,
+    style: PropTypes.object,
     datum: PropTypes.object,
     width: PropTypes.number,
     padding: PropTypes.number,
@@ -19,8 +20,8 @@ export default class Candle extends React.Component {
   }
 
   renderWick() {
-    const width = this.props.width;
-    const padding = this.props.padding;
+    const width = VictoryCandlestick.defaultProps.width;
+    const padding = VictoryCandlestick.defaultProps.padding;
     const dataLength = this.props.data.length;
     const x = this.props.x + 0.25 * (width - 2 * padding) / dataLength;
 
@@ -37,8 +38,8 @@ export default class Candle extends React.Component {
   }
 
   renderCandle() {
-    const width = this.props.width;
-    const padding = this.props.padding;
+    const width = VictoryCandlestick.defaultProps.width;
+    const padding = VictoryCandlestick.defaultProps.padding;
     const dataLength = this.props.data.length;
     const candleWidth = 0.5 * (width - 2 * padding) / dataLength;
 

--- a/src/components/victory-candlestick/candle.js
+++ b/src/components/victory-candlestick/candle.js
@@ -13,13 +13,16 @@ export default class Candle extends React.Component {
     style: PropTypes.object,
     datum: PropTypes.object,
     width: PropTypes.number,
-    padding: PropTypes.number,
+    padding: PropTypes.oneOfType([
+      PropTypes.number,
+      PropTypes.object
+    ]),
     data: PropTypes.array
   }
 
   renderWick() {
     const width = this.props.width;
-    const padding = this.props.padding;
+    const padding = this.props.padding.left || this.props.padding;
     const dataLength = this.props.data.length;
     const x = this.props.x + 0.25 * (width - 2 * padding) / dataLength;
 
@@ -36,7 +39,7 @@ export default class Candle extends React.Component {
 
   renderCandle() {
     const width = this.props.width;
-    const padding = this.props.padding;
+    const padding = this.props.padding.left || this.props.padding;
     const dataLength = this.props.data.length;
     const candleWidth = 0.5 * (width - 2 * padding) / dataLength;
 

--- a/src/components/victory-candlestick/candle.js
+++ b/src/components/victory-candlestick/candle.js
@@ -1,5 +1,4 @@
 import React, { PropTypes } from "react";
-import VictoryCandlestick from "./victory-candlestick";
 
 
 export default class Candle extends React.Component {
@@ -8,7 +7,6 @@ export default class Candle extends React.Component {
     x: PropTypes.number,
     y1: PropTypes.number,
     y2: PropTypes.number,
-    candleColor: PropTypes.string,
     y: PropTypes.number,
     candleHeight: PropTypes.number,
     scale: PropTypes.object,
@@ -20,8 +18,8 @@ export default class Candle extends React.Component {
   }
 
   renderWick() {
-    const width = VictoryCandlestick.defaultProps.width;
-    const padding = VictoryCandlestick.defaultProps.padding;
+    const width = this.props.width;
+    const padding = this.props.padding;
     const dataLength = this.props.data.length;
     const x = this.props.x + 0.25 * (width - 2 * padding) / dataLength;
 
@@ -31,25 +29,22 @@ export default class Candle extends React.Component {
           x2={x}
           y1={this.props.y1}
           y2={this.props.y2}
-          stroke={this.props.candleColor}
-          strokeWidth={1}
+          style={this.props.style}
         />
       );
   }
 
   renderCandle() {
-    const width = VictoryCandlestick.defaultProps.width;
-    const padding = VictoryCandlestick.defaultProps.padding;
+    const width = this.props.width;
+    const padding = this.props.padding;
     const dataLength = this.props.data.length;
     const candleWidth = 0.5 * (width - 2 * padding) / dataLength;
 
     return (
       <rect
-        fill={this.props.candleColor}
         x={this.props.x}
         y={this.props.y}
-        stroke={this.props.candleColor}
-        strokeWidth={1}
+        style={this.props.style}
         width={candleWidth}
         height={this.props.candleHeight}
       />

--- a/src/components/victory-candlestick/candle.js
+++ b/src/components/victory-candlestick/candle.js
@@ -21,10 +21,7 @@ export default class Candle extends React.Component {
   }
 
   renderWick() {
-    const width = this.props.width;
-    const padding = this.props.padding.left || this.props.padding;
-    const dataLength = this.props.data.length;
-    const x = this.props.x + 0.25 * (width - 2 * padding) / dataLength;
+    const x = this.props.x;
 
     return (
         <line
@@ -42,10 +39,11 @@ export default class Candle extends React.Component {
     const padding = this.props.padding.left || this.props.padding;
     const dataLength = this.props.data.length;
     const candleWidth = 0.5 * (width - 2 * padding) / dataLength;
+    const candleX = this.props.x - candleWidth / 2;
 
     return (
       <rect
-        x={this.props.x}
+        x={candleX}
         y={this.props.y}
         style={this.props.style}
         width={candleWidth}

--- a/src/components/victory-candlestick/candle.js
+++ b/src/components/victory-candlestick/candle.js
@@ -8,6 +8,7 @@ export default class Candle extends React.Component {
     y1: PropTypes.number,
     y2: PropTypes.number,
     y: PropTypes.number,
+    events: PropTypes.object,
     candleHeight: PropTypes.number,
     scale: PropTypes.object,
     style: PropTypes.object,
@@ -25,6 +26,7 @@ export default class Candle extends React.Component {
 
     return (
         <line
+          {...this.props.events}
           x1={x}
           x2={x}
           y1={this.props.y1}
@@ -43,6 +45,7 @@ export default class Candle extends React.Component {
 
     return (
       <rect
+        {...this.props.events}
         x={candleX}
         y={this.props.y}
         style={this.props.style}

--- a/src/components/victory-candlestick/candle.js
+++ b/src/components/victory-candlestick/candle.js
@@ -1,0 +1,67 @@
+import React, { PropTypes } from "react";
+
+
+export default class Candle extends React.Component {
+  static propTypes = {
+    index: React.PropTypes.number,
+    x: PropTypes.number,
+    y1: PropTypes.number,
+    y2: PropTypes.number,
+    candleColor: PropTypes.string,
+    y: PropTypes.number,
+    candleHeight: PropTypes.number,
+    scale: PropTypes.object,
+    // style: PropTypes.object,
+    datum: PropTypes.object,
+    width: PropTypes.number,
+    padding: PropTypes.number,
+    data: PropTypes.array
+  }
+
+  renderWick() {
+    const width = this.props.width;
+    const padding = this.props.padding;
+    const dataLength = this.props.data.length;
+    const x = this.props.x + 0.25 * (width - 2 * padding) / dataLength;
+
+    return (
+        <line
+          x1={x}
+          x2={x}
+          y1={this.props.y1}
+          y2={this.props.y2}
+          stroke={this.props.candleColor}
+          strokeWidth={1}
+        />
+      );
+  }
+
+  renderCandle() {
+    const width = this.props.width;
+    const padding = this.props.padding;
+    const dataLength = this.props.data.length;
+    const candleWidth = 0.5 * (width - 2 * padding) / dataLength;
+
+    return (
+      <rect
+        fill={this.props.candleColor}
+        x={this.props.x}
+        y={this.props.y}
+        stroke={this.props.candleColor}
+        strokeWidth={1}
+        width={candleWidth}
+        height={this.props.candleHeight}
+      />
+    );
+  }
+
+  render() {
+    return (
+      <g>
+        {this.renderWick()}
+
+        {this.renderCandle()}
+      </g>
+    );
+  }
+}

--- a/src/components/victory-candlestick/helper-methods.js
+++ b/src/components/victory-candlestick/helper-methods.js
@@ -1,7 +1,7 @@
 import { pick, omit, defaults } from "lodash";
 import { Helpers, Events } from "victory-core";
 import Scale from "../../helpers/scale";
-import Data from "../../helpers/data";
+// import Data from "../../helpers/data";
 
 export default {
   getBaseProps(props, defaultStyles) { // eslint-disable-line max-statements

--- a/src/components/victory-candlestick/helper-methods.js
+++ b/src/components/victory-candlestick/helper-methods.js
@@ -1,0 +1,96 @@
+import { pick, omit, defaults } from "lodash";
+import { Helpers, Events } from "victory-core";
+import Scale from "../../helpers/scale";
+import Domain from "../../helpers/domain";
+import Data from "../../helpers/data";
+
+export default {
+  getBaseProps(props, defaultStyles) {
+    const calculatedValues = this.getCalculatedValues(props, defaultStyles);
+    const { data, style, scale } = calculatedValues;
+    return data.reduce((memo, datum, index) => {
+      const eventKey = datum.eventKey;
+      const x = scale.x(datum.x);
+      const y = scale.y(datum.y);
+      const size = this.getSize(datum, props, calculatedValues);
+      const dataStyle = this.getDataStyles(datum, style.data);
+      const dataProps = {
+        x, y, size, scale, datum, index, style: dataStyle
+      };
+
+      const text = this.getLabelText(props, datum, index);
+      const labelStyle = this.getLabelStyle(style.labels, dataProps);
+      const labelProps = {
+        style: labelStyle,
+        x,
+        y: y - labelStyle.padding,
+        text,
+        index,
+        scale,
+        datum: dataProps.datum,
+        textAnchor: labelStyle.textAnchor,
+        verticalAnchor: labelStyle.verticalAnchor || "end",
+        angle: labelStyle.angle
+      };
+      memo[eventKey] = {
+        data: dataProps,
+        labels: labelProps
+      };
+      return memo;
+    }, {});
+  },
+
+  getCalculatedValues(props, defaultStyles) {
+    const style = Helpers.getStyles(props.style, defaultStyles, "auto", "100%");
+    const data = Events.addEventKeys(props, Data.getData(props));
+    const range = {
+      x: Helpers.getRange(props, "x"),
+      y: Helpers.getRange(props, "y")
+    };
+    const domain = {
+      x: Domain.getDomain(props, "x"),
+      y: Domain.getDomain(props, "y")
+    };
+    const scale = {
+      x: Scale.getBaseScale(props, "x").domain(domain.x).range(range.x),
+      y: Scale.getBaseScale(props, "y").domain(domain.y).range(range.y)
+    };
+    return {data, scale, style};
+  },
+
+  getDataStyles(datum, style) {
+    const stylesFromData = omit(datum, [
+      "x", "y", "size", "name", "label"
+    ]);
+    const baseDataStyle = defaults({}, stylesFromData, style);
+    return Helpers.evaluateStyle(baseDataStyle, datum);
+  },
+
+  getLabelText(props, datum, index) {
+    const propsLabel = Array.isArray(props.labels) ?
+      props.labels[index] : Helpers.evaluateProp(props.labels, datum);
+    return datum.label || propsLabel;
+  },
+
+  getLabelStyle(labelStyle, dataProps) {
+    const { datum, size, style } = dataProps;
+    const matchedStyle = pick(style, ["opacity", "fill"]);
+    const padding = labelStyle.padding || size * 0.25;
+    const baseLabelStyle = defaults({}, labelStyle, matchedStyle, {padding});
+    return Helpers.evaluateStyle(baseLabelStyle, datum);
+  },
+
+  getSize(data, props, calculatedValues) {
+    let size;
+    if (data.size) {
+      size = typeof data.size === "function" ? data.size : Math.max(data.size, 1);
+    } else if (typeof props.size === "function") {
+      size = props.size;
+    } else if (data[calculatedValues.z]) {
+      size = this.getBubbleSize(data, props, calculatedValues);
+    } else {
+      size = Math.max(props.size, 1);
+    }
+    return Helpers.evaluateProp(size, data);
+  }
+};

--- a/src/components/victory-candlestick/helper-methods.js
+++ b/src/components/victory-candlestick/helper-methods.js
@@ -72,10 +72,10 @@ export default {
     };
     return data.map((datum) => {
       const x = accessor.x(datum);
-      const { open } = accessor.open(datum);
-      const { close } = accessor.close(datum);
-      const { high } = accessor.high(datum);
-      const { low } = accessor.low(datum);
+      const open = accessor.open(datum);
+      const close = accessor.close(datum);
+      const high = accessor.high(datum);
+      const low = accessor.low(datum);
       const y = [open, close, high, low];
       return Object.assign(
         {},

--- a/src/components/victory-candlestick/helper-methods.js
+++ b/src/components/victory-candlestick/helper-methods.js
@@ -1,8 +1,6 @@
 import { pick, omit, defaults, flatten } from "lodash";
 import { Helpers, Events } from "victory-core";
 import Scale from "../../helpers/scale";
-import Domain from "../../helpers/domain";
-// import Data from "../../helpers/data";
 
 export default {
   getBaseProps(props, defaultStyles) { // eslint-disable-line max-statements

--- a/src/components/victory-candlestick/helper-methods.js
+++ b/src/components/victory-candlestick/helper-methods.js
@@ -45,6 +45,7 @@ export default {
   getCalculatedValues(props, defaultStyles) {
     const style = Helpers.getStyles(props.style, defaultStyles, "auto", "100%");
     const data = Events.addEventKeys(props, this.getData(props));
+    // console.log(this.getData({data: [{x: 5, open: 10, close: 20, high: 25, low: 5}]}));
     const range = {
       x: Helpers.getRange(props, "x"),
       y: Helpers.getRange(props, "y")
@@ -61,7 +62,8 @@ export default {
   },
 
   getData(props) {
-    return props.data.map((datum) => {
+    const data = props.data ? props.data : this.generateData(props);
+    return data.map((datum) => {
       const x = datum.x;
       const y = [datum.open, datum.close, datum.high, datum.low];
       return Object.assign(
@@ -70,6 +72,27 @@ export default {
         {x, y}
         );
     });
+  },
+
+  generateData(props) {
+    // create an array of values evenly spaced across the x domain that include domain min/max
+    const domain = props.domain ? (props.domain.x || props.domain) :
+      Scale.getBaseScale(props, "x").domain();
+    const samples = props.samples || 1;
+    const max = Math.max(...domain);
+    const values = Array(...Array(samples)).map((val, index) => {
+      const v = (max / samples) * index + Math.min(...domain);
+      return { x: v, open: v, close: v + 2, low: v - 3, high: v + 5 };
+    });
+    return values[samples - 1].x === max ? values : values.concat([
+      {
+        x: max,
+        open: max,
+        close: max,
+        high: max,
+        low: max
+      }
+    ]);
   },
 
   getDomain(props, axis) {

--- a/src/components/victory-candlestick/helper-methods.js
+++ b/src/components/victory-candlestick/helper-methods.js
@@ -1,6 +1,7 @@
 import { pick, omit, defaults } from "lodash";
 import { Helpers, Events } from "victory-core";
 import Scale from "../../helpers/scale";
+import Data from "../../helpers/data";
 
 export default {
   getBaseProps(props, defaultStyles) { // eslint-disable-line max-statements
@@ -73,19 +74,25 @@ export default {
   },
 
   getDomain(props, axis) {
-    const dataset = this.getData(props);
-    const allData = dataset.reduce((memo, datum) => {
-      return Array.isArray(datum[axis]) ?
-       memo.concat(...datum[axis]) : memo.concat(datum[axis]);
-    },
-    []);
-    const min = Math.min(...allData);
-    const max = Math.max(...allData);
-    if (min === max) {
-      const adjustedMax = max === 0 ? 1 : max;
-      return [0, adjustedMax];
+    if (props.domain && props.domain[axis]) {
+      return props.domain[axis];
+    } else if (props.domain && Array.isArray(props.domain)) {
+      return props.domain;
+    } else {
+      const dataset = this.getData(props);
+      const allData = dataset.reduce((memo, datum) => {
+        return Array.isArray(datum[axis]) ?
+         memo.concat(...datum[axis]) : memo.concat(datum[axis]);
+      },
+      []);
+      const min = Math.min(...allData);
+      const max = Math.max(...allData);
+      if (min === max) {
+        const adjustedMax = max === 0 ? 1 : max;
+        return [0, adjustedMax];
+      }
+      return [min, max];
     }
-    return [min, max];
   },
 
   getDataStyles(datum, style, props) {

--- a/src/components/victory-candlestick/helper-methods.js
+++ b/src/components/victory-candlestick/helper-methods.js
@@ -1,7 +1,6 @@
 import { pick, omit, defaults } from "lodash";
 import { Helpers, Events } from "victory-core";
 import Scale from "../../helpers/scale";
-// import Data from "../../helpers/data";
 
 export default {
   getBaseProps(props, defaultStyles) { // eslint-disable-line max-statements

--- a/src/components/victory-candlestick/helper-methods.js
+++ b/src/components/victory-candlestick/helper-methods.js
@@ -62,37 +62,27 @@ export default {
   },
 
   getData(props) {
-    const data = props.data ? props.data : this.generateData(props);
+    const data = props.data;
+    const accessor = {
+      x: Helpers.createAccessor(props.x),
+      open: Helpers.createAccessor(props.open),
+      close: Helpers.createAccessor(props.close),
+      high: Helpers.createAccessor(props.high),
+      low: Helpers.createAccessor(props.low)
+    };
     return data.map((datum) => {
-      const x = datum.x;
-      const y = [datum.open, datum.close, datum.high, datum.low];
+      const x = accessor.x(datum);
+      const { open } = accessor.open(datum);
+      const { close } = accessor.close(datum);
+      const { high } = accessor.high(datum);
+      const { low } = accessor.low(datum);
+      const y = [open, close, high, low];
       return Object.assign(
         {},
         datum,
         {x, y}
         );
     });
-  },
-
-  generateData(props) {
-    // create an array of values evenly spaced across the x domain that include domain min/max
-    const domain = props.domain ? (props.domain.x || props.domain) :
-      Scale.getBaseScale(props, "x").domain();
-    const samples = props.samples || 1;
-    const max = Math.max(...domain);
-    const values = Array(...Array(samples)).map((val, index) => {
-      const v = (max / samples) * index + Math.min(...domain);
-      return { x: v, open: v, close: v + 2, low: v - 3, high: v + 5 };
-    });
-    return values[samples - 1].x === max ? values : values.concat([
-      {
-        x: max,
-        open: max,
-        close: max,
-        high: max,
-        low: max
-      }
-    ]);
   },
 
   getDomain(props, axis) {

--- a/src/components/victory-candlestick/helper-methods.js
+++ b/src/components/victory-candlestick/helper-methods.js
@@ -1,7 +1,7 @@
 import { pick, omit, defaults } from "lodash";
 import { Helpers, Events } from "victory-core";
 import Scale from "../../helpers/scale";
-import Domain from "../../helpers/domain";
+// import Domain from "../../helpers/domain";
 import Data from "../../helpers/data";
 
 export default {
@@ -11,11 +11,17 @@ export default {
     return data.reduce((memo, datum, index) => {
       const eventKey = datum.eventKey;
       const x = scale.x(datum.x);
-      const y = scale.y(datum.y);
+      const y1 = scale.y(datum.high);
+      const y2 = scale.y(datum.low);
+      const candleColor = datum.open > datum.close ?
+            props.candleColors.negative : props.candleColors.positive;
+      const candleHeight = Math.abs(scale.y(datum.open) - scale.y(datum.close));
+      const y = scale.y(Math.max(datum.open, datum.close));
       const size = this.getSize(datum, props, calculatedValues);
       const dataStyle = this.getDataStyles(datum, style.data);
       const dataProps = {
-        x, y, size, scale, datum, index, style: dataStyle
+        x, y, y1, y2, candleColor, candleHeight, size, scale, data, datum,
+        index, style: dataStyle
       };
 
       const text = this.getLabelText(props, datum, index);
@@ -47,20 +53,20 @@ export default {
       x: Helpers.getRange(props, "x"),
       y: Helpers.getRange(props, "y")
     };
-    const domain = {
-      x: Domain.getDomain(props, "x"),
-      y: Domain.getDomain(props, "y")
-    };
+    // const domain = {
+    //   x: Domain.getDomain(props, "x"),
+    //   y: Domain.getDomain(props, "y")
+    // };
     const scale = {
-      x: Scale.getBaseScale(props, "x").domain(domain.x).range(range.x),
-      y: Scale.getBaseScale(props, "y").domain(domain.y).range(range.y)
+      x: Scale.getBaseScale(props, "x").domain([50, 400]).range(range.x),
+      y: Scale.getBaseScale(props, "y").domain([0, 100]).range(range.y)
     };
     return {data, scale, style};
   },
 
   getDataStyles(datum, style) {
     const stylesFromData = omit(datum, [
-      "x", "y", "size", "name", "label"
+      "x", "y", "size", "name", "label", "open", "close", "high", "low"
     ]);
     const baseDataStyle = defaults({}, stylesFromData, style);
     return Helpers.evaluateStyle(baseDataStyle, datum);

--- a/src/components/victory-candlestick/helper-methods.js
+++ b/src/components/victory-candlestick/helper-methods.js
@@ -62,8 +62,6 @@ export default {
       x: Scale.getBaseScale(props, "x").domain(domain.x).range(range.x),
       y: Scale.getBaseScale(props, "y").domain(domain.y).range(range.y)
     };
-    console.log(domain.x);
-    console.log(domain.y);
     return {data, scale, style};
   },
 
@@ -95,22 +93,6 @@ export default {
     }
     return [min, max];
   },
-
-  // getDomainY(props) {
-  //   const dataset = this.getData(props);
-  //   const allData = flatten(dataset).map((datum) => {
-  //     return datum.y;
-  //   });
-  //   const flattened = flatten(allData);
-  //   const min = Math.min(...flattened);
-  //   const max = Math.max(...flattened);
-  //   if (min === max) {
-  //     const adjustedMax = max === 0 ? 1 : max;
-  //     return [0, adjustedMax];
-  //   }
-  //   return [min, max];
-
-  // },
 
   getDataStyles(datum, style) {
     const stylesFromData = omit(datum, [

--- a/src/components/victory-candlestick/victory-candlestick.js
+++ b/src/components/victory-candlestick/victory-candlestick.js
@@ -48,21 +48,6 @@ export default class VictoryCandlestick extends React.Component {
      */
     animate: PropTypes.object,
     /**
-     * The categories prop specifies how categorical data for a chart should be ordered.
-     * This prop should be given as an array of string values, or an object with
-     * these arrays of values specified for x and y. If this prop is not set,
-     * categorical data will be plotted in the order it was given in the data array
-     * @examples ["dogs", "cats", "mice"]
-     */
-    categories: PropTypes.oneOfType([
-      PropTypes.arrayOf(PropTypes.string),
-      PropTypes.shape({
-        x: PropTypes.arrayOf(PropTypes.string),
-        y: PropTypes.arrayOf(PropTypes.string)
-      })
-    ]),
-
-    /**
      * The data prop specifies the data to be plotted.
      * Data should be in the form of an array of data points.
      * Each data point may be any format you wish (depending on the `x` and `y` accessor props),
@@ -308,7 +293,14 @@ export default class VictoryCandlestick extends React.Component {
      * popular each dog breed is by percentage in Seattle." />
      */
     containerComponent: PropTypes.element,
-    /**/
+    /**
+    * Candle colors are significant in candlestick charts - one color signifies the stock
+    * closed at a higher price than it opened, and the other signifies the reverse. The
+    * candleColors prop takes an object with keys positive and negative, which each take
+    * a string that should be a color. Positive is for data points where close is higher
+    * than open, and defaults to green, and negative (close < open) defaults to red.
+    * @example: candleColors={{positive: "purple", negative: "blue"}}
+    */
     candleColors: PropTypes.shape({
       positive: PropTypes.string,
       negative: PropTypes.string

--- a/src/components/victory-candlestick/victory-candlestick.js
+++ b/src/components/victory-candlestick/victory-candlestick.js
@@ -1,8 +1,6 @@
 import React, { PropTypes } from "react";
 import { defaults, isFunction, partialRight } from "lodash";
 import Candle from "./candle";
-import Domain from "../../helpers/domain";
-import Data from "../../helpers/data";
 import {
   PropTypes as CustomPropTypes, Helpers, Events, VictoryTransition, VictoryLabel,
   VictoryContainer

--- a/src/components/victory-candlestick/victory-candlestick.js
+++ b/src/components/victory-candlestick/victory-candlestick.js
@@ -25,7 +25,7 @@ const defaultStyles = {
 };
 
 export default class VictoryCandlestick extends React.Component {
-  static role = "scatter";
+  static role = "candlestick";
 
   static defaultTransitions = {
     onExit: {
@@ -61,10 +61,10 @@ export default class VictoryCandlestick extends React.Component {
     /**
      * The dataComponent prop takes an entire component which will be used to create points for
      * each datum in the chart. The new element created from the passed dataComponent will be
-     * provided with the following properties calculated by VictoryScatter: datum, index, scale,
+     * provided with the following properties calculated by VictoryCandlestick: datum, index, scale,
      * style, events, x, y, size, and symbol. Any of these props may be overridden by passing in
      * props to the supplied component, or modified or ignored within the custom component itself.
-     * If a dataComponent is not provided, VictoryScatter will use its default Point component.
+     * If a dataComponent is not provided, VictoryCandlestick will use its default Point component.
      */
     dataComponent: PropTypes.element,
     /**
@@ -85,7 +85,7 @@ export default class VictoryCandlestick extends React.Component {
     /**
      * The event prop take an array of event objects. Event objects are composed of
      * a target, an eventKey, and eventHandlers. Targets may be any valid style namespace
-     * for a given component, so "data" and "labels" are all valid targets for VictoryScatter
+     * for a given component, so "data" and "labels" are all valid targets for VictoryCandlestick
      * events. The eventKey may optionally be used to select a single element by index rather than
      * an entire set. The eventHandlers object should be given as an object whose keys are standard
      * event names (i.e. onClick) and whose values are event callbacks. The return value
@@ -160,7 +160,7 @@ export default class VictoryCandlestick extends React.Component {
     height: CustomPropTypes.nonNegative,
     /**
      * The labelComponent prop takes in an entire label component which will be used
-     * to create labels for each point in the scatter. The new element created from
+     * to create labels for each point in the chart. The new element created from
      * the passed labelComponent will be supplied with the following properties:
      * x, y, index, datum, verticalAnchor, textAnchor, angle, style, text, and events.
      * any of these props may be overridden by passing in props to the supplied component,
@@ -223,11 +223,11 @@ export default class VictoryCandlestick extends React.Component {
     /**
      * The standalone prop determines whether the component will render a standalone svg
      * or a <g> tag that will be included in an external svg. Set standalone to false to
-     * compose VictoryScatter with other components within an enclosing <svg> tag.
+     * compose VictoryCandlestick with other components within an enclosing <svg> tag.
      */
     standalone: PropTypes.bool,
     /**
-     * The style prop specifies styles for your VictoryScatter. Any valid inline style properties
+     * The style prop specifies styles for your VictoryCandlestick. Any valid inline style properties
      * will be applied. Height, width, and padding should be specified via the height,
      * width, and padding props, as they are used to calculate the alignment of
      * components within chart. In addition to normal style properties, angle and verticalAnchor
@@ -281,14 +281,14 @@ export default class VictoryCandlestick extends React.Component {
      * The containerComponent prop takes an entire component which will be used to
      * create a container element for standalone charts.
      * The new element created from the passed containerComponent wil be provided with
-     * these props from VictoryScatter: height, width, children
+     * these props from VictoryCandlestick: height, width, children
      * (the chart itself) and style. Props that are not provided by the
      * child chart component include title and desc, both of which
      * are intended to add accessibility to Victory components. The more descriptive these props
      * are, the more accessible your data will be for people using screen readers.
      * Any of these props may be overridden by passing in props to the supplied component,
      * or modified or ignored within the custom component itself. If a dataComponent is
-     * not provided, VictoryScatter will use the default VictoryContainer component.
+     * not provided, VictoryCandlestick will use the default VictoryContainer component.
      * @example <VictoryContainer title="Chart of Dog Breeds" desc="This chart shows how
      * popular each dog breed is by percentage in Seattle." />
      */
@@ -356,17 +356,17 @@ export default class VictoryCandlestick extends React.Component {
     return Object.keys(this.baseProps).map((key) => {
       const dataEvents = this.getEvents(props, "data", key);
       const dataProps = defaults(
-        {key: `scatter-${key}`},
+        {key: `candlestick-${key}`},
         this.getEventState(key, "data"),
         getSharedEventState(key, "data"),
         this.baseProps[key].data,
         dataComponent.props
       );
-      const scatterComponent = React.cloneElement(dataComponent, Object.assign(
+      const candleComponent = React.cloneElement(dataComponent, Object.assign(
         {}, dataProps, {events: Events.getPartialEvents(dataEvents, key, dataProps)}
       ));
       const labelProps = defaults(
-        {key: `scatter-label-${key}`},
+        {key: `candlestick-label-${key}`},
         this.getEventState(key, "labels"),
         getSharedEventState(key, "labels"),
         this.baseProps[key].labels,
@@ -374,23 +374,23 @@ export default class VictoryCandlestick extends React.Component {
       );
       if (labelProps && labelProps.text) {
         const labelEvents = this.getEvents(props, "labels", key);
-        const scatterLabel = React.cloneElement(labelComponent, Object.assign({
+        const candleLabel = React.cloneElement(labelComponent, Object.assign({
           events: Events.getPartialEvents(labelEvents, key, labelProps)
         }, labelProps));
         return (
-          <g key={`scatter-group-${key}`}>
-            {scatterComponent}
-            {scatterLabel}
+          <g key={`candle-group-${key}`}>
+            {candleComponent}
+            {candleLabel}
           </g>
         );
       }
-      return scatterComponent;
+      return candleComponent;
     });
   }
 
   render() {
     // If animating, return a `VictoryAnimation` element that will create
-    // a new `VictoryScatter` with nearly identical props, except (1) tweened
+    // a new `VictoryCandlestick` with nearly identical props, except (1) tweened
     // and (2) `animate` set to null so we don't recurse forever.
     if (this.props.animate) {
       // Do less work by having `VictoryAnimation` tween only values that

--- a/src/components/victory-candlestick/victory-candlestick.js
+++ b/src/components/victory-candlestick/victory-candlestick.js
@@ -340,22 +340,6 @@ export default class VictoryCandlestick extends React.Component {
       PropTypes.arrayOf(PropTypes.string)
     ]),
     /**
-     * The y prop specifies how to access the Y value of each data point.
-     * If given as a function, it will be run on each data point, and returned value will be used.
-     * If given as an integer, it will be used as an array index for array-type data points.
-     * If given as a string, it will be used as a property key for object-type data points.
-     * If given as an array of strings, or a string containing dots or brackets,
-     * it will be used as a nested object property path (for details see Lodash docs for _.get).
-     * If `null` or `undefined`, the data value will be used as is (identity function/pass-through).
-     * @examples 0, 'y', 'y.value.nested.1.thing', 'y[2].also.nested', null, d => Math.sin(d)
-     */
-    y: PropTypes.oneOfType([
-      PropTypes.func,
-      CustomPropTypes.allOfType([CustomPropTypes.integer, CustomPropTypes.nonNegative]),
-      PropTypes.string,
-      PropTypes.arrayOf(PropTypes.string)
-    ]),
-    /**
      * The containerComponent prop takes an entire component which will be used to
      * create a container element for standalone charts.
      * The new element created from the passed containerComponent wil be provided with
@@ -400,7 +384,6 @@ export default class VictoryCandlestick extends React.Component {
     close: "close",
     high: "high",
     low: "low",
-    y: "y",
     dataComponent: <Candle/>,
     labelComponent: <VictoryLabel/>,
     containerComponent: <VictoryContainer/>,

--- a/src/components/victory-candlestick/victory-candlestick.js
+++ b/src/components/victory-candlestick/victory-candlestick.js
@@ -14,7 +14,7 @@ const defaultStyles = {
     fill: "#756f6a",
     opacity: 1,
     stroke: "transparent",
-    strokeWidth: 0
+    strokeWidth: 1
   },
   labels: {
     stroke: "transparent",
@@ -63,11 +63,7 @@ export default class VictoryCandlestick extends React.Component {
         y: PropTypes.arrayOf(PropTypes.string)
       })
     ]),
-    /**
-     * The bubbleProperty prop indicates which property of the data object should be used
-     * to scale data points in a bubble chart
-     */
-    bubbleProperty: PropTypes.string,
+
     /**
      * The data prop specifies the data to be plotted.
      * Data should be in the form of an array of data points.
@@ -202,10 +198,6 @@ export default class VictoryCandlestick extends React.Component {
       PropTypes.array
     ]),
     /**
-     * The maxBubbleSize prop sets an upper limit for scaling data points in a bubble chart
-     */
-    maxBubbleSize: CustomPropTypes.nonNegative,
-    /**
      * The padding props specifies the amount of padding in number of pixels between
      * the edge of the chart and any rendered child components. This prop can be given
      * as a number or as an object with padding specified for top, bottom, left
@@ -266,15 +258,6 @@ export default class VictoryCandlestick extends React.Component {
       labels: PropTypes.object
     }),
     /**
-     * The symbol prop determines which symbol should be drawn to represent data points.
-     */
-    symbol: PropTypes.oneOfType([
-      PropTypes.oneOf([
-        "circle", "diamond", "plus", "square", "star", "triangleDown", "triangleUp"
-      ]),
-      PropTypes.func
-    ]),
-    /**
      * The width props specifies the width of the svg viewBox of the chart container
      * This value should be given as a number of pixels
      */
@@ -326,7 +309,12 @@ export default class VictoryCandlestick extends React.Component {
      * @example <VictoryContainer title="Chart of Dog Breeds" desc="This chart shows how
      * popular each dog breed is by percentage in Seattle." />
      */
-    containerComponent: PropTypes.element
+    containerComponent: PropTypes.element,
+    /**/
+    candleColors: PropTypes.shape({
+      positive: PropTypes.string,
+      negative: PropTypes.string
+    })
   };
 
   static defaultProps = {
@@ -342,11 +330,15 @@ export default class VictoryCandlestick extends React.Component {
     y: "y",
     dataComponent: <Candle/>,
     labelComponent: <VictoryLabel/>,
-    containerComponent: <VictoryContainer/>
+    containerComponent: <VictoryContainer/>,
+    candleColors: {
+      positive: "green",
+      negative: "red"
+    }
   };
 
-  static getDomain = Domain.getDomain.bind(Domain);
-  static getData = Data.getData.bind(Data);
+  static getDomain = CandlestickHelpers.getDomain.bind(CandlestickHelpers);
+  static getData = CandlestickHelpers.getData.bind(CandlestickHelpers);
   static getBaseProps = partialRight(
     CandlestickHelpers.getBaseProps.bind(CandlestickHelpers), defaultStyles
   );
@@ -374,7 +366,7 @@ export default class VictoryCandlestick extends React.Component {
     return Object.keys(this.baseProps).map((key) => {
       const dataEvents = this.getEvents(props, "data", key);
       const dataProps = defaults(
-        {key: `candle-${key}`},
+        {key: `scatter-${key}`},
         this.getEventState(key, "data"),
         getSharedEventState(key, "data"),
         this.baseProps[key].data,

--- a/src/components/victory-candlestick/victory-candlestick.js
+++ b/src/components/victory-candlestick/victory-candlestick.js
@@ -20,7 +20,7 @@ const defaultStyles = {
     stroke: "transparent",
     fill: "#756f6a",
     fontFamily: "Helvetica",
-    fontSize: 10,
+    fontSize: 13,
     textAnchor: "middle",
     padding: 10
   }
@@ -374,7 +374,7 @@ export default class VictoryCandlestick extends React.Component {
     return Object.keys(this.baseProps).map((key) => {
       const dataEvents = this.getEvents(props, "data", key);
       const dataProps = defaults(
-        {key: `scatter-${key}`},
+        {key: `candle-${key}`},
         this.getEventState(key, "data"),
         getSharedEventState(key, "data"),
         this.baseProps[key].data,

--- a/src/components/victory-candlestick/victory-candlestick.js
+++ b/src/components/victory-candlestick/victory-candlestick.js
@@ -227,8 +227,8 @@ export default class VictoryCandlestick extends React.Component {
      */
     standalone: PropTypes.bool,
     /**
-     * The style prop specifies styles for your VictoryCandlestick. Any valid inline style properties
-     * will be applied. Height, width, and padding should be specified via the height,
+     * The style prop specifies styles for your VictoryCandlestick. Any valid inline style
+     * properties will be applied. Height, width, and padding should be specified via the height,
      * width, and padding props, as they are used to calculate the alignment of
      * components within chart. In addition to normal style properties, angle and verticalAnchor
      * may also be specified via the labels object, and they will be passed as props to

--- a/src/components/victory-candlestick/victory-candlestick.js
+++ b/src/components/victory-candlestick/victory-candlestick.js
@@ -1,0 +1,446 @@
+import React, { PropTypes } from "react";
+import { defaults, isFunction, partialRight } from "lodash";
+import Candle from "./candle";
+import Domain from "../../helpers/domain";
+import Data from "../../helpers/data";
+import {
+  PropTypes as CustomPropTypes, Helpers, Events, VictoryTransition, VictoryLabel,
+  VictoryContainer
+} from "victory-core";
+import CandlestickHelpers from "./helper-methods";
+
+const defaultStyles = {
+  data: {
+    fill: "#756f6a",
+    opacity: 1,
+    stroke: "transparent",
+    strokeWidth: 0
+  },
+  labels: {
+    stroke: "transparent",
+    fill: "#756f6a",
+    fontFamily: "Helvetica",
+    fontSize: 10,
+    textAnchor: "middle",
+    padding: 10
+  }
+};
+
+export default class VictoryCandlestick extends React.Component {
+  static role = "scatter";
+
+  static defaultTransitions = {
+    onExit: {
+      duration: 600,
+      before: () => ({ opacity: 0 })
+    },
+    onEnter: {
+      duration: 600,
+      before: () => ({ opacity: 0 }),
+      after: (datum) => ({ opacity: datum.opacity || 1 })
+    }
+  };
+
+  static propTypes = {
+    /**
+     * The animate prop specifies props for VictoryAnimation to use. The animate prop should
+     * also be used to specify enter and exit transition configurations with the `onExit`
+     * and `onEnter` namespaces respectively.
+     * @examples {duration: 500, onEnd: () => {}, onEnter: {duration: 500, before: () => ({y: 0})})}
+     */
+    animate: PropTypes.object,
+    /**
+     * The categories prop specifies how categorical data for a chart should be ordered.
+     * This prop should be given as an array of string values, or an object with
+     * these arrays of values specified for x and y. If this prop is not set,
+     * categorical data will be plotted in the order it was given in the data array
+     * @examples ["dogs", "cats", "mice"]
+     */
+    categories: PropTypes.oneOfType([
+      PropTypes.arrayOf(PropTypes.string),
+      PropTypes.shape({
+        x: PropTypes.arrayOf(PropTypes.string),
+        y: PropTypes.arrayOf(PropTypes.string)
+      })
+    ]),
+    /**
+     * The bubbleProperty prop indicates which property of the data object should be used
+     * to scale data points in a bubble chart
+     */
+    bubbleProperty: PropTypes.string,
+    /**
+     * The data prop specifies the data to be plotted.
+     * Data should be in the form of an array of data points.
+     * Each data point may be any format you wish (depending on the `x` and `y` accessor props),
+     * but by default, an object with x and y properties is expected.
+     * Other properties may be added to the data point object, such as fill, size, and symbol.
+     * These properties will be interpreted and applied to the individual lines
+     * @examples [{x: 1, y: 2, fill: "red"}, {x: 2, y: 3, label: "foo"}]
+     */
+
+    data: PropTypes.array,
+    /**
+     * The dataComponent prop takes an entire component which will be used to create points for
+     * each datum in the chart. The new element created from the passed dataComponent will be
+     * provided with the following properties calculated by VictoryScatter: datum, index, scale,
+     * style, events, x, y, size, and symbol. Any of these props may be overridden by passing in
+     * props to the supplied component, or modified or ignored within the custom component itself.
+     * If a dataComponent is not provided, VictoryScatter will use its default Point component.
+     */
+    dataComponent: PropTypes.element,
+    /**
+     * The domain prop describes the range of values your chart will include. This prop can be
+     * given as a array of the minimum and maximum expected values for your chart,
+     * or as an object that specifies separate arrays for x and y.
+     * If this prop is not provided, a domain will be calculated from data, or other
+     * available information.
+     * @examples [-1, 1], {x: [0, 100], y: [0, 1]}
+     */
+    domain: PropTypes.oneOfType([
+      CustomPropTypes.domain,
+      PropTypes.shape({
+        x: CustomPropTypes.domain,
+        y: CustomPropTypes.domain
+      })
+    ]),
+    /**
+     * The event prop take an array of event objects. Event objects are composed of
+     * a target, an eventKey, and eventHandlers. Targets may be any valid style namespace
+     * for a given component, so "data" and "labels" are all valid targets for VictoryScatter
+     * events. The eventKey may optionally be used to select a single element by index rather than
+     * an entire set. The eventHandlers object should be given as an object whose keys are standard
+     * event names (i.e. onClick) and whose values are event callbacks. The return value
+     * of an event handler is used to modify elemnts. The return value should be given
+     * as an object or an array of objects with optional target and eventKey keys,
+     * and a mutation key whose value is a function. The target and eventKey keys
+     * will default to those corresponding to the element the event handler was attached to.
+     * The mutation function will be called with the calculated props for the individual selected
+     * element (i.e. a single bar), and the object returned from the mutation function
+     * will override the props of the selected element via object assignment.
+     * @examples
+     * events={[
+     *   {
+     *     target: "data",
+     *     eventKey: "thisOne",
+     *     eventHandlers: {
+     *       onClick: () => {
+     *         return [
+     *            {
+     *              eventKey: "theOtherOne",
+     *              mutation: (props) => {
+     *                return {style: merge({}, props.style, {fill: "orange"})};
+     *              }
+     *            }, {
+     *              eventKey: "theOtherOne",
+     *              target: "labels",
+     *              mutation: () => {
+     *                return {text: "hey"};
+     *              }
+     *            }
+     *          ];
+     *       }
+     *     }
+     *   }
+     * ]}
+     *}}
+     */
+    events: PropTypes.arrayOf(PropTypes.shape({
+      target: PropTypes.oneOf(["data", "labels"]),
+      eventKey: PropTypes.oneOfType([
+        PropTypes.func,
+        CustomPropTypes.allOfType([CustomPropTypes.integer, CustomPropTypes.nonNegative]),
+        PropTypes.string
+      ]),
+      eventHandlers: PropTypes.object
+    })),
+    /**
+     * The name prop is used to reference a component instance when defining shared events.
+     */
+    name: PropTypes.string,
+    /**
+     * Similar to data accessor props `x` and `y`, this prop may be used to functionally
+     * assign eventKeys to data
+     */
+    eventKey: PropTypes.oneOfType([
+      PropTypes.func,
+      CustomPropTypes.allOfType([CustomPropTypes.integer, CustomPropTypes.nonNegative]),
+      PropTypes.string
+    ]),
+    /**
+     * This prop is used to coordinate events between VictoryArea and other Victory
+     * Components via VictorySharedEvents. This prop should not be set manually.
+     */
+    sharedEvents: PropTypes.shape({
+      events: PropTypes.array,
+      getEventState: PropTypes.func
+    }),
+    /**
+     * The height props specifies the height the svg viewBox of the chart container.
+     * This value should be given as a number of pixels
+     */
+    height: CustomPropTypes.nonNegative,
+    /**
+     * The labelComponent prop takes in an entire label component which will be used
+     * to create labels for each point in the scatter. The new element created from
+     * the passed labelComponent will be supplied with the following properties:
+     * x, y, index, datum, verticalAnchor, textAnchor, angle, style, text, and events.
+     * any of these props may be overridden by passing in props to the supplied component,
+     * or modified or ignored within the custom component itself. If labelComponent is omitted,
+     * a new VictoryLabel will be created with props described above.
+     */
+    labelComponent: PropTypes.element,
+    /**
+     * The labels prop defines labels that will appear with each point in your chart.
+     * This prop should be given as an array of values or as a function of data.
+     * If given as an array, the number of elements in the array should be equal to
+     * the length of the data array. Labels may also be added directly to the data object
+     * like data={[{x: 1, y: 1, label: "first"}]}.
+     * @examples: ["spring", "summer", "fall", "winter"], (datum) => datum.title
+     */
+    labels: PropTypes.oneOfType([
+      PropTypes.func,
+      PropTypes.array
+    ]),
+    /**
+     * The maxBubbleSize prop sets an upper limit for scaling data points in a bubble chart
+     */
+    maxBubbleSize: CustomPropTypes.nonNegative,
+    /**
+     * The padding props specifies the amount of padding in number of pixels between
+     * the edge of the chart and any rendered child components. This prop can be given
+     * as a number or as an object with padding specified for top, bottom, left
+     * and right.
+     */
+    padding: PropTypes.oneOfType([
+      PropTypes.number,
+      PropTypes.shape({
+        top: PropTypes.number,
+        bottom: PropTypes.number,
+        left: PropTypes.number,
+        right: PropTypes.number
+      })
+    ]),
+    /**
+     * The samples prop specifies how many individual points to plot when plotting
+     * y as a function of x. Samples is ignored if x props are provided instead.
+     */
+    samples: CustomPropTypes.nonNegative,
+    /**
+     * The scale prop determines which scales your chart should use. This prop can be
+     * given as a string specifying a supported scale ("linear", "time", "log", "sqrt"),
+     * as a d3 scale function, or as an object with scales specified for x and y
+     * @exampes d3Scale.time(), {x: "linear", y: "log"}
+     */
+    scale: PropTypes.oneOfType([
+      CustomPropTypes.scale,
+      PropTypes.shape({
+        x: CustomPropTypes.scale,
+        y: CustomPropTypes.scale
+      })
+    ]),
+    /**
+     * The size prop determines how to scale each data point
+     */
+    size: PropTypes.oneOfType([
+      CustomPropTypes.nonNegative,
+      PropTypes.func
+    ]),
+    /**
+     * The standalone prop determines whether the component will render a standalone svg
+     * or a <g> tag that will be included in an external svg. Set standalone to false to
+     * compose VictoryScatter with other components within an enclosing <svg> tag.
+     */
+    standalone: PropTypes.bool,
+    /**
+     * The style prop specifies styles for your VictoryScatter. Any valid inline style properties
+     * will be applied. Height, width, and padding should be specified via the height,
+     * width, and padding props, as they are used to calculate the alignment of
+     * components within chart. In addition to normal style properties, angle and verticalAnchor
+     * may also be specified via the labels object, and they will be passed as props to
+     * VictoryLabel, or any custom labelComponent.
+     * @examples {data: {fill: "red"}, labels: {fontSize: 12}}
+     */
+    style: PropTypes.shape({
+      parent: PropTypes.object,
+      data: PropTypes.object,
+      labels: PropTypes.object
+    }),
+    /**
+     * The symbol prop determines which symbol should be drawn to represent data points.
+     */
+    symbol: PropTypes.oneOfType([
+      PropTypes.oneOf([
+        "circle", "diamond", "plus", "square", "star", "triangleDown", "triangleUp"
+      ]),
+      PropTypes.func
+    ]),
+    /**
+     * The width props specifies the width of the svg viewBox of the chart container
+     * This value should be given as a number of pixels
+     */
+    width: CustomPropTypes.nonNegative,
+    /**
+     * The x prop specifies how to access the X value of each data point.
+     * If given as a function, it will be run on each data point, and returned value will be used.
+     * If given as an integer, it will be used as an array index for array-type data points.
+     * If given as a string, it will be used as a property key for object-type data points.
+     * If given as an array of strings, or a string containing dots or brackets,
+     * it will be used as a nested object property path (for details see Lodash docs for _.get).
+     * If `null` or `undefined`, the data value will be used as is (identity function/pass-through).
+     * @examples 0, 'x', 'x.value.nested.1.thing', 'x[2].also.nested', null, d => Math.sin(d)
+     */
+    x: PropTypes.oneOfType([
+      PropTypes.func,
+      CustomPropTypes.allOfType([CustomPropTypes.integer, CustomPropTypes.nonNegative]),
+      PropTypes.string,
+      PropTypes.arrayOf(PropTypes.string)
+    ]),
+    /**
+     * The y prop specifies how to access the Y value of each data point.
+     * If given as a function, it will be run on each data point, and returned value will be used.
+     * If given as an integer, it will be used as an array index for array-type data points.
+     * If given as a string, it will be used as a property key for object-type data points.
+     * If given as an array of strings, or a string containing dots or brackets,
+     * it will be used as a nested object property path (for details see Lodash docs for _.get).
+     * If `null` or `undefined`, the data value will be used as is (identity function/pass-through).
+     * @examples 0, 'y', 'y.value.nested.1.thing', 'y[2].also.nested', null, d => Math.sin(d)
+     */
+    y: PropTypes.oneOfType([
+      PropTypes.func,
+      CustomPropTypes.allOfType([CustomPropTypes.integer, CustomPropTypes.nonNegative]),
+      PropTypes.string,
+      PropTypes.arrayOf(PropTypes.string)
+    ]),
+    /**
+     * The containerComponent prop takes an entire component which will be used to
+     * create a container element for standalone charts.
+     * The new element created from the passed containerComponent wil be provided with
+     * these props from VictoryScatter: height, width, children
+     * (the chart itself) and style. Props that are not provided by the
+     * child chart component include title and desc, both of which
+     * are intended to add accessibility to Victory components. The more descriptive these props
+     * are, the more accessible your data will be for people using screen readers.
+     * Any of these props may be overridden by passing in props to the supplied component,
+     * or modified or ignored within the custom component itself. If a dataComponent is
+     * not provided, VictoryScatter will use the default VictoryContainer component.
+     * @example <VictoryContainer title="Chart of Dog Breeds" desc="This chart shows how
+     * popular each dog breed is by percentage in Seattle." />
+     */
+    containerComponent: PropTypes.element
+  };
+
+  static defaultProps = {
+    height: 300,
+    padding: 50,
+    samples: 50,
+    scale: "linear",
+    size: 3,
+    standalone: true,
+    symbol: "circle",
+    width: 450,
+    x: "x",
+    y: "y",
+    dataComponent: <Candle/>,
+    labelComponent: <VictoryLabel/>,
+    containerComponent: <VictoryContainer/>
+  };
+
+  static getDomain = Domain.getDomain.bind(Domain);
+  static getData = Data.getData.bind(Data);
+  static getBaseProps = partialRight(
+    CandlestickHelpers.getBaseProps.bind(CandlestickHelpers), defaultStyles
+  );
+
+  constructor() {
+    super();
+    this.state = {};
+    const getScopedEvents = Events.getScopedEvents.bind(this);
+    this.getEvents = partialRight(Events.getEvents.bind(this), getScopedEvents);
+    this.getEventState = Events.getEventState.bind(this);
+  }
+
+  componentWillMount() {
+    this.baseProps = CandlestickHelpers.getBaseProps(this.props, defaultStyles);
+  }
+
+  componentWillReceiveProps(newProps) {
+    this.baseProps = CandlestickHelpers.getBaseProps(newProps, defaultStyles);
+  }
+
+  renderData(props) {
+    const { dataComponent, labelComponent, sharedEvents } = props;
+    const getSharedEventState = sharedEvents && isFunction(sharedEvents.getEventState) ?
+      sharedEvents.getEventState : () => undefined;
+    return Object.keys(this.baseProps).map((key) => {
+      const dataEvents = this.getEvents(props, "data", key);
+      const dataProps = defaults(
+        {key: `scatter-${key}`},
+        this.getEventState(key, "data"),
+        getSharedEventState(key, "data"),
+        this.baseProps[key].data,
+        dataComponent.props
+      );
+      const scatterComponent = React.cloneElement(dataComponent, Object.assign(
+        {}, dataProps, {events: Events.getPartialEvents(dataEvents, key, dataProps)}
+      ));
+      const labelProps = defaults(
+        {key: `scatter-label-${key}`},
+        this.getEventState(key, "labels"),
+        getSharedEventState(key, "labels"),
+        this.baseProps[key].labels,
+        labelComponent.props
+      );
+      if (labelProps && labelProps.text) {
+        const labelEvents = this.getEvents(props, "labels", key);
+        const scatterLabel = React.cloneElement(labelComponent, Object.assign({
+          events: Events.getPartialEvents(labelEvents, key, labelProps)
+        }, labelProps));
+        return (
+          <g key={`scatter-group-${key}`}>
+            {scatterComponent}
+            {scatterLabel}
+          </g>
+        );
+      }
+      return scatterComponent;
+    });
+  }
+
+  render() {
+    // If animating, return a `VictoryAnimation` element that will create
+    // a new `VictoryScatter` with nearly identical props, except (1) tweened
+    // and (2) `animate` set to null so we don't recurse forever.
+    if (this.props.animate) {
+      // Do less work by having `VictoryAnimation` tween only values that
+      // make sense to tween. In the future, allow customization of animated
+      // prop whitelist/blacklist?
+      const whitelist = [
+        "data", "domain", "height", "maxBubbleSize", "padding", "samples", "size",
+        "style", "width", "x", "y"
+      ];
+      return (
+        <VictoryTransition animate={this.props.animate} animationWhitelist={whitelist}>
+          <VictoryCandlestick {...this.props}/>
+        </VictoryTransition>
+      );
+    }
+
+    const style = Helpers.getStyles(
+      this.props.style,
+      defaultStyles,
+      "auto",
+      "100%"
+    );
+
+    const group = <g role="presentation" style={style.parent}>{this.renderData(this.props)}</g>;
+    return this.props.standalone ?
+      React.cloneElement(
+        this.props.containerComponent,
+        Object.assign({
+          height: this.props.height,
+          width: this.props.width,
+          style: style.parent}, this.props.containerComponent.props),
+        group) :
+      group;
+  }
+}

--- a/src/components/victory-candlestick/victory-candlestick.js
+++ b/src/components/victory-candlestick/victory-candlestick.js
@@ -24,6 +24,17 @@ const defaultStyles = {
   }
 };
 
+const defaultData = [
+  {x: new Date(2016, 6, 1), open: 5, close: 10, high: 15, low: 0},
+  {x: new Date(2016, 6, 2), open: 10, close: 15, high: 20, low: 5},
+  {x: new Date(2016, 6, 3), open: 15, close: 20, high: 25, low: 10},
+  {x: new Date(2016, 6, 4), open: 20, close: 25, high: 30, low: 15},
+  {x: new Date(2016, 6, 5), open: 25, close: 30, high: 35, low: 20},
+  {x: new Date(2016, 6, 6), open: 30, close: 35, high: 40, low: 25},
+  {x: new Date(2016, 6, 7), open: 35, close: 40, high: 45, low: 30},
+  {x: new Date(2016, 6, 8), open: 40, close: 45, high: 50, low: 35}
+];
+
 export default class VictoryCandlestick extends React.Component {
   static role = "candlestick";
 
@@ -262,6 +273,73 @@ export default class VictoryCandlestick extends React.Component {
       PropTypes.arrayOf(PropTypes.string)
     ]),
     /**
+     * The open prop specifies how to access the open value of each data point.
+     * If given as a function, it will be run on each data point, and returned value will be used.
+     * If given as an integer, it will be used as an array index for array-type data points.
+     * If given as a string, it will be used as a property key for object-type data points.
+     * If given as an array of strings, or a string containing dots or brackets,
+     * it will be used as a nested object property path (for details see Lodash docs for _.get).
+     * If `null` or `undefined`, the data value will be used as is (identity function/pass-through).
+     * @examples 0, 'open', 'open.value.nested.1.thing', 'open[2].also.nested', null,
+     * d => Math.sin(d)
+     */
+    open: PropTypes.oneOfType([
+      PropTypes.func,
+      CustomPropTypes.allOfType([CustomPropTypes.integer, CustomPropTypes.nonNegative]),
+      PropTypes.string,
+      PropTypes.arrayOf(PropTypes.string)
+    ]),
+    /**
+     * The close prop specifies how to access the close value of each data point.
+     * If given as a function, it will be run on each data point, and returned value will be used.
+     * If given as an integer, it will be used as an array index for array-type data points.
+     * If given as a string, it will be used as a property key for object-type data points.
+     * If given as an array of strings, or a string containing dots or brackets,
+     * it will be used as a nested object property path (for details see Lodash docs for _.get).
+     * If `null` or `undefined`, the data value will be used as is (identity function/pass-through).
+     * @examples 0, 'close', 'close.value.nested.1.thing', 'close[2].also.nested', null,
+     * d => Math.sin(d)
+     */
+    close: PropTypes.oneOfType([
+      PropTypes.func,
+      CustomPropTypes.allOfType([CustomPropTypes.integer, CustomPropTypes.nonNegative]),
+      PropTypes.string,
+      PropTypes.arrayOf(PropTypes.string)
+    ]),
+    /**
+     * The high prop specifies how to access the high value of each data point.
+     * If given as a function, it will be run on each data point, and returned value will be used.
+     * If given as an integer, it will be used as an array index for array-type data points.
+     * If given as a string, it will be used as a property key for object-type data points.
+     * If given as an array of strings, or a string containing dots or brackets,
+     * it will be used as a nested object property path (for details see Lodash docs for _.get).
+     * If `null` or `undefined`, the data value will be used as is (identity function/pass-through).
+     * @examples 0, 'high', 'high.value.nested.1.thing', 'high[2].also.nested', null,
+     * d => Math.sin(d)
+     */
+    high: PropTypes.oneOfType([
+      PropTypes.func,
+      CustomPropTypes.allOfType([CustomPropTypes.integer, CustomPropTypes.nonNegative]),
+      PropTypes.string,
+      PropTypes.arrayOf(PropTypes.string)
+    ]),
+    /**
+     * The low prop specifies how to access the low value of each data point.
+     * If given as a function, it will be run on each data point, and returned value will be used.
+     * If given as an integer, it will be used as an array index for array-type data points.
+     * If given as a string, it will be used as a property key for object-type data points.
+     * If given as an array of strings, or a string containing dots or brackets,
+     * it will be used as a nested object property path (for details see Lodash docs for _.get).
+     * If `null` or `undefined`, the data value will be used as is (identity function/pass-through).
+     * @examples 0, 'low', 'low.value.nested.1.thing', 'low[2].also.nested', null, d => Math.sin(d)
+     */
+    low: PropTypes.oneOfType([
+      PropTypes.func,
+      CustomPropTypes.allOfType([CustomPropTypes.integer, CustomPropTypes.nonNegative]),
+      PropTypes.string,
+      PropTypes.arrayOf(PropTypes.string)
+    ]),
+    /**
      * The y prop specifies how to access the Y value of each data point.
      * If given as a function, it will be run on each data point, and returned value will be used.
      * If given as an integer, it will be used as an array index for array-type data points.
@@ -312,11 +390,16 @@ export default class VictoryCandlestick extends React.Component {
     padding: 50,
     samples: 50,
     scale: "linear",
+    data: defaultData,
     size: 3,
     standalone: true,
     symbol: "circle",
     width: 450,
     x: "x",
+    open: "open",
+    close: "close",
+    high: "high",
+    low: "low",
     y: "y",
     dataComponent: <Candle/>,
     labelComponent: <VictoryLabel/>,

--- a/src/helpers/data.js
+++ b/src/helpers/data.js
@@ -74,7 +74,6 @@ export default {
       x: Helpers.createAccessor(props.x),
       y: Helpers.createAccessor(props.y)
     };
-    console.log(this.cleanData(dataset, props));
     return this.cleanData(dataset, props).map((datum) => {
       const x = accessor.x(datum);
       const y = accessor.y(datum);

--- a/src/helpers/data.js
+++ b/src/helpers/data.js
@@ -74,6 +74,7 @@ export default {
       x: Helpers.createAccessor(props.x),
       y: Helpers.createAccessor(props.y)
     };
+    console.log(this.cleanData(dataset, props));
     return this.cleanData(dataset, props).map((datum) => {
       const x = accessor.x(datum);
       const y = accessor.y(datum);

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import VictoryBar from "./components/victory-bar/victory-bar";
 import VictoryScatter from "./components/victory-scatter/victory-scatter";
 import VictoryGroup from "./components/victory-group/victory-group";
 import VictoryStack from "./components/victory-stack/victory-stack";
+import VictoryCandlestick from "./components/victory-candlestick/victory-candlestick";
 
 export {
   VictoryChart,
@@ -15,5 +16,6 @@ export {
   VictoryBar,
   VictoryScatter,
   VictoryGroup,
-  VictoryStack
+  VictoryStack,
+  VictoryCandlestick
 };

--- a/test/client/spec/components/victory-candlestick/helper-methods.spec.js
+++ b/test/client/spec/components/victory-candlestick/helper-methods.spec.js
@@ -6,7 +6,8 @@ describe("victory-candlestick/helper-methods", () => {
   describe("getData", () => {
     const dataSet = [{x: 5, open: 10, close: 20, high: 25, low: 5}];
     it("returns an object with an array of y values", () => {
-      const dataResult = Helpers.getData({data: dataSet});
+      const dataResult = Helpers.getData({data: dataSet, x: "x", open: "open",
+      close: "close", high: "high", low: "low"});
       expect(dataResult[0].y).to.eql([10, 20, 25, 5]);
     });
   });
@@ -15,12 +16,14 @@ describe("victory-candlestick/helper-methods", () => {
     const dataSet = [{x: 5, open: 10, close: 20, high: 25, low: 5},
     {x: 10, open: 15, close: 25, high: 30, low: 10}];
     it("returns a domain array for the x axis", () => {
-      const domainXResult = Helpers.getDomain({data: dataSet}, "x");
+      const domainXResult = Helpers.getDomain({data: dataSet, x: "x", open: "open",
+      close: "close", high: "high", low: "low"}, "x");
       expect(domainXResult).to.eql([5, 10]);
     });
 
     it("returns a domain array for the y axis", () => {
-      const domainYResult = Helpers.getDomain({data: dataSet}, "y");
+      const domainYResult = Helpers.getDomain({data: dataSet, open: "open",
+      close: "close", high: "high", low: "low"}, "y");
       expect(domainYResult).to.eql([5, 30]);
     });
   });

--- a/test/client/spec/components/victory-candlestick/helper-methods.spec.js
+++ b/test/client/spec/components/victory-candlestick/helper-methods.spec.js
@@ -1,0 +1,27 @@
+/* eslint no-unused-expressions: 0 */
+
+import Helpers from "src/components/victory-candlestick/helper-methods";
+
+describe("victory-candlestick/helper-methods", () => {
+  describe("getData", () => {
+    const dataSet = [{x: 5, open: 10, close: 20, high: 25, low: 5}];
+    it("returns an object with an array of y values", () => {
+      const dataResult = Helpers.getData({data: dataSet});
+      expect(dataResult[0].y).to.eql([10, 20, 25, 5]);
+    });
+  });
+
+  describe("getDomain", () => {
+    const dataSet = [{x: 5, open: 10, close: 20, high: 25, low: 5},
+    {x: 10, open: 15, close: 25, high: 30, low: 10}];
+    it("returns a domain array for the x axis", () => {
+      const domainXResult = Helpers.getDomain({data: dataSet}, "x");
+      expect(domainXResult).to.eql([5, 10]);
+    });
+
+    it("returns a domain array for the y axis", () => {
+      const domainYResult = Helpers.getDomain({data: dataSet}, "y");
+      expect(domainYResult).to.eql([5, 30]);
+    });
+  });
+});

--- a/test/client/spec/components/victory-candlestick/victory-candlestick.spec.js
+++ b/test/client/spec/components/victory-candlestick/victory-candlestick.spec.js
@@ -1,0 +1,149 @@
+/**
+ * Client tests
+ */
+/*eslint-disable max-nested-callbacks */
+/* global sinon */
+/* eslint no-unused-expressions: 0 */
+import React from "react";
+import { shallow, mount } from "enzyme";
+import { omit, range } from "lodash";
+import VictoryCandlestick from "src/components/victory-candlestick/victory-candlestick";
+import Candle from "src/components/victory-candlestick/candle";
+import { VictoryLabel } from "victory-core";
+
+class MyCandle extends React.Component {
+
+  render() { }
+}
+
+const dataSet = [{x: 5, open: 10, close: 20, high: 25, low: 5}];
+
+describe("components/victory-candlestick", () => {
+  describe("default component rendering", () => {
+    it("renders an svg with the correct width and height", () => {
+      const wrapper = mount(
+        <VictoryCandlestick data={dataSet}/>
+      );
+      const svg = wrapper.find("svg");
+      expect(svg.prop("style").width).to.equal("100%");
+      expect(svg.prop("style").height).to.equal("auto");
+    });
+
+    it("renders an svg with the correct viewBox", () => {
+      const wrapper = mount(
+        <VictoryCandlestick data={dataSet}/>
+      );
+      const svg = wrapper.find("svg");
+      const viewBoxValue =
+        `0 0 ${VictoryCandlestick.defaultProps.width} ${VictoryCandlestick.defaultProps.height}`;
+      expect(svg.prop("viewBox")).to.equal(viewBoxValue);
+    });
+
+    it("renders 51 points", () => {
+      const wrapper = shallow(
+        <VictoryCandlestick/>
+      );
+      const points = wrapper.find(Candle);
+      expect(points.length).to.equal(51);
+    });
+  });
+
+  describe("rendering data", () => {
+    it("renders injected points for {x, y} shaped data (default)", () => {
+      const data = range(10).map((i) => ({x: i, y: i}));
+      const wrapper = shallow(
+        <VictoryCandlestick data={data} dataComponent={<MyCandle />} />
+      );
+
+      const points = wrapper.find(MyCandle);
+      expect(points.length).to.equal(10);
+    });
+
+    it("renders points for {x, y} shaped data (default)", () => {
+      const data = range(10).map((i) => ({x: i, y: i}));
+      const wrapper = shallow(
+        <VictoryCandlestick data={data}/>
+      );
+      const points = wrapper.find(Candle);
+      expect(points.length).to.equal(10);
+    });
+
+    it("renders points for array-shaped data", () => {
+      const data = range(20).map((i) => [i, i]);
+      const wrapper = shallow(
+        <VictoryCandlestick data={data} x={0} y={1}/>
+      );
+      const points = wrapper.find(Candle);
+      expect(points.length).to.equal(20);
+    });
+
+    it("renders points for deeply-nested data", () => {
+      const data = range(40).map((i) => ({a: {b: [{x: i, y: i}]}}));
+      const wrapper = shallow(
+        <VictoryCandlestick data={data} x="a.b[0].x" y="a.b[0].y"/>
+      );
+      const points = wrapper.find(Candle);
+      expect(points.length).to.equal(40);
+    });
+
+    it("renders data values with null accessor", () => {
+      const data = range(30);
+      const wrapper = shallow(
+        <VictoryCandlestick data={data} x={null} y={null}/>
+      );
+      const points = wrapper.find(Candle);
+      expect(points.length).to.equal(30);
+    });
+  });
+
+  describe("event handling", () => {
+    it("attaches an event to data", () => {
+      const clickHandler = sinon.spy();
+      const wrapper = mount(
+        <VictoryCandlestick
+          data={dataSet}
+          events={[{
+            target: "data",
+            eventHandlers: {onClick: clickHandler}
+          }]}
+        />
+      );
+      const Data = wrapper.find(Candle);
+      Data.forEach((node, index) => {
+        const initialProps = Data.at(index).props();
+        node.simulate("click");
+        expect(clickHandler.called).to.equal(true);
+        // the first argument is the standard evt object
+        expect(omit(clickHandler.args[index][1], ["events", "key"]))
+          .to.eql(omit(initialProps, ["events", "key"]));
+        expect(`${clickHandler.args[index][2]}`).to.eql(`${index}`);
+      });
+    });
+
+    it("attaches an event to a label", () => {
+      const clickHandler = sinon.spy();
+      const data = [
+        {eventKey: 0, x: 0, open: 0, close: 0, high: 0, low: 0, label: "0"},
+        {eventKey: 1, x: 1, open: 1, close: 1, high: 1, low: 1, label: "1"},
+        {eventKey: 2, x: 2, open: 2, close: 2, high: 2, low: 2, label: "2"}
+      ];
+      const wrapper = mount(
+        <VictoryCandlestick
+          data={data}
+          events={[{
+            target: "labels",
+            eventHandlers: {onClick: clickHandler}
+          }]}
+        />
+      );
+      const Labels = wrapper.find(VictoryLabel);
+      Labels.forEach((node, index) => {
+        node.childAt(0).simulate("click");
+        expect(clickHandler).called;
+        // the first argument is the standard evt object
+        expect(clickHandler.args[index][1].datum).to.eql(data[index]);
+        expect(`${clickHandler.args[index][2]}`).to.eql(`${index}`);
+      });
+    });
+  });
+});

--- a/test/client/spec/components/victory-candlestick/victory-candlestick.spec.js
+++ b/test/client/spec/components/victory-candlestick/victory-candlestick.spec.js
@@ -42,18 +42,18 @@ describe("components/victory-candlestick", () => {
       expect(svg.prop("viewBox")).to.equal(viewBoxValue);
     });
 
-    it("renders 51 points", () => {
+    it("renders 8 points", () => {
       const wrapper = shallow(
         <VictoryCandlestick/>
       );
       const points = wrapper.find(Candle);
-      expect(points.length).to.equal(51);
+      expect(points.length).to.equal(8);
     });
   });
 
   describe("rendering data", () => {
     it("renders injected points for {x, y} shaped data (default)", () => {
-      const data = range(10).map((i) => ({x: i, y: i}));
+      const data = range(10).map((i) => ({x: i, open: i, close: i, high: i, low: i}));
       const wrapper = shallow(
         <VictoryCandlestick data={data} dataComponent={<MyCandle />} />
       );
@@ -63,7 +63,7 @@ describe("components/victory-candlestick", () => {
     });
 
     it("renders points for {x, y} shaped data (default)", () => {
-      const data = range(10).map((i) => ({x: i, y: i}));
+      const data = range(10).map((i) => ({x: i, open: i, close: i, high: i, low: i}));
       const wrapper = shallow(
         <VictoryCandlestick data={data}/>
       );
@@ -72,18 +72,23 @@ describe("components/victory-candlestick", () => {
     });
 
     it("renders points for array-shaped data", () => {
-      const data = range(20).map((i) => [i, i]);
+      const data = range(20).map((i) => [i, i, i, i, i]);
       const wrapper = shallow(
-        <VictoryCandlestick data={data} x={0} y={1}/>
+        <VictoryCandlestick data={data} x={0} open={1} close={2} high={3} low={4}/>
       );
       const points = wrapper.find(Candle);
       expect(points.length).to.equal(20);
     });
 
     it("renders points for deeply-nested data", () => {
-      const data = range(40).map((i) => ({a: {b: [{x: i, y: i}]}}));
+      const data = range(40).map((i) => ({a: {b: [{x: i, open: i, close: i, high: i, low: i}]}}));
       const wrapper = shallow(
-        <VictoryCandlestick data={data} x="a.b[0].x" y="a.b[0].y"/>
+        <VictoryCandlestick data={data} x="a.b[0].x"
+          open="a.b[0].open"
+          close="a.b[0].close"
+          high="a.b[0].high"
+          low="a.b[0].low"
+        />
       );
       const points = wrapper.find(Candle);
       expect(points.length).to.equal(40);
@@ -92,7 +97,7 @@ describe("components/victory-candlestick", () => {
     it("renders data values with null accessor", () => {
       const data = range(30);
       const wrapper = shallow(
-        <VictoryCandlestick data={data} x={null} y={null}/>
+        <VictoryCandlestick data={data} x={null} open={null} close={null} high={null} low={null}/>
       );
       const points = wrapper.find(Candle);
       expect(points.length).to.equal(30);

--- a/test/client/spec/components/victory-candlestick/victory-candlestick.spec.js
+++ b/test/client/spec/components/victory-candlestick/victory-candlestick.spec.js
@@ -8,7 +8,7 @@
 /* eslint no-unused-expressions: 0 */
 import React from "react";
 import { shallow, mount } from "enzyme";
-import { range } from "lodash";
+import { range, omit } from "lodash";
 import VictoryCandlestick from "src/components/victory-candlestick/victory-candlestick";
 import Candle from "src/components/victory-candlestick/candle";
 import { VictoryLabel } from "victory-core";
@@ -18,7 +18,8 @@ class MyCandle extends React.Component {
   render() { }
 }
 
-const dataSet = [{x: 5, open: 10, close: 20, high: 25, low: 5}];
+const dataSet = [{x: 5, open: 10, close: 20, high: 25, low: 5},
+{x: 1, open: 80, close: 40, high: 120, low: 10, label: "1"}];
 
 describe("components/victory-candlestick", () => {
   describe("default component rendering", () => {
@@ -111,23 +112,22 @@ describe("components/victory-candlestick", () => {
         />
       );
       const Data = wrapper.find(Candle);
-      Data.forEach((node) => {
-        // const initialProps = Data.at(index).props();
-        console.log(node);
-        node.simulate("click");
+      Data.forEach((node, index) => {
+        const initialProps = Data.at(index).props();
+        node.find("rect").simulate("click");
         expect(clickHandler.called).to.equal(true);
         // the first argument is the standard evt object
-        // expect(omit(clickHandler.args[index][1], ["events", "key"]))
-        //   .to.eql(omit(initialProps, ["events", "key"]));
-        // expect(`${clickHandler.args[index][2]}`).to.eql(`${index}`);
+        expect(omit(clickHandler.args[index][1], ["events", "key"]))
+          .to.eql(omit(initialProps, ["events", "key"]));
+        expect(`${clickHandler.args[index][2]}`).to.eql(`${index}`);
       });
     });
     it("attaches an event to a label", () => {
       const clickHandler = sinon.spy();
       const data = [
-        {x: 0, y: 0, label: "0"},
-        {x: 1, y: 1, label: "1"},
-        {x: 2, y: 2, label: "2"}
+        {x: 0, open: 9, close: 30, high: 56, low: 7, label: "0"},
+        {x: 1, open: 80, close: 40, high: 120, low: 10, label: "1"},
+        {x: 2, open: 50, close: 80, high: 90, low: 20, label: "2"}
       ];
       const wrapper = mount(
         <VictoryCandlestick

--- a/test/client/spec/components/victory-candlestick/victory-candlestick.spec.js
+++ b/test/client/spec/components/victory-candlestick/victory-candlestick.spec.js
@@ -2,11 +2,13 @@
  * Client tests
  */
 /*eslint-disable max-nested-callbacks */
+/*eslint-disable no-console */
+/*eslint-disable no-undef */
 /* global sinon */
 /* eslint no-unused-expressions: 0 */
 import React from "react";
 import { shallow, mount } from "enzyme";
-import { omit, range } from "lodash";
+import { range } from "lodash";
 import VictoryCandlestick from "src/components/victory-candlestick/victory-candlestick";
 import Candle from "src/components/victory-candlestick/candle";
 import { VictoryLabel } from "victory-core";
@@ -101,6 +103,7 @@ describe("components/victory-candlestick", () => {
       const clickHandler = sinon.spy();
       const wrapper = mount(
         <VictoryCandlestick
+          data={dataSet}
           events={[{
             target: "data",
             eventHandlers: {onClick: clickHandler}
@@ -108,23 +111,23 @@ describe("components/victory-candlestick", () => {
         />
       );
       const Data = wrapper.find(Candle);
-      Data.forEach((node, index) => {
-        const initialProps = Data.at(index).props();
+      Data.forEach((node) => {
+        // const initialProps = Data.at(index).props();
+        console.log(node);
         node.simulate("click");
         expect(clickHandler.called).to.equal(true);
         // the first argument is the standard evt object
-        expect(omit(clickHandler.args[index][1], ["events", "key"]))
-          .to.eql(omit(initialProps, ["events", "key"]));
-        expect(`${clickHandler.args[index][2]}`).to.eql(`${index}`);
+        // expect(omit(clickHandler.args[index][1], ["events", "key"]))
+        //   .to.eql(omit(initialProps, ["events", "key"]));
+        // expect(`${clickHandler.args[index][2]}`).to.eql(`${index}`);
       });
     });
-
     it("attaches an event to a label", () => {
       const clickHandler = sinon.spy();
       const data = [
-        {eventKey: 0, x: 0, open: 0, close: 0, high: 0, low: 0, label: "0"},
-        {eventKey: 1, x: 1, open: 1, close: 1, high: 1, low: 1, label: "1"},
-        {eventKey: 2, x: 2, open: 2, close: 2, high: 2, low: 2, label: "2"}
+        {x: 0, y: 0, label: "0"},
+        {x: 1, y: 1, label: "1"},
+        {x: 2, y: 2, label: "2"}
       ];
       const wrapper = mount(
         <VictoryCandlestick
@@ -140,7 +143,7 @@ describe("components/victory-candlestick", () => {
         node.childAt(0).simulate("click");
         expect(clickHandler).called;
         // the first argument is the standard evt object
-        expect(clickHandler.args[index][1].datum).to.eql(data[index]);
+        expect(clickHandler.args[index][1]).to.contain({text: `${index}`});
         expect(`${clickHandler.args[index][2]}`).to.eql(`${index}`);
       });
     });

--- a/test/client/spec/components/victory-candlestick/victory-candlestick.spec.js
+++ b/test/client/spec/components/victory-candlestick/victory-candlestick.spec.js
@@ -101,7 +101,6 @@ describe("components/victory-candlestick", () => {
       const clickHandler = sinon.spy();
       const wrapper = mount(
         <VictoryCandlestick
-          data={dataSet}
           events={[{
             target: "data",
             eventHandlers: {onClick: clickHandler}


### PR DESCRIPTION
@boygirl 

A basic chart currently renders as desired when the demo is run. Scale and range are calculated correctly for x and y values, but getDomain and getData both still need to be modified for this type of dataset. 

TODO

- [x] Pass styles down to candle component through this.props.style
- [x] Set default colors for positive and negative candles in getDataStyles (?)
- [x] Modify getData to accept four y values
- [x] Modify getDomain to accept four y values
- [x] eliminate flatten redundancy
- [x] figure out padding issue
- [x] figure out why x values don't quite line up with x-axis tick values
- [x] make sure non-numerical x values work (dates in particular)
- [x] write description for candlecolors prop
- [x] Write tests
- [x] Write more robust demos