### PR TITLE
axes render under data, grid renders under labels

### DIFF
--- a/src/components/victory-axis/victory-axis.js
+++ b/src/components/victory-axis/victory-axis.js
@@ -24,7 +24,7 @@ const defaultStyles = {
     fontFamily: "Helvetica"
   },
   grid: {
-    stroke: "none",
+    stroke: "transparent",
     fill: "none",
     strokeLinecap: "round"
   },
@@ -427,9 +427,9 @@ export default class VictoryAxis extends React.Component {
       }, tickLabelProps));
       return (
         <g key={`tick-group-${key}`}>
+          {GridComponent}
           {TickComponent}
           {TickLabel}
-          {GridComponent}
         </g>
       );
     });

--- a/src/components/victory-chart/helper-methods.js
+++ b/src/components/victory-chart/helper-methods.js
@@ -20,7 +20,7 @@ export default {
     };
 
     if (axisComponents.dependent.length === 0 && axisComponents.independent.length === 0) {
-      return childComponents.concat(defaultAxes.independent, defaultAxes.dependent);
+      return [defaultAxes.independent, defaultAxes.dependent].concat(childComponents);
     }
     if (axisComponents.dependent.length > 1 || axisComponents.independent.length > 1) {
       const msg = `Only one VictoryAxis component of each axis type is allowed when ` +
@@ -29,7 +29,7 @@ export default {
       Log.warn(msg);
       const dataComponents = this.getDataComponents(childComponents);
       return Collection.removeUndefined(
-        dataComponents.concat(axisComponents.dependent[0], axisComponents.independent[0])
+        [axisComponents.dependent[0], axisComponents.independent[0]].concat(dataComponents)
       );
     }
     return childComponents;


### PR DESCRIPTION
This PR changes the render order of _default_ axes within chart, so that default axes will always render before data. If you are explicitly defining axes they will still render in the order they are provided to chart. This PR also renders axis grid lines lower than ticks and tickLabels as requested by @SereznoKot 

supports https://github.com/FormidableLabs/victory-chart/pull/242
closes #246 