### PR TITLE
bug-#284 - adds aria roles and tabindex attrs to path elements

### DIFF
--- a/src/components/victory-area/area.js
+++ b/src/components/victory-area/area.js
@@ -5,10 +5,11 @@ import d3Shape from "d3-shape";
 export default class Area extends React.Component {
   static propTypes = {
     data: PropTypes.array,
+    events: PropTypes.object,
     interpolation: PropTypes.string,
+    role: PropTypes.string,
     scale: PropTypes.object,
-    style: PropTypes.object,
-    events: PropTypes.object
+    style: PropTypes.object
   };
 
   toNewName(interpolation) {
@@ -17,7 +18,7 @@ export default class Area extends React.Component {
     return `curve${capitalize(interpolation)}`;
   }
 
-  renderArea(style, interpolation, events) {
+  renderArea({ style, interpolation, events, role }) {
     const xScale = this.props.scale.x;
     const yScale = this.props.scale.y;
     const areaStroke = style.stroke ? "none" : style.fill;
@@ -29,7 +30,7 @@ export default class Area extends React.Component {
       .y0((data) => yScale(data.y0));
     const path = areaFunction(this.props.data);
 
-    return <path style={areaStyle} d={path} {...events}/>;
+    return <path role={role} style={areaStyle} d={path} {...events}/>;
   }
 
   renderLine(style, interpolation, events) {
@@ -50,10 +51,10 @@ export default class Area extends React.Component {
   }
 
   render() {
-    const { style, interpolation, events } = this.props;
+    const { events, interpolation, role, style } = this.props;
     return (
       <g>
-        {this.renderArea(style, interpolation, events)}
+        {this.renderArea({style, interpolation, events, role})}
         {this.renderLine(style, interpolation, events)}
       </g>
     );

--- a/src/components/victory-area/victory-area.js
+++ b/src/components/victory-area/victory-area.js
@@ -360,10 +360,11 @@ export default class VictoryArea extends React.Component {
   }
 
   renderData(props) {
+    const { role } = VictoryArea;
     const { dataComponent, labelComponent } = props;
     const dataEvents = this.getEvents(props, "data", "all");
     const dataProps = defaults(
-      {},
+      {role},
       this.getEventState("all", "data"),
       this.getSharedEventState("all", "data"),
       dataComponent.props,

--- a/src/components/victory-bar/bar.js
+++ b/src/components/victory-bar/bar.js
@@ -3,12 +3,13 @@ import React, { PropTypes } from "react";
 export default class Bar extends React.Component {
 
   static propTypes = {
-    index: PropTypes.number,
+    datum: PropTypes.object,
     events: PropTypes.object,
     horizontal: PropTypes.bool,
+    index: PropTypes.number,
+    role: PropTypes.string,
     scale: PropTypes.object,
     style: PropTypes.object,
-    datum: PropTypes.object,
     x: React.PropTypes.number,
     y: React.PropTypes.number,
     y0: React.PropTypes.number
@@ -41,14 +42,17 @@ export default class Bar extends React.Component {
 
   render() {
     // TODO better bar width calculation
-    const barWidth = this.props.style && this.props.style.width || 8;
+    const { events, role, style } = this.props;
+    const barWidth = style && style.width || 8;
     const path = typeof this.props.x === "number" ?
       this.getBarPath(this.props, barWidth) : undefined;
+
     return (
       <path
-        {...this.props.events}
         d={path}
-        style={this.props.style}
+        {...events}
+        role={role}
+        style={style}
         shapeRendering="optimizeSpeed"
       />
     );

--- a/src/components/victory-bar/victory-bar.js
+++ b/src/components/victory-bar/victory-bar.js
@@ -366,13 +366,15 @@ export default class VictoryBar extends React.Component {
   }
 
   renderData(props) {
+    const { role } = VictoryBar;
     const { dataComponent, labelComponent } = props;
     const barComponents = [];
     const barLabelComponents = [];
-    this.dataKeys.forEach((key) => {
+
+    this.dataKeys.forEach((key, index) => {
       const dataEvents = this.getEvents(props, "data", key);
       const dataProps = defaults(
-        {key: `bar-${key}`},
+        {index, key: `${role}-${key}`, role: `${role}-${index}`},
         this.getEventState(key, "data"),
         this.getSharedEventState(key, "data"),
         dataComponent.props,
@@ -384,7 +386,7 @@ export default class VictoryBar extends React.Component {
       )));
 
       const labelProps = defaults(
-        {key: `bar-label-${key}`},
+        {key: `${role}-label-${key}`},
         this.getEventState(key, "labels"),
         this.getSharedEventState(key, "labels"),
         labelComponent.props,

--- a/src/components/victory-candlestick/candle.js
+++ b/src/components/victory-candlestick/candle.js
@@ -18,7 +18,8 @@ export default class Candle extends React.Component {
       PropTypes.number,
       PropTypes.object
     ]),
-    data: PropTypes.array
+    data: PropTypes.array,
+    role: PropTypes.string
   }
 
   renderWick() {
@@ -37,20 +38,20 @@ export default class Candle extends React.Component {
   }
 
   renderCandle() {
-    const width = this.props.width;
+    const {candleHeight, data: {length: dataLength}, events, role, style, width, x} = this.props;
     const padding = this.props.padding.left || this.props.padding;
-    const dataLength = this.props.data.length;
     const candleWidth = 0.5 * (width - 2 * padding) / dataLength;
-    const candleX = this.props.x - candleWidth / 2;
+    const candleX = x - candleWidth / 2;
 
     return (
       <rect
-        {...this.props.events}
+        {...events}
+        height={candleHeight}
+        role={role}
+        style={style}
+        width={candleWidth}
         x={candleX}
         y={this.props.y}
-        style={this.props.style}
-        width={candleWidth}
-        height={this.props.candleHeight}
       />
     );
   }

--- a/src/components/victory-candlestick/victory-candlestick.js
+++ b/src/components/victory-candlestick/victory-candlestick.js
@@ -416,13 +416,14 @@ export default class VictoryCandlestick extends React.Component {
   }
 
   renderData(props) {
+    const {role} = VictoryCandlestick;
     const { dataComponent, labelComponent, sharedEvents } = props;
     const getSharedEventState = sharedEvents && isFunction(sharedEvents.getEventState) ?
       sharedEvents.getEventState : () => undefined;
-    return Object.keys(this.baseProps).map((key) => {
+    return Object.keys(this.baseProps).map((key, index) => {
       const dataEvents = this.getEvents(props, "data", key);
       const dataProps = defaults(
-        {key: `candlestick-${key}`},
+        {key: `${role}-${key}`, role: `${role}-${index}`},
         this.getEventState(key, "data"),
         getSharedEventState(key, "data"),
         this.baseProps[key].data,
@@ -432,7 +433,7 @@ export default class VictoryCandlestick extends React.Component {
         {}, dataProps, {events: Events.getPartialEvents(dataEvents, key, dataProps)}
       ));
       const labelProps = defaults(
-        {key: `candlestick-label-${key}`},
+        {key: `${role}-label-${key}`},
         this.getEventState(key, "labels"),
         getSharedEventState(key, "labels"),
         this.baseProps[key].labels,

--- a/src/components/victory-line/line-segment.js
+++ b/src/components/victory-line/line-segment.js
@@ -5,7 +5,9 @@ export default class LineSegment extends React.Component {
   static propTypes = {
     data: PropTypes.array,
     events: PropTypes.object,
+    index: PropTypes.number,
     interpolation: PropTypes.string,
+    role: PropTypes.string,
     scale: PropTypes.object,
     style: PropTypes.object
   };
@@ -17,7 +19,7 @@ export default class LineSegment extends React.Component {
   }
 
   render() {
-    const { events, style, interpolation, scale, data } = this.props;
+    const { data, events, interpolation, role, scale, style } = this.props;
     const xScale = scale.x;
     const yScale = scale.y;
     const lineFunction = d3Shape.line()
@@ -25,8 +27,15 @@ export default class LineSegment extends React.Component {
       .x((d) => xScale(d.x))
       .y((d) => yScale(d.y));
     const path = lineFunction(data);
+
     return (
-      <path style={style} d={path} {...events} vectorEffect="non-scaling-stroke"/>
+      <path
+        d={path}
+        {...events}
+        role={role}
+        style={style}
+        vectorEffect="non-scaling-stroke"
+      />
     );
   }
 }

--- a/src/components/victory-line/victory-line.js
+++ b/src/components/victory-line/victory-line.js
@@ -377,10 +377,12 @@ export default class VictoryLine extends React.Component {
   renderData(props) {
     const { dataComponent, labelComponent } = props;
     const dataSegments = LineHelpers.getDataSegments(Data.getData(props));
+
     return dataSegments.map((data, key) => {
+      const role = `${VictoryLine.role}-${key}`;
       const dataEvents = this.getEvents(props, "data", "all");
       const dataProps = defaults(
-        {key: `line-${key}`},
+        {index: key, key: role, role},
         this.getEventState("all", "data"),
         this.getSharedEventState("all", "data"),
         { data },
@@ -392,7 +394,7 @@ export default class VictoryLine extends React.Component {
       ));
 
       const labelProps = defaults(
-          {key: `line-label-${key}`},
+          {key: `${role}-label-${key}`},
           this.getEventState("all", "labels"),
           this.getSharedEventState("all", "labels"),
           { data },

--- a/src/components/victory-scatter/point.js
+++ b/src/components/victory-scatter/point.js
@@ -4,23 +4,24 @@ import pathHelpers from "./path-helpers";
 
 export default class Point extends React.Component {
   static propTypes = {
-    index: React.PropTypes.number,
     datum: PropTypes.object,
     events: PropTypes.object,
+    index: PropTypes.number,
+    role: PropTypes.string,
+    size: PropTypes.oneOfType([
+      PropTypes.number,
+      PropTypes.func
+    ]),
     symbol: PropTypes.oneOfType([
       PropTypes.oneOf([
         "circle", "diamond", "plus", "square", "star", "triangleDown", "triangleUp"
       ]),
       PropTypes.func
     ]),
-    size: PropTypes.oneOfType([
-      PropTypes.number,
-      PropTypes.func
-    ]),
     scale: PropTypes.object,
     style: PropTypes.object,
-    x: React.PropTypes.number,
-    y: React.PropTypes.number
+    x: PropTypes.number,
+    y: PropTypes.number
   };
 
   getPath(props) {
@@ -37,12 +38,15 @@ export default class Point extends React.Component {
   }
 
   render() {
+    const {events, role, style} = this.props;
+
     return (
       <path
-        {...this.props.events}
-        style={this.props.style}
+        {...events}
         d={this.getPath(this.props)}
+        role={role}
         shapeRendering="optimizeSpeed"
+        style={style}
       />
     );
   }

--- a/src/components/victory-scatter/victory-scatter.js
+++ b/src/components/victory-scatter/victory-scatter.js
@@ -389,13 +389,14 @@ export default class VictoryScatter extends React.Component {
   }
 
   renderData(props) {
+    const {role} = VictoryScatter;
     const { dataComponent, labelComponent } = props;
     const pointComponents = [];
     const pointLabelComponents = [];
-    this.dataKeys.forEach((key) => {
+    this.dataKeys.forEach((key, index) => {
       const dataEvents = this.getEvents(props, "data", key);
       const dataProps = defaults(
-        {key: `scatter-${key}`},
+        {index, key: `${role}-${key}`, role: `${role}-${index}`},
         this.getEventState(key, "data"),
         this.getSharedEventState(key, "data"),
         dataComponent.props,
@@ -407,7 +408,7 @@ export default class VictoryScatter extends React.Component {
       )));
 
       const labelProps = defaults(
-        {key: `scatter-label-${key}`},
+        {key: `scatter-label-${key}`, index},
         this.getEventState(key, "labels"),
         this.getSharedEventState(key, "labels"),
         labelComponent.props,

--- a/test/client/spec/components/victory-area/victory-area.spec.js
+++ b/test/client/spec/components/victory-area/victory-area.spec.js
@@ -113,4 +113,19 @@ describe("components/victory-area", () => {
       });
     });
   });
+
+  describe("accessibility", () => {
+    it("adds an area role to the path area", () => {
+      const wrapper = mount(<VictoryArea />);
+      wrapper.find("path").nodes.forEach((p) => {
+        const {attributes: attr} = p;
+        const role = attr.getNamedItem("role");
+        if (role) {
+          const roleValue = role.value;
+          expect(roleValue).to.be.a("string");
+          expect(roleValue).to.equal("area");
+        }
+      });
+    });
+  });
 });

--- a/test/client/spec/components/victory-bar/victory-bar.spec.js
+++ b/test/client/spec/components/victory-bar/victory-bar.spec.js
@@ -161,4 +161,18 @@ describe("components/victory-bar", () => {
       });
     });
   });
+
+  describe("accessibility", () => {
+    it("adds an area role to each bar in the series", () => {
+      const data = range(20).map((y, x) => ({x, y}));
+      const wrapper = mount(<VictoryBar data={data} />);
+
+      wrapper.find("path").nodes.forEach((p, i) => {
+        const {attributes: attr} = p;
+        const roleValue = attr.getNamedItem("role").value;
+        expect(roleValue).to.be.a("string");
+        expect(roleValue).to.equal(`bar-${i}`);
+      });
+    });
+  });
 });

--- a/test/client/spec/components/victory-candlestick/victory-candlestick.spec.js
+++ b/test/client/spec/components/victory-candlestick/victory-candlestick.spec.js
@@ -153,4 +153,24 @@ describe("components/victory-candlestick", () => {
       });
     });
   });
+
+  describe("accessibility", () => {
+    it("adds an area role to each point in the series", () => {
+      const data = [
+        {x: 0, open: 9, close: 30, high: 56, low: 7},
+        {x: 1, open: 80, close: 40, high: 120, low: 10},
+        {x: 2, open: 50, close: 80, high: 90, low: 20}
+      ];
+      const wrapper = mount(
+        <VictoryCandlestick data={data} />
+      );
+
+      wrapper.find("rect").nodes.forEach((r, i) => {
+        const {attributes: attr} = r;
+        const roleValue = attr.getNamedItem("role").value;
+        expect(roleValue).to.be.a("string");
+        expect(roleValue).to.equal(`candlestick-${i}`);
+      });
+    });
+  });
 });

--- a/test/client/spec/components/victory-line/victory-line.spec.js
+++ b/test/client/spec/components/victory-line/victory-line.spec.js
@@ -277,4 +277,41 @@ describe("components/victory-line", () => {
       });
     });
   });
+
+  describe("accessibility", () => {
+
+    it("adds an area role to a line segment", () => {
+      const wrapper = mount(<VictoryLine />);
+      const p = wrapper.find("path").node;
+
+      const {attributes: attr} = p;
+      const roleValue = attr.getNamedItem("role").value;
+      expect(roleValue).to.be.a("string");
+      expect(roleValue).to.equal(`line-0`);
+    });
+
+    it("adds an area role to each line segment", () => {
+      const data = [
+        {x: 1, y: 1},
+        {x: 2, y: 3},
+        {x: 3, y: 5},
+        {x: 4, y: 2},
+        {x: 5, y: null},
+        {x: 6, y: null},
+        {x: 7, y: 6},
+        {x: 8, y: 7},
+        {x: 9, y: 8},
+        {x: 10, y: 12}
+      ];
+      const wrapper = mount(<VictoryLine data={data} />);
+
+      wrapper.find("path").nodes.forEach((p, i) => {
+        const {attributes: attr} = p;
+        const roleValue = attr.getNamedItem("role").value;
+        expect(roleValue).to.be.a("string");
+        expect(roleValue).to.equal(`line-${i}`);
+      });
+    });
+
+  });
 });

--- a/test/client/spec/components/victory-scatter/victory-scatter.spec.js
+++ b/test/client/spec/components/victory-scatter/victory-scatter.spec.js
@@ -193,4 +193,19 @@ describe("components/victory-scatter", () => {
       });
     });
   });
+
+
+  describe("accessibility", () => {
+    it("adds an area role to each point in the series", () => {
+      const data = range(20).map((y, x) => ({x, y}));
+      const wrapper = mount(<VictoryScatter data={data} />);
+
+      wrapper.find("path").nodes.forEach((p, i) => {
+        const {attributes: attr} = p;
+        const roleValue = attr.getNamedItem("role").value;
+        expect(roleValue).to.be.a("string");
+        expect(roleValue).to.equal(`scatter-${i}`);
+      });
+    });
+  });
 });


### PR DESCRIPTION
1. minor cleanup, organizes some props alphabetically.
2. adds area roles to paths. 
3. adds tabIndex to path elements iff there are bound events as per: http://www.w3.org/TR/wai-aria-practices/#focus_tabindex --- @boygirl let me know what you think about adding `tabindex` react-a11y complains if a focus tabindex isn't available for an element with a bound event. 
 * note that I added a default `data` style to make sure we don't get a focus `outline` style on tab elements.
4. roles and tab index uses the index of the datum in the series as oppose to the key, let me know what you think about this one, I thought it was more appropriate to use the index but I notice the `key` is used in various places.
5. adds some basic unit test

Last but not least there is only area roles on `victory-area` since this component is a bit of a unique case, what do you suggest we do for a unique naming convention for both `role` and `tabindex`? I was thinking passing an `id` from `VictoryStack` down to `VictoryArea` - are you okay to introduce a new prop for this? I suppose it would only be used while cloning children @ `getNewChildren`.


the above affects: `VictoryBar`, `VictoryLine`, `VictoryScatter`, `VictoryArea`
Todo: `VictoryLabel`
