### PR TITLE
check for horizontal bars in tickFormat: extract check into a helper …

### DIFF
--- a/demo/components/victory-bar-demo.js
+++ b/demo/components/victory-bar-demo.js
@@ -114,6 +114,24 @@ export default class App extends React.Component {
     return (
       <div className="demo">
         <h1>VictoryBar</h1>
+        <ChartWrap>
+          <VictoryBar
+            horizontal
+            data={[
+              {x: 1, y: "Label 1"},
+              {x: 7, y: "Label 2"},
+              {x: 3, y: "Label 3"},
+              {x: 4, y: "Label 4"}
+            ]}
+          />
+        </ChartWrap>
+
+        <ChartWrap>
+          <VictoryBar horizontal
+            data={[ {x: 1, y: 20}, {x: 7, y: 40}, {x: 3, y: 60}, {x: 4, y: 80} ]}
+          />
+        </ChartWrap>
+
         <VictoryBar
           style={{
             parent: parentStyle,

--- a/src/components/victory-chart/helper-methods.js
+++ b/src/components/victory-chart/helper-methods.js
@@ -83,9 +83,10 @@ export default {
   },
 
   getTicksFromData(calculatedProps, axis) {
-    const stringMap = calculatedProps.stringMap[axis];
+    const currentAxis = Axis.getCurrentAxis(axis, calculatedProps.horizontal);
+    const stringMap = calculatedProps.stringMap[currentAxis];
     // if tickValues are defined for an axis component use them
-    const categoryArray = calculatedProps.categories[axis];
+    const categoryArray = calculatedProps.categories[currentAxis];
     const ticksFromCategories = categoryArray && Collection.containsOnlyStrings(categoryArray) ?
       categoryArray.map((tick) => stringMap[tick]) : categoryArray;
     const ticksFromStringMap = stringMap && values(stringMap);
@@ -99,7 +100,8 @@ export default {
     if (!tickValues) {
       return undefined;
     }
-    const stringMap = calculatedProps.stringMap[axis];
+    const currentAxis = Axis.getCurrentAxis(axis, calculatedProps.horizontal);
+    const stringMap = calculatedProps.stringMap[currentAxis];
     return Collection.containsOnlyStrings(tickValues) && stringMap ?
       tickValues.map((tick) => stringMap[tick]) : tickValues;
   },
@@ -109,8 +111,9 @@ export default {
   },
 
   getTickFormat(component, axis, calculatedProps) {
+    const currentAxis = Axis.getCurrentAxis(axis, calculatedProps.horizontal);
+    const stringMap = calculatedProps.stringMap[currentAxis];
     const tickValues = component.props.tickValues;
-    const stringMap = calculatedProps.stringMap[axis];
     const useIdentity = tickValues && !Collection.containsStrings(tickValues) &&
       !Collection.containsDates(tickValues);
     if (useIdentity) {
@@ -123,7 +126,7 @@ export default {
       const dataTicks = ["", ...dataNames, ""];
       return (x) => dataTicks[x];
     } else {
-      return calculatedProps.scale[axis].tickFormat() || identity;
+      return calculatedProps.scale[currentAxis].tickFormat() || identity;
     }
   },
 

--- a/src/components/victory-group/victory-group.js
+++ b/src/components/victory-group/victory-group.js
@@ -3,6 +3,7 @@ import React, { PropTypes } from "react";
 import { PropTypes as CustomPropTypes, Helpers, Log, VictorySharedEvents,
   VictoryContainer } from "victory-core";
 import Scale from "../../helpers/scale";
+import Axis from "../../helpers/axis";
 import Wrapper from "../../helpers/wrapper";
 
 const fallbackProps = {
@@ -333,8 +334,7 @@ export default class VictoryGroup extends React.Component {
     const childComponents = React.Children.toArray(props.children);
     const horizontalChildren = childComponents.some((child) => child.props.horizontal);
     const horizontal = props && props.horizontal || horizontalChildren.length > 0;
-    const otherAxis = axis === "x" ? "y" : "x";
-    const currentAxis = horizontal ? otherAxis : axis;
+    const currentAxis = Axis.getCurrentAxis(axis, horizontal);
     const domain = calculatedProps.domain[currentAxis];
     const range = calculatedProps.range[currentAxis];
     const domainExtent = Math.max(...domain) - Math.min(...domain);

--- a/src/helpers/axis.js
+++ b/src/helpers/axis.js
@@ -17,6 +17,11 @@ export default {
     return props.dependentAxis ? "y" : "x";
   },
 
+  getCurrentAxis(axis, horizontal) {
+    const otherAxis = axis === "x" ? "y" : "x";
+    return horizontal ? otherAxis : axis;
+  },
+
   /**
    * Returns a single axis component of the desired axis type (x or y)
    * @param {Array} childComponents: an array of children

--- a/src/helpers/domain.js
+++ b/src/helpers/domain.js
@@ -44,8 +44,7 @@ export default {
   },
 
   getDomainFromData(props, axis, dataset) {
-    const otherAxis = axis === "x" ? "y" : "x";
-    const currentAxis = props.horizontal ? otherAxis : axis;
+    const currentAxis = Axis.getCurrentAxis(axis, props.horizontal);
     const allData = flatten(dataset).map((datum) => datum[currentAxis]);
     const min = Math.min(...allData);
     const max = Math.max(...allData);
@@ -127,8 +126,7 @@ export default {
   },
 
   getCumulativeData(props, axis, datasets) {
-    const otherAxis = axis === "x" ? "y" : "x";
-    const currentAxis = props.horizontal ? otherAxis : axis;
+    const currentAxis = Axis.getCurrentAxis(axis, props.horizontal);
     const categories = [];
     const axisValues = [];
     datasets.forEach((dataset) => {

--- a/src/helpers/wrapper.js
+++ b/src/helpers/wrapper.js
@@ -79,8 +79,7 @@ export default {
     childComponents = childComponents || React.Children.toArray(props.children);
     const horizontalChildren = childComponents.some((child) => child.props.horizontal);
     const horizontal = props && props.horizontal || horizontalChildren.length > 0;
-    const otherAxis = axis === "x" ? "y" : "x";
-    const currentAxis = horizontal ? otherAxis : axis;
+    const currentAxis = Axis.getCurrentAxis(axis, horizontal);
     const getChildDomains = (children) => {
       return children.reduce((memo, child) => {
         if (child.type && isFunction(child.type.getDomain)) {


### PR DESCRIPTION
cc/ @coopy @ebrillhart 

closes https://github.com/FormidableLabs/victory/issues/289

One thing though. The "y" labels end up on the "x" axis for horizontal bar charts, but that is also how the data is already being laid out, so the axis label behavior is matching the data behavior. It would be a more elaborate change to swap those. 
<img width="417" alt="screen shot 2016-06-30 at 4 23 35 pm" src="https://cloud.githubusercontent.com/assets/3719995/16507552/71a35f9e-3edf-11e6-9385-bcbacdcdf20c.png">
