### PR TITLE
[NO REVIEW] Add dropdown to change data sets 

### DIFF
--- a/docs/victory-chart/data-source.js
+++ b/docs/victory-chart/data-source.js
@@ -1,0 +1,59 @@
+import React from "react";
+
+const dataSets = [
+  [{x: 0, y: 0}, {x: 10, y: 20}, {x: 2, y: 1}],
+  [{x: 0, y: 0}, {x: -1, y: -2}, {x: -2, y: -1}]
+];
+
+class DataSource extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      selectedDataSet: 0
+    };
+  }
+
+  getChildContext() {
+    return ({
+      dataSet: dataSets[this.state ? this.state.selectedDataSet : 0 ]
+    });
+  }
+
+  renderOptions() {
+    const options = [
+      { id: 0, label: "POSITIVE" },
+      { id: 1, label: "Negative" }
+    ];
+
+    return options.map((option) => (
+      <option key={option.id}>{option.label}</option>
+    ));
+  }
+
+  onDataSetChanged(selectedIndex) {
+    this.setState({
+      selectedDataSet: selectedIndex
+    });
+  }
+
+  render() {
+    return (
+      <div>
+        <select onChange={(ev) => {this.onDataSetChanged(ev.target.selectedIndex);}}>
+          {this.renderOptions()}
+        </select>
+        {this.props.children}
+      </div>
+    );
+  }
+}
+
+DataSource.childContextTypes = {
+  dataSet: React.PropTypes.array
+};
+
+DataSource.propTypes = {
+  children: React.PropTypes.node
+};
+
+export default DataSource;

--- a/docs/victory-chart/docs.js
+++ b/docs/victory-chart/docs.js
@@ -4,6 +4,7 @@ import Ecology from "ecology";
 import { merge, random, range } from "lodash";
 import Radium, { Style } from "radium";
 import * as docgen from "react-docgen";
+import DataSource from "./data-source";
 import {
   VictoryChart, VictoryLine, VictoryAxis, VictoryBar, VictoryScatter, VictoryStack
 } from "../../src/index";
@@ -17,7 +18,7 @@ class Docs extends React.Component {
           overview={require("!!raw!./ecology.md")}
           source={docgen.parse(require("!!raw!../../src/components/victory-chart/victory-chart"))}
           scope={{
-            merge, range, random, React, ReactDOM, VictoryScatter, VictoryLine,
+            merge, range, random, DataSource, React, ReactDOM, VictoryScatter, VictoryLine,
             VictoryAxis, VictoryBar, VictoryChart, VictoryStack
           }}
           playgroundtheme="elegant"

--- a/docs/victory-chart/ecology.md
+++ b/docs/victory-chart/ecology.md
@@ -30,6 +30,29 @@ VictoryChart was designed to build charts from minimal information. Pass in only
 
 In the example above, VictoryChart was given a [VictoryLine][] component as a child. In addition, it also created a set of VictoryAxis components with the correct domain for the data being plotted by [VictoryLine][], created tick values based on that data, aligned all of its child components into a correct chart, and applied a set of default styles.
 
+### Domain and Scale
+
+TODO.
+
+```playground_norender
+class App extends React.Component {
+  render() {
+    return (
+      <VictoryChart>
+        <VictoryScatter
+          data={this.context.dataSet}/>
+      </VictoryChart>
+    );
+  }
+}
+
+App.contextTypes = {
+  dataSet: React.PropTypes.array
+};
+
+ReactDOM.render(<DataSource><App/></DataSource>, mountNode);
+```
+
 ### Declarative Composition
 
 VictoryCharts are composed of other Victory components. Compose several components of the same type...


### PR DESCRIPTION
Resolves https://github.com/FormidableLabs/victory-docs/issues/29 &  https://github.com/FormidableLabs/ecology/issues/33 

- Add a `<DataSource>` wrapper
- Since not all examples need a dropdown to change data sets, add an example to VictoryChart to talk about domain and scaling, where changing a data set does make sense. 

TODO:
- Add copy for domain and scale 
- Explore other potential use cases for `<DataSource>`
- Potentially refactor `<DataSource>` such that it does not require `playground_norender` ...this will require adding a child component that sets `contextTypes`, for example:
```
DataSourceChild.contextTypes = {
  dataSet: React.PropTypes.array
};
```