### PR TITLE
Add domain padding

### DIFF
--- a/demo/components/victory-area-demo.js
+++ b/demo/components/victory-area-demo.js
@@ -103,6 +103,7 @@ export default class App extends React.Component {
           style={style} animate={{duration: 1000}}
           data={this.state.areaTransitionData}
           theme={VictoryTheme.material}
+          domainPadding={100}
           containerComponent={
             <VictoryContainer
               title="Area Chart"

--- a/demo/components/victory-bar-demo.js
+++ b/demo/components/victory-bar-demo.js
@@ -178,6 +178,7 @@ export default class App extends React.Component {
             parent: parentStyle,
             labels: {angle: 45, verticalAnchor: "end", textAnchor: "end"}
           }}
+          domainPadding={100}
           labels={() => "HELLO"}
           animate={{
             duration: 500,

--- a/demo/components/victory-candlestick-demo.js
+++ b/demo/components/victory-candlestick-demo.js
@@ -66,11 +66,13 @@ export default class App extends React.Component {
     return (
       <div className="demo">
         <h1>Victory Candlestick</h1>
-        <svg>
+        <svg height={500} width={500}>
         <VictoryCandlestick
           style={{data: {width: 10}, parent: style.parent}}
           data={data}
           size={8}
+          standalone={false}
+          domainPadding={100}
           events={[{
             target: "labels",
             eventHandlers: {
@@ -104,7 +106,10 @@ export default class App extends React.Component {
             }
           }]}
         />
-        <VictoryAxis/>
+        <VictoryAxis
+          standalone={false}
+          domainPadding={20}
+        />
         </svg>
 
         <VictoryCandlestick

--- a/demo/components/victory-candlestick-demo.js
+++ b/demo/components/victory-candlestick-demo.js
@@ -1,7 +1,7 @@
 /*global window:false */
 import React from "react";
 import { random, range, merge } from "lodash";
-import {VictoryCandlestick, VictoryChart} from "../../src/index";
+import {VictoryCandlestick, VictoryChart, VictoryAxis} from "../../src/index";
 import { VictoryTheme } from "victory-core";
 
 const getData = () => {
@@ -66,7 +66,7 @@ export default class App extends React.Component {
     return (
       <div className="demo">
         <h1>Victory Candlestick</h1>
-
+        <svg>
         <VictoryCandlestick
           style={{data: {width: 10}, parent: style.parent}}
           data={data}
@@ -104,6 +104,8 @@ export default class App extends React.Component {
             }
           }]}
         />
+        <VictoryAxis/>
+        </svg>
 
         <VictoryCandlestick
           style={{parent: style.parent}}

--- a/demo/components/victory-line-demo.js
+++ b/demo/components/victory-line-demo.js
@@ -1,7 +1,7 @@
 /*global window:false */
 import React from "react";
 import { merge, random, range } from "lodash";
-import {VictoryLine, VictoryChart} from "../../src/index";
+import {VictoryLine, VictoryChart, VictoryAxis} from "../../src/index";
 import LineSegment from "../../src/components/victory-line/line-segment";
 import Point from "../../src/components/victory-scatter/point";
 import { VictoryContainer, VictoryTheme } from "victory-core";
@@ -219,11 +219,13 @@ export default class App extends React.Component {
           style={{parent: parentStyle}}
           scale={{x: "linear", y: "log"}}
         />
+
         <VictoryLine
           style={{parent: parentStyle}}
           data={this.state.arrayData}
           label="Hello"
           x={0}
+          domainPadding={20}
           y={1}
           theme={VictoryTheme.material}
         />

--- a/demo/components/victory-line-demo.js
+++ b/demo/components/victory-line-demo.js
@@ -1,7 +1,7 @@
 /*global window:false */
 import React from "react";
 import { merge, random, range } from "lodash";
-import {VictoryLine, VictoryChart, VictoryAxis} from "../../src/index";
+import {VictoryLine, VictoryChart} from "../../src/index";
 import LineSegment from "../../src/components/victory-line/line-segment";
 import Point from "../../src/components/victory-scatter/point";
 import { VictoryContainer, VictoryTheme } from "victory-core";

--- a/demo/components/victory-scatter-demo.js
+++ b/demo/components/victory-scatter-demo.js
@@ -211,6 +211,7 @@ export default class App extends React.Component {
           data={range(0, 50)}
           x={null}
           y={(d) => d * d * Math.random()}
+          domainPadding={200}
         />
 
         <VictoryChart

--- a/src/components/victory-area/victory-area.js
+++ b/src/components/victory-area/victory-area.js
@@ -75,6 +75,19 @@ export default class VictoryArea extends React.Component {
      */
     data: PropTypes.array,
     /**
+     * The domainPadding prop specifies a number of pixels of padding to add to the
+     * beginning and end of a domain. This prop is useful for explicitly spacing ticks farther
+     * from the origin to prevent crowding. This prop should be given as an object with
+     * numbers specified for x and y.
+     */
+    domainPadding: PropTypes.oneOfType([
+      PropTypes.shape({
+        x: PropTypes.number,
+        y: PropTypes.number
+      }),
+      PropTypes.number
+    ]),
+    /**
      * The dataComponent prop takes an entire component which will be used to create an area.
      * The new element created from the passed dataComponent will be provided with the
      * following properties calculated by VictoryArea: a scale, style, events, interpolation,

--- a/src/components/victory-axis/helper-methods.js
+++ b/src/components/victory-axis/helper-methods.js
@@ -19,11 +19,11 @@ export default {
       return undefined;
     }
     if (Array.isArray(props.domain)) {
-      return props.domain;
+      return Domain.padDomain(props.domain, props, axis);
     } else if (props.domain && props.domain[inherentAxis]) {
-      return props.domain[inherentAxis];
+      return Domain.padDomain(props.domain[inherentAxis], props, axis);
     } else if (props.tickValues) {
-      return Domain.getDomainFromTickValues(props);
+      return Domain.padDomain(Domain.getDomainFromTickValues(props), props, axis);
     }
     return undefined;
   },

--- a/src/components/victory-axis/victory-axis.js
+++ b/src/components/victory-axis/victory-axis.js
@@ -101,6 +101,19 @@ export default class VictoryAxis extends React.Component {
      */
     dependentAxis: PropTypes.bool,
     /**
+     * The domainPadding prop specifies a number of pixels of padding to add to the
+     * beginning and end of a domain. This prop is useful for explicitly spacing ticks farther
+     * from the origin to prevent crowding. This prop should be given as an object with
+     * numbers specified for x and y.
+     */
+    domainPadding: PropTypes.oneOfType([
+      PropTypes.shape({
+        x: PropTypes.number,
+        y: PropTypes.number
+      }),
+      PropTypes.number
+    ]),
+    /**
      * The domain prop describes the range of values your axis will include. This prop should be
      * given as a array of the minimum and maximum expected values for your axis.
      * If this value is not given it will be calculated based on the scale or tickValues.

--- a/src/components/victory-bar/victory-bar.js
+++ b/src/components/victory-bar/victory-bar.js
@@ -97,6 +97,19 @@ export default class VictoryBar extends React.Component {
      */
     dataComponent: PropTypes.element,
     /**
+     * The domainPadding prop specifies a number of pixels of padding to add to the
+     * beginning and end of a domain. This prop is useful for explicitly spacing ticks farther
+     * from the origin to prevent crowding. This prop should be given as an object with
+     * numbers specified for x and y.
+     */
+    domainPadding: PropTypes.oneOfType([
+      PropTypes.shape({
+        x: PropTypes.number,
+        y: PropTypes.number
+      }),
+      PropTypes.number
+    ]),
+    /**
      * The domain prop describes the range of values your bar chart will cover. This prop can be
      * given as a array of the minimum and maximum expected values for your bar chart,
      * or as an object that specifies separate arrays for x and y.

--- a/src/components/victory-candlestick/helper-methods.js
+++ b/src/components/victory-candlestick/helper-methods.js
@@ -89,11 +89,12 @@ export default {
     });
   },
 
-  getDomainFromData(props, axis) {
+  getDomain(props, axis) {
+    let domain;
     if (props.domain && props.domain[axis]) {
-      return props.domain[axis];
+      domain = props.domain[axis];
     } else if (props.domain && Array.isArray(props.domain)) {
-      return props.domain;
+      domain = props.domain;
     } else {
       const dataset = this.getData(props);
       const allData = dataset.reduce((memo, datum) => {
@@ -107,12 +108,9 @@ export default {
         const adjustedMax = max === 0 ? 1 : max;
         return [0, adjustedMax];
       }
-      return [min, max];
+      domain = [min, max];
     }
-  },
-
-  getDomain(props, axis) {
-    return Domain.padDomain(this.getDomainFromData(props, axis), props, axis);
+    return Domain.padDomain(domain, props, axis);
   },
 
   isTransparent(attr) {

--- a/src/components/victory-candlestick/helper-methods.js
+++ b/src/components/victory-candlestick/helper-methods.js
@@ -1,6 +1,7 @@
 import { pick, omit, defaults } from "lodash";
 import { Helpers, Events } from "victory-core";
 import Scale from "../../helpers/scale";
+import Domain from "../../helpers/domain";
 
 export default {
   getBaseProps(props, fallbackProps) { // eslint-disable-line max-statements
@@ -88,7 +89,7 @@ export default {
     });
   },
 
-  getDomain(props, axis) {
+  getDomainFromData(props, axis) {
     if (props.domain && props.domain[axis]) {
       return props.domain[axis];
     } else if (props.domain && Array.isArray(props.domain)) {
@@ -108,6 +109,10 @@ export default {
       }
       return [min, max];
     }
+  },
+
+  getDomain(props, axis) {
+    return Domain.padDomain(this.getDomainFromData(props, axis), props, axis);
   },
 
   isTransparent(attr) {

--- a/src/components/victory-candlestick/victory-candlestick.js
+++ b/src/components/victory-candlestick/victory-candlestick.js
@@ -92,6 +92,19 @@ export default class VictoryCandlestick extends React.Component {
      */
     dataComponent: PropTypes.element,
     /**
+     * The domainPadding prop specifies a number of pixels of padding to add to the
+     * beginning and end of a domain. This prop is useful for explicitly spacing ticks farther
+     * from the origin to prevent crowding. This prop should be given as an object with
+     * numbers specified for x and y.
+     */
+    domainPadding: PropTypes.oneOfType([
+      PropTypes.shape({
+        x: PropTypes.number,
+        y: PropTypes.number
+      }),
+      PropTypes.number
+    ]),
+    /**
      * The domain prop describes the range of values your chart will include. This prop can be
      * given as a array of the minimum and maximum expected values for your chart,
      * or as an object that specifies separate arrays for x and y.

--- a/src/components/victory-errorbar/helper-methods.js
+++ b/src/components/victory-errorbar/helper-methods.js
@@ -121,14 +121,15 @@ export default {
   getDomain(props, axis) {
     const propsDomain = Domain.getDomainFromProps(props, axis);
     if (propsDomain) {
-      return propsDomain;
+      return Domain.padDomain(propsDomain, props, axis);
     }
     const categoryDomain = Domain.getDomainFromCategories(props, axis);
     if (categoryDomain) {
-      return categoryDomain;
+      return Domain.padDomain(categoryDomain, props, axis);
     }
     const dataset = this.getErrorData(props);
-    return this.getDomainFromData(props, axis, dataset);
+    const domain = this.getDomainFromData(props, axis, dataset);
+    return Domain.padDomain(domain, props, axis);
   },
 
   getDomainFromData(props, axis, dataset) {

--- a/src/components/victory-errorbar/victory-errorbar.js
+++ b/src/components/victory-errorbar/victory-errorbar.js
@@ -85,6 +85,19 @@ export default class VictoryErrorBar extends React.Component {
      */
     dataComponent: PropTypes.element,
     /**
+     * The domainPadding prop specifies a number of pixels of padding to add to the
+     * beginning and end of a domain. This prop is useful for explicitly spacing ticks farther
+     * from the origin to prevent crowding. This prop should be given as an object with
+     * numbers specified for x and y.
+     */
+    domainPadding: PropTypes.oneOfType([
+      PropTypes.shape({
+        x: PropTypes.number,
+        y: PropTypes.number
+      }),
+      PropTypes.number
+    ]),
+    /**
      * The domain prop describes the range of values your chart will include. This prop can be
      * given as a array of the minimum and maximum expected values for your chart,
      * or as an object that specifies separate arrays for x and y.

--- a/src/components/victory-line/victory-line.js
+++ b/src/components/victory-line/victory-line.js
@@ -72,6 +72,19 @@ export default class VictoryLine extends React.Component {
       })
     ]),
     /**
+     * The domainPadding prop specifies a number of pixels of padding to add to the
+     * beginning and end of a domain. This prop is useful for explicitly spacing ticks farther
+     * from the origin to prevent crowding. This prop should be given as an object with
+     * numbers specified for x and y.
+     */
+    domainPadding: PropTypes.oneOfType([
+      PropTypes.shape({
+        x: PropTypes.number,
+        y: PropTypes.number
+      }),
+      PropTypes.number
+    ]),
+    /**
      * The data prop specifies the data to be plotted.
      * Data should be in the form of an array of data points.
      * Each data point may be any format you wish (depending on the `x` and `y` accessor props),

--- a/src/components/victory-scatter/victory-scatter.js
+++ b/src/components/victory-scatter/victory-scatter.js
@@ -87,6 +87,19 @@ export default class VictoryScatter extends React.Component {
 
     data: PropTypes.array,
     /**
+     * The domainPadding prop specifies a number of pixels of padding to add to the
+     * beginning and end of a domain. This prop is useful for explicitly spacing ticks farther
+     * from the origin to prevent crowding. This prop should be given as an object with
+     * numbers specified for x and y.
+     */
+    domainPadding: PropTypes.oneOfType([
+      PropTypes.shape({
+        x: PropTypes.number,
+        y: PropTypes.number
+      }),
+      PropTypes.number
+    ]),
+    /**
      * The dataComponent prop takes an entire component which will be used to create points for
      * each datum in the chart. The new element created from the passed dataComponent will be
      * provided with the following properties calculated by VictoryScatter: datum, index, scale,

--- a/src/helpers/domain.js
+++ b/src/helpers/domain.js
@@ -7,14 +7,15 @@ export default {
   getDomain(props, axis) {
     const propsDomain = this.getDomainFromProps(props, axis);
     if (propsDomain) {
-      return propsDomain;
+      return this.padDomain(propsDomain, props, axis);
     }
     const categoryDomain = this.getDomainFromCategories(props, axis);
     if (categoryDomain) {
-      return categoryDomain;
+      return this.padDomain(categoryDomain, props, axis);
     }
     const dataset = Data.getData(props);
-    return this.getDomainFromData(props, axis, dataset);
+    const domain = this.getDomainFromData(props, axis, dataset);
+    return this.padDomain(domain, props, axis);
   },
 
   getDomainWithZero(props, axis) {

--- a/src/helpers/domain.js
+++ b/src/helpers/domain.js
@@ -21,19 +21,22 @@ export default {
   getDomainWithZero(props, axis) {
     const propsDomain = this.getDomainFromProps(props, axis);
     if (propsDomain) {
-      return propsDomain;
+      return this.padDomain(propsDomain, props, axis);
     }
     const { horizontal } = props;
     const ensureZero = (domain) => {
       const isDependent = (axis === "y" && !horizontal) || (axis === "x" && horizontal);
-      return isDependent ? [Math.min(...domain, 0), Math.max(... domain, 0)] : domain;
+      const zeroDomain = isDependent ? [Math.min(...domain, 0), Math.max(... domain, 0)]
+      : domain;
+      return this.padDomain(zeroDomain, props, axis);
     };
     const categoryDomain = this.getDomainFromCategories(props, axis);
     if (categoryDomain) {
-      return ensureZero(categoryDomain);
+      return this.padDomain(ensureZero(categoryDomain), props, axis);
     }
     const dataset = Data.getData(props);
-    return ensureZero(this.getDomainFromData(props, axis, dataset));
+    const domain = ensureZero(this.getDomainFromData(props, axis, dataset));
+    return this.padDomain(domain, props, axis);
   },
 
   getDomainFromProps(props, axis) {


### PR DESCRIPTION
adds domainpadding to all of the chart components (but not stack, group, or axis... does it make sense to add to those?). Works great unless there's a log scale being used... not sure what the best fix for that is.

addresses https://github.com/FormidableLabs/victory-chart/issues/295#issuecomment-233690158

@boygirl 