### PR TITLE
update base style and themes for errorbar to align with other components

### DIFF
--- a/demo/components/victory-errorbar-demo.js
+++ b/demo/components/victory-errorbar-demo.js
@@ -144,7 +144,7 @@ export default class App extends React.Component {
         />
 
         <VictoryChart
-          theme={VictoryTheme.grayscale}
+          theme={VictoryTheme.material}
         >
           <VictoryErrorBar
             style={style}

--- a/src/components/victory-errorbar/victory-errorbar.js
+++ b/src/components/victory-errorbar/victory-errorbar.js
@@ -15,9 +15,10 @@ const fallbackProps = {
   },
   style: {
     data: {
+      fill: "none",
       opacity: 1,
-      stroke: "#CCC",
-      strokeWidth: 1
+      strokeWidth: 2,
+      stroke: "#252525"
     },
     labels: {
       fill: "#252525",
@@ -474,7 +475,11 @@ export default class VictoryErrorBar extends React.Component {
       );
     }
 
-    const baseStyle = Helpers.getStyles(style, fallbackProps.style, "auto", "100%");
+    const styleObject = modifiedProps.theme && modifiedProps.theme.errorbar
+    ? modifiedProps.theme.errorbar
+    : fallbackProps.style;
+
+    const baseStyle = Helpers.getStyles(style, styleObject, "auto", "100%");
 
     const group = this.renderGroup(this.renderData(modifiedProps), baseStyle.parent);
     return standalone ? this.renderContainer(modifiedProps, group) : group;


### PR DESCRIPTION
modifies base styles and demo themes for error bar to be consistent with the other chart components (grayscale for base styles, material as the theme in demo)

@boygirl 

@paulathevalley does this look correct?

works in conjunction with https://github.com/FormidableLabs/victory-core/pull/86