### PR TITLE
fix line, area chart transition problem

### DIFF
--- a/demo/components/victory-errorbar-demo.js
+++ b/demo/components/victory-errorbar-demo.js
@@ -43,7 +43,7 @@ export default class App extends React.Component {
       this.setState({
         data: getData()
       });
-    }, 10000);
+    }, 3000);
   }
 
   componentWillUnmount() {

--- a/demo/components/victory-line-demo.js
+++ b/demo/components/victory-line-demo.js
@@ -115,17 +115,17 @@ export default class App extends React.Component {
       <div className="demo">
         <h1>VictoryLine</h1>
 
-          <VictoryLine
-            style={{parent: parentStyle, data: this.state.style}}
-            data={this.state.transitionData}
-            animate={{duration: 800}}
-            containerComponent={
-              <VictoryContainer
-                title="Line Chart"
-                desc="This is a line chart for displaying data."
-              />
-            }
-          />
+        <VictoryLine
+          style={{parent: parentStyle, data: this.state.style}}
+          data={this.state.transitionData}
+          animate={{duration: 800}}
+          containerComponent={
+            <VictoryContainer
+              title="Line Chart"
+              desc="This is a line chart for displaying data."
+            />
+          }
+        />
 
         <VictoryLine
           style={{parent: parentStyle, data: this.state.style}}
@@ -235,13 +235,17 @@ export default class App extends React.Component {
           theme={VictoryTheme.material}
         >
           <VictoryLine
-            style={{parent: parentStyle}}
-            data={this.state.data}
-            label="Hello"
-            x={"x"}
-            y={(d) => (d.y + 15)}
+            style={{parent: parentStyle, data: this.state.style}}
+            data={this.state.transitionData}
+            animate={{duration: 1500}}
+            containerComponent={
+              <VictoryContainer
+                title="Line Chart"
+                desc="This is a line chart for displaying data."
+              />
+            }
           />
-      </VictoryChart>
+        </VictoryChart>
       </div>
     );
   }

--- a/demo/components/victory-line-demo.js
+++ b/demo/components/victory-line-demo.js
@@ -102,7 +102,7 @@ export default class App extends React.Component {
         transitionData: this.getTransitionData(),
         style: this.getStyles()
       });
-    }, 2000);
+    }, 3000);
   }
 
   componentWillUnmount() {

--- a/demo/components/victory-line-demo.js
+++ b/demo/components/victory-line-demo.js
@@ -1,7 +1,7 @@
 /*global window:false */
 import React from "react";
 import { merge, random, range } from "lodash";
-import {VictoryLine, VictoryChart} from "../../src/index";
+import {VictoryLine, VictoryBar, VictoryChart} from "../../src/index";
 import LineSegment from "../../src/components/victory-line/line-segment";
 import Point from "../../src/components/victory-scatter/point";
 import { VictoryContainer, VictoryTheme } from "victory-core";
@@ -59,6 +59,7 @@ export default class App extends React.Component {
     this.state = {
       data: this.getData(),
       transitionData: this.getTransitionData(),
+      transitionData2: this.getTransitionData(),
       arrayData: this.getArrayData(),
       style: {
         stroke: "blue",
@@ -100,6 +101,7 @@ export default class App extends React.Component {
       this.setState({
         data: this.getData(),
         transitionData: this.getTransitionData(),
+        transitionData2: this.getTransitionData(),
         style: this.getStyles()
       });
     }, 3000);
@@ -235,6 +237,36 @@ export default class App extends React.Component {
           theme={VictoryTheme.material}
         >
           <VictoryLine
+            style={{parent: parentStyle, data: this.state.style}}
+            data={this.state.transitionData}
+            animate={{duration: 1500}}
+            containerComponent={
+              <VictoryContainer
+                title="Line Chart"
+                desc="This is a line chart for displaying data."
+              />
+            }
+          />
+        </VictoryChart>
+
+        <VictoryChart
+          style={{parent: parentStyle}}
+          theme={VictoryTheme.material}
+          animate={{duration: 1500}}
+        >
+          <VictoryLine
+            style={{parent: parentStyle, data: this.state.style}}
+            data={this.state.transitionData}
+            animate={{duration: 1500}}
+            containerComponent={
+              <VictoryContainer
+                title="Line Chart"
+                desc="This is a line chart for displaying data."
+              />
+            }
+          />
+
+          <VictoryBar
             style={{parent: parentStyle, data: this.state.style}}
             data={this.state.transitionData}
             animate={{duration: 1500}}

--- a/src/components/helpers/clip-path.js
+++ b/src/components/helpers/clip-path.js
@@ -1,0 +1,69 @@
+import React, { PropTypes } from "react";
+import { isObject } from "lodash";
+import {
+  PropTypes as CustomPropTypes, Helpers
+} from "victory-core";
+
+export default class ClipPath extends React.Component {
+  static propTypes = {
+    /**
+     * A unique ID for clipPath so, it could make sure using specific clipPath on
+     * specific chart
+     * @type {String}
+     */
+    clipId: PropTypes.string,
+    /**
+     * The height props specifies the height the svg viewBox of the chart container.
+     * This value should be given as a number of pixels
+     */
+    height: CustomPropTypes.nonNegative,
+    /**
+     * The width props specifies the width of the svg viewBox of the chart container
+     * This value should be given as a number of pixels
+     */
+    width: CustomPropTypes.nonNegative,
+    /**
+     * The padding props specifies the amount of padding in number of pixels between
+     * the edge of the chart and any rendered child components. This prop can be given
+     * as a number or as an object with padding specified for top, bottom, left
+     * and right.
+     */
+    padding: PropTypes.oneOfType([
+      PropTypes.number,
+      PropTypes.shape({
+        top: PropTypes.number,
+        bottom: PropTypes.number,
+        left: PropTypes.number,
+        right: PropTypes.number
+      })
+    ])
+  };
+
+  static defaultProps = {
+    width: 450,
+    height: 300
+  }
+
+  render() {
+    const {
+      clipId,
+      width,
+      height
+    } = this.props;
+
+    const padding = Helpers.getPadding(this.props);
+
+    return (
+      <defs>
+        <clipPath id={clipId}>
+            <rect
+              x={padding.left}
+              y={padding.top}
+              width={width - padding.left - padding.right}
+              height={height - padding.top - padding.bottom}
+            />
+        </clipPath>
+      </defs>
+    );
+  }
+}

--- a/src/components/helpers/clip-path.js
+++ b/src/components/helpers/clip-path.js
@@ -1,5 +1,4 @@
 import React, { PropTypes } from "react";
-import { isObject } from "lodash";
 import {
   PropTypes as CustomPropTypes, Helpers
 } from "victory-core";
@@ -11,7 +10,7 @@ export default class ClipPath extends React.Component {
      * specific chart
      * @type {String}
      */
-    clipId: PropTypes.string,
+    clipId: PropTypes.number,
     /**
      * The height props specifies the height the svg viewBox of the chart container.
      * This value should be given as a number of pixels

--- a/src/components/victory-area/area.js
+++ b/src/components/victory-area/area.js
@@ -4,6 +4,7 @@ import * as d3Shape from "d3-shape";
 
 export default class Area extends React.Component {
   static propTypes = {
+    clipId: PropTypes.number,
     data: PropTypes.array,
     events: PropTypes.object,
     groupComponent: PropTypes.element,
@@ -43,18 +44,34 @@ export default class Area extends React.Component {
   renderArea(path, style, events) {
     const areaStroke = style.stroke ? "none" : style.fill;
     const areaStyle = assign({}, style, {stroke: areaStroke});
-    const { role } = this.props;
-    return <path key="area" style={areaStyle} role={role} d={path} {...events}/>;
+    const { role, clipId } = this.props;
+    return (
+      <path
+        key="area"
+        style={areaStyle}
+        role={role}
+        d={path}
+        {...events}
+        clipPath={`url(#${clipId})`}
+      />
+    );
   }
 
   renderLine(path, style, events) {
     if (!style.stroke || style.stroke === "none" || style.stroke === "transparent") {
       return undefined;
     }
-    const { role } = this.props;
+    const { role, clipId } = this.props;
     const lineStyle = assign({}, style, {fill: "none"});
     return (
-      <path key="area-stroke" style={lineStyle} role={role} d={path} {...events}/>
+      <path
+        key="area-stroke"
+        style={lineStyle}
+        role={role}
+        d={path}
+        {...events}
+        clipPath={`url(#${clipId})`}
+      />
     );
   }
 

--- a/src/components/victory-area/victory-area.js
+++ b/src/components/victory-area/victory-area.js
@@ -3,7 +3,7 @@ import React, { PropTypes } from "react";
 import Data from "../../helpers/data";
 import Domain from "../../helpers/domain";
 import {
-  PropTypes as CustomPropTypes, Helpers, Events, VictoryTransition, VictoryLabel,
+  PropTypes as CustomPropTypes, Helpers, Events, VictoryContinuousTransition, VictoryLabel,
   VictoryContainer
 } from "victory-core";
 import Area from "./area";
@@ -448,9 +448,9 @@ export default class VictoryArea extends React.Component {
         "data", "domain", "height", "padding", "style", "width"
       ];
       return (
-        <VictoryTransition animate={animate} animationWhitelist={whitelist}>
+        <VictoryContinuousTransition animate={animate} animationWhitelist={whitelist}>
           {React.createElement(this.constructor, modifiedProps)}
-        </VictoryTransition>
+        </VictoryContinuousTransition>
       );
     }
 

--- a/src/components/victory-area/victory-area.js
+++ b/src/components/victory-area/victory-area.js
@@ -4,7 +4,7 @@ import Data from "../../helpers/data";
 import ClipPath from "../helpers/clip-path";
 import Domain from "../../helpers/domain";
 import {
-  PropTypes as CustomPropTypes, Helpers, Events, VictoryContinuousTransition, VictoryLabel,
+  PropTypes as CustomPropTypes, Helpers, Events, VictoryTransition, VictoryLabel,
   VictoryContainer
 } from "victory-core";
 import Area from "./area";
@@ -458,9 +458,9 @@ export default class VictoryArea extends React.Component {
         "data", "domain", "height", "padding", "style", "width"
       ];
       return (
-        <VictoryContinuousTransition animate={animate} animationWhitelist={whitelist}>
+        <VictoryTransition animate={animate} animationWhitelist={whitelist}>
           {React.createElement(this.constructor, modifiedProps)}
-        </VictoryContinuousTransition>
+        </VictoryTransition>
       );
     }
 

--- a/src/components/victory-chart/victory-chart.js
+++ b/src/components/victory-chart/victory-chart.js
@@ -17,6 +17,13 @@ const fallbackProps = {
 };
 
 export default class VictoryChart extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.setAnimationState = Wrapper.setAnimationState.bind(this);
+    this.getAnimationProps = Wrapper.getAnimationProps.bind(this);
+  }
+
   static propTypes = {
     /**
      * The animate prop specifies props for VictoryAnimation to use. If this prop is
@@ -227,11 +234,6 @@ export default class VictoryChart extends React.Component {
     }
   };
 
-  componentWillReceiveProps(nextProps) {
-    const setAnimationState = Wrapper.setAnimationState.bind(this);
-    setAnimationState(nextProps);
-  }
-
   getStyles(props) {
     const styleProps = props.style && props.style.parent;
     return {
@@ -317,12 +319,11 @@ export default class VictoryChart extends React.Component {
 
   getNewChildren(props, childComponents, calculatedProps) {
     const baseStyle = calculatedProps.style.parent;
-    const getAnimationProps = Wrapper.getAnimationProps.bind(this);
     return childComponents.map((child, index) => {
       const style = defaults({}, child.props.style, {parent: baseStyle});
       const childProps = this.getChildProps(child, props, calculatedProps);
       const newProps = defaults({
-        animate: getAnimationProps(props, child, index),
+        animate: this.getAnimationProps(props, child),
         height: props.height,
         width: props.width,
         padding: Helpers.getPadding(props),
@@ -342,7 +343,7 @@ export default class VictoryChart extends React.Component {
     const parentProps = defaults(
       {},
       containerComponent.props,
-      {style: style.parent, scale, width, height}
+      { style: style.parent, scale, width, height}
     );
     return React.cloneElement(containerComponent, parentProps);
   }

--- a/src/components/victory-line/line-segment.js
+++ b/src/components/victory-line/line-segment.js
@@ -3,7 +3,7 @@ import * as d3Shape from "d3-shape";
 
 export default class LineSegment extends React.Component {
   static propTypes = {
-    clipId: PropTypes.string,
+    clipId: PropTypes.number,
     data: PropTypes.array,
     events: PropTypes.object,
     index: PropTypes.number,

--- a/src/components/victory-line/line-segment.js
+++ b/src/components/victory-line/line-segment.js
@@ -3,6 +3,7 @@ import * as d3Shape from "d3-shape";
 
 export default class LineSegment extends React.Component {
   static propTypes = {
+    clipId: PropTypes.string,
     data: PropTypes.array,
     events: PropTypes.object,
     index: PropTypes.number,
@@ -19,9 +20,16 @@ export default class LineSegment extends React.Component {
   }
 
   renderLine(path, style, events) {
-    const { role } = this.props;
+    const { role, clipId } = this.props;
     return (
-      <path style={style} d={path} role={role} {...events} vectorEffect="non-scaling-stroke"/>
+      <path
+        style={style}
+        d={path}
+        role={role}
+        {...events}
+        vectorEffect="non-scaling-stroke"
+        clipPath={`url(#${clipId})`}
+      />
     );
   }
 

--- a/src/components/victory-line/victory-line.js
+++ b/src/components/victory-line/victory-line.js
@@ -40,12 +40,12 @@ export default class VictoryLine extends React.Component {
   static defaultTransitions = {
     onExit: {
       duration: 500,
-      before: () => ({ y: null })
+      before: (datum) => ({ y: datum.y })
     },
     onEnter: {
       duration: 500,
       before: () => ({ y: null }),
-      after: (datum) => ({ y: datum.y})
+      after: (datum) => ({ y: datum.y })
     }
   };
 

--- a/src/components/victory-line/victory-line.js
+++ b/src/components/victory-line/victory-line.js
@@ -5,7 +5,7 @@ import LineHelpers from "./helper-methods";
 import Domain from "../../helpers/domain";
 import Data from "../../helpers/data";
 import {
-  PropTypes as CustomPropTypes, Helpers, Events, VictoryTransition, VictoryLabel,
+  PropTypes as CustomPropTypes, Helpers, Events, VictoryContinuousTransition, VictoryLabel,
   VictoryContainer
 } from "victory-core";
 
@@ -476,9 +476,9 @@ export default class VictoryLine extends React.Component {
         "data", "domain", "height", "padding", "samples", "style", "width", "x", "y"
       ];
       return (
-        <VictoryTransition animate={animate} animationWhitelist={whitelist}>
+        <VictoryContinuousTransition animate={animate} animationWhitelist={whitelist}>
           {React.createElement(this.constructor, modifiedProps)}
-        </VictoryTransition>
+        </VictoryContinuousTransition>
       );
     }
 

--- a/src/components/victory-line/victory-line.js
+++ b/src/components/victory-line/victory-line.js
@@ -6,7 +6,7 @@ import ClipPath from "../helpers/clip-path";
 import Domain from "../../helpers/domain";
 import Data from "../../helpers/data";
 import {
-  PropTypes as CustomPropTypes, Helpers, Events, VictoryContinuousTransition, VictoryLabel,
+  PropTypes as CustomPropTypes, Helpers, Events, VictoryTransition, VictoryLabel,
   VictoryContainer
 } from "victory-core";
 
@@ -486,9 +486,9 @@ export default class VictoryLine extends React.Component {
         "data", "domain", "height", "padding", "samples", "style", "width", "x", "y"
       ];
       return (
-        <VictoryContinuousTransition animate={animate} animationWhitelist={whitelist}>
+        <VictoryTransition animate={animate} animationWhitelist={whitelist}>
           {React.createElement(this.constructor, modifiedProps)}
-        </VictoryContinuousTransition>
+        </VictoryTransition>
       );
     }
 

--- a/src/components/victory-line/victory-line.js
+++ b/src/components/victory-line/victory-line.js
@@ -1,4 +1,4 @@
-import { defaults, partialRight, isFunction, random } from "lodash";
+import { defaults, partialRight, isFunction } from "lodash";
 import React, { PropTypes } from "react";
 import LineSegment from "./line-segment";
 import LineHelpers from "./helper-methods";
@@ -356,7 +356,6 @@ export default class VictoryLine extends React.Component {
   };
 
   static defaultProps = {
-    clipId: random(0, 1000),
     interpolation: "linear",
     padding: 50,
     samples: 50,
@@ -412,8 +411,10 @@ export default class VictoryLine extends React.Component {
         this.getSharedEventState("all", "data"),
         { data },
         dataComponent.props,
-        this.baseProps.all.data
+        this.baseProps.all.data,
+        props
       );
+
       const lineComponent = React.cloneElement(dataComponent, Object.assign(
         {}, dataProps, {events: Events.getPartialEvents(dataEvents, "all", dataProps)}
       ));
@@ -424,7 +425,8 @@ export default class VictoryLine extends React.Component {
           this.getSharedEventState("all", "labels"),
           { data },
           labelComponent.props,
-          this.baseProps.all.labels
+          this.baseProps.all.labels,
+          props
         );
       if (labelProps && labelProps.text) {
         const labelEvents = this.getEvents(props, "labels", "all");
@@ -474,7 +476,8 @@ export default class VictoryLine extends React.Component {
   }
 
   render() {
-    const modifiedProps = Helpers.modifyProps(this.props, fallbackProps);
+    const clipId = Math.round(Math.random() * 10000);
+    const modifiedProps = Helpers.modifyProps(this.props, fallbackProps, {clipId});
     const { animate, style, standalone } = modifiedProps;
 
     if (animate) {

--- a/src/components/victory-line/victory-line.js
+++ b/src/components/victory-line/victory-line.js
@@ -420,14 +420,14 @@ export default class VictoryLine extends React.Component {
       ));
 
       const labelProps = defaults(
-          {key: `${role}-label-${key}`},
-          this.getEventState("all", "labels"),
-          this.getSharedEventState("all", "labels"),
-          { data },
-          labelComponent.props,
-          this.baseProps.all.labels,
-          props
-        );
+        {key: `${role}-label-${key}`},
+        this.getEventState("all", "labels"),
+        this.getSharedEventState("all", "labels"),
+        { data },
+        labelComponent.props,
+        this.baseProps.all.labels,
+        props
+      );
       if (labelProps && labelProps.text) {
         const labelEvents = this.getEvents(props, "labels", "all");
         const lineLabel = React.cloneElement(labelComponent, Object.assign({

--- a/src/helpers/wrapper.js
+++ b/src/helpers/wrapper.js
@@ -1,15 +1,12 @@
-import { defaults, flatten, isFunction, partialRight, uniq } from "lodash";
+import { defaults, flatten, isFunction, uniq } from "lodash";
 import React from "react";
 import Axis from "./axis";
 import Data from "./data";
 import Domain from "./domain";
 import {
   Style,
-  ContinuousTransitions,
-  Transitions,
   TransitionHelpers,
-  Helpers,
-  Collection
+  Helpers
 } from "victory-core";
 
 
@@ -56,40 +53,17 @@ export default {
         childrenTransitions,
         nodesShouldEnter,
         nodesShouldExit,
-        oldProps: nodesWillEnter || nodesWillExit ? this.props : null
+        oldProps: (nodesWillEnter || nodesWillExit) ? this.props : null
       });
     }
   },
 
-  getAnimationProps(props, child, index) {
+  getAnimationProps(props, child) {
     if (!props.animate) {
+      // if parent don't have an animate props return child animate
       return child.props.animate;
     }
-
-    let childTransitions = Transitions;
-    if (TransitionHelpers.checkContinuousChartType(child)) {
-      childTransitions = ContinuousTransitions;
-    }
-
-    const getFilteredState = () => {
-      let childrenTransitions = this.state && this.state.childrenTransitions;
-      childrenTransitions = Collection.isArrayOfArrays(childrenTransitions) ?
-        childrenTransitions[index] : childrenTransitions;
-      return defaults({childrenTransitions}, this.state);
-    };
-
-    let getTransitions = props.animate && props.animate.getTransitions;
-    const state = getFilteredState();
-    const parentState = props.animate && props.animate.parentState || state;
-    if (!getTransitions) {
-      const getTransitionProps = childTransitions.getTransitionPropsFactory(
-        props,
-        state,
-        (newState) => this.setState(newState)
-      );
-      getTransitions = partialRight(getTransitionProps, index);
-    }
-    return defaults({getTransitions, parentState}, props.animate, child.props.animate);
+    return defaults(props.animate, child.props.animate);
   },
 
   getDomainFromChildren(props, axis, childComponents) {


### PR DESCRIPTION
@boygirl I've finished the main part of improving line and area chart transition.

Before: 

![before](https://camo.githubusercontent.com/7d84e9fe480f29909337e4891201b4f5630474a0/687474703a2f2f692e696d6775722e636f6d2f694134656963622e676966)

After: 

![line_animation](https://cloud.githubusercontent.com/assets/1216029/17058989/95562494-5055-11e6-96b0-04a4ba0fe6a3.gif)

The only thing left is `clipPath` haven't added. I have some questions before doing further implementation.

## 1.   

Do we need `onExit` after function, because this is strange. In my opinion, I think onExit after means the data point is deleted in the chart, so it isn't exist?

## 2.   

The `onExit` and `onEnter` work different in bar type charts and line type charts, the modification I do in line type charts https://github.com/FormidableLabs/victory-core/commit/91591c6f8edf97ceadd56522f76da3fa108b7bde , we should think of a way to work prefect.

Differences: 

### Bar type charts
- When points need to exit, the points will exit first and then transition to the next state.
- When points need to enter, the transition will goes to the next state first and then the points will enter afterward.

### Line type charts
- When points need to exit, the points should transition to the next state and exit.
- When points need to enter, the points should enter first and transition.
