### PR TITLE
Docs: Move Style component and spellcheck for the props table

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -1,6 +1,8 @@
 import React from "react";
 import { Link } from "react-router";
-import { StyleRoot } from "radium";
+import { StyleRoot, Style } from "radium";
+import { VictoryTheme } from "formidable-landers";
+
 
 const App = React.createClass({
   propTypes: {
@@ -21,6 +23,7 @@ const App = React.createClass({
           <li><Link to="/errorbar">Victory ErrorBar Docs</Link></li>
         </ul>
         {this.props.children}
+        <Style rules={VictoryTheme} />
       </StyleRoot>
     );
   }

--- a/docs/victory-area/docs.js
+++ b/docs/victory-area/docs.js
@@ -1,11 +1,11 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import Ecology from "ecology";
-import Radium, { Style } from "radium";
+import Radium from "radium";
 import * as docgen from "react-docgen";
 import { merge } from "lodash";
 import { VictoryArea, VictoryStack, VictoryGroup, VictoryScatter } from "../../src/index";
-import { VictoryTheme, appendLinkIcon, ecologyPlaygroundLoading } from "formidable-landers";
+import { appendLinkIcon, ecologyPlaygroundLoading } from "formidable-landers";
 
 class Docs extends React.Component {
   render() {
@@ -18,7 +18,6 @@ class Docs extends React.Component {
           playgroundtheme="elegant"
           customRenderers={merge(ecologyPlaygroundLoading, appendLinkIcon)}
         />
-        <Style rules={VictoryTheme}/>
       </div>
     );
   }

--- a/docs/victory-axis/docs.js
+++ b/docs/victory-axis/docs.js
@@ -2,10 +2,10 @@ import React from "react";
 import ReactDOM from "react-dom";
 import Ecology from "ecology";
 import { random, range, merge } from "lodash";
-import Radium, { Style } from "radium";
+import Radium from "radium";
 import * as docgen from "react-docgen";
 import { VictoryAxis } from "../../src/index";
-import { VictoryTheme, appendLinkIcon, ecologyPlaygroundLoading } from "formidable-landers";
+import { appendLinkIcon, ecologyPlaygroundLoading } from "formidable-landers";
 
 class Docs extends React.Component {
   render() {
@@ -18,7 +18,6 @@ class Docs extends React.Component {
           playgroundtheme="elegant"
           customRenderers={merge(appendLinkIcon, ecologyPlaygroundLoading)}
         />
-        <Style rules={VictoryTheme}/>
       </div>
     );
   }

--- a/docs/victory-bar/docs.js
+++ b/docs/victory-bar/docs.js
@@ -1,12 +1,12 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import Ecology from "ecology";
-import Radium, { Style } from "radium";
+import Radium from "radium";
 import { merge, random, range } from "lodash";
 import * as docgen from "react-docgen";
 import { VictoryBar, VictoryGroup, VictoryStack} from "../../src/index";
 import { VictoryLabel } from "victory-core";
-import { VictoryTheme, appendLinkIcon, ecologyPlaygroundLoading } from "formidable-landers";
+import { appendLinkIcon, ecologyPlaygroundLoading } from "formidable-landers";
 
 class Docs extends React.Component {
   render() {
@@ -22,7 +22,6 @@ class Docs extends React.Component {
           playgroundtheme="elegant"
           customRenderers={merge(appendLinkIcon, ecologyPlaygroundLoading)}
         />
-        <Style rules={VictoryTheme}/>
       </div>
     );
   }

--- a/docs/victory-candlestick/docs.js
+++ b/docs/victory-candlestick/docs.js
@@ -1,12 +1,12 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import Ecology from "ecology";
-import Radium, { Style } from "radium";
+import Radium from "radium";
 import { merge, random, range } from "lodash";
 import * as docgen from "react-docgen";
 import { VictoryCandlestick, VictoryChart, VictoryAxis} from "../../src/index";
 import { VictoryLabel } from "victory-core";
-import { VictoryTheme, appendLinkIcon, ecologyPlaygroundLoading } from "formidable-landers";
+import { appendLinkIcon, ecologyPlaygroundLoading } from "formidable-landers";
 
 class Docs extends React.Component {
   render() {
@@ -24,7 +24,6 @@ class Docs extends React.Component {
           playgroundtheme="elegant"
           customRenderers={merge(appendLinkIcon, ecologyPlaygroundLoading)}
         />
-        <Style rules={VictoryTheme}/>
       </div>
     );
   }

--- a/docs/victory-chart/docs.js
+++ b/docs/victory-chart/docs.js
@@ -2,12 +2,12 @@ import React from "react";
 import ReactDOM from "react-dom";
 import Ecology from "ecology";
 import { merge, random, range } from "lodash";
-import Radium, { Style } from "radium";
+import Radium from "radium";
 import * as docgen from "react-docgen";
 import {
   VictoryChart, VictoryLine, VictoryAxis, VictoryBar, VictoryScatter, VictoryStack
 } from "../../src/index";
-import { VictoryTheme, appendLinkIcon, ecologyPlaygroundLoading } from "formidable-landers";
+import { appendLinkIcon, ecologyPlaygroundLoading } from "formidable-landers";
 import DatasetDropdown from "../dataset-dropdown";
 import dataset from "./dataset";
 
@@ -25,7 +25,6 @@ class Docs extends React.Component {
           playgroundtheme="elegant"
           customRenderers={merge(appendLinkIcon, ecologyPlaygroundLoading)}
         />
-        <Style rules={VictoryTheme}/>
       </div>
     );
   }

--- a/docs/victory-errorbar/docs.js
+++ b/docs/victory-errorbar/docs.js
@@ -1,12 +1,12 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import Ecology from "ecology";
-import Radium, { Style } from "radium";
+import Radium from "radium";
 import { merge, random, range } from "lodash";
 import * as docgen from "react-docgen";
 import { VictoryErrorBar, VictoryChart, VictoryAxis} from "../../src/index";
 import { VictoryLabel } from "victory-core";
-import { VictoryTheme, appendLinkIcon, ecologyPlaygroundLoading } from "formidable-landers";
+import { appendLinkIcon, ecologyPlaygroundLoading } from "formidable-landers";
 
 class Docs extends React.Component {
   render() {
@@ -24,7 +24,6 @@ class Docs extends React.Component {
           playgroundtheme="elegant"
           customRenderers={merge(appendLinkIcon, ecologyPlaygroundLoading)}
         />
-        <Style rules={VictoryTheme}/>
       </div>
     );
   }

--- a/docs/victory-line/docs.js
+++ b/docs/victory-line/docs.js
@@ -5,7 +5,7 @@ import { merge, random } from "lodash";
 import Radium from "radium";
 import * as docgen from "react-docgen";
 import { VictoryLine, VictoryScatter } from "../../src/index";
-import { VictoryTheme, appendLinkIcon, ecologyPlaygroundLoading } from "formidable-landers";
+import { appendLinkIcon, ecologyPlaygroundLoading } from "formidable-landers";
 
 class Docs extends React.Component {
   render() {

--- a/docs/victory-line/docs.js
+++ b/docs/victory-line/docs.js
@@ -2,7 +2,7 @@ import React from "react";
 import ReactDOM from "react-dom";
 import Ecology from "ecology";
 import { merge, random } from "lodash";
-import Radium, { Style } from "radium";
+import Radium from "radium";
 import * as docgen from "react-docgen";
 import { VictoryLine, VictoryScatter } from "../../src/index";
 import { VictoryTheme, appendLinkIcon, ecologyPlaygroundLoading } from "formidable-landers";
@@ -18,7 +18,6 @@ class Docs extends React.Component {
           playgroundtheme="elegant"
           customRenderers={merge(appendLinkIcon, ecologyPlaygroundLoading)}
         />
-        <Style rules={VictoryTheme}/>
       </div>
     );
   }

--- a/docs/victory-scatter/docs.js
+++ b/docs/victory-scatter/docs.js
@@ -1,12 +1,12 @@
 import Ecology from "ecology";
 import { merge, random, range } from "lodash";
-import Radium, { Style } from "radium";
+import Radium from "radium";
 import React from "react";
 import ReactDOM from "react-dom";
 import symbolData from "./symbol-data";
 import * as docgen from "react-docgen";
 import { VictoryScatter } from "../../src/index";
-import { VictoryTheme, appendLinkIcon, ecologyPlaygroundLoading } from "formidable-landers";
+import { appendLinkIcon, ecologyPlaygroundLoading } from "formidable-landers";
 
 class Docs extends React.Component {
   render() {
@@ -23,7 +23,6 @@ class Docs extends React.Component {
           playgroundtheme="elegant"
           customRenderers={merge(appendLinkIcon, ecologyPlaygroundLoading)}
         />
-        <Style rules={VictoryTheme}/>
       </div>
     );
   }

--- a/src/components/victory-area/victory-area.js
+++ b/src/components/victory-area/victory-area.js
@@ -318,7 +318,7 @@ export default class VictoryArea extends React.Component {
      * Any of these props may be overridden by passing in props to the supplied component,
      * or modified or ignored within the custom component itself. If a dataComponent is
      * not provided, VictoryArea will use the default VictoryContainer component.
-     * @example <VictoryContainer title="Chart of Dog Breeds" desc="This chart shows how
+     * @examples <VictoryContainer title="Chart of Dog Breeds" desc="This chart shows how
      * popular each dog breed is by percentage in Seattle." />
      */
     containerComponent: PropTypes.element,
@@ -328,8 +328,7 @@ export default class VictoryArea extends React.Component {
     * When using VictoryArea as a solo component, implement the theme directly on
     * VictoryArea. If you are wrapping VictoryArea in VictoryChart, VictoryStack, or
     * VictoryGroup, please call the theme on the outermost wrapper component instead.
-    * @example theme={VictoryTheme.grayscale}
-    * http://www.github.com/FormidableLabs/victory-core/tree/master/src/victory-theme/grayscale.js
+    * @examples theme={VictoryTheme.material}
     */
     theme: PropTypes.object,
     /**

--- a/src/components/victory-axis/victory-axis.js
+++ b/src/components/victory-axis/victory-axis.js
@@ -332,7 +332,7 @@ export default class VictoryAxis extends React.Component {
      * Any of these props may be overridden by passing in props to the supplied component,
      * or modified or ignored within the custom component itself. If a dataComponent is
      * not provided, VictoryAxis will use the default VictoryContainer component.
-     * @example <VictoryContainer title="Chart of Dog Breeds" desc="This chart shows how
+     * @examples <VictoryContainer title="Chart of Dog Breeds" desc="This chart shows how
      * popular each dog breed is by percentage in Seattle." />
      */
     containerComponent: PropTypes.element,
@@ -342,8 +342,7 @@ export default class VictoryAxis extends React.Component {
     * Victory. When using VictoryAxis as a solo component, implement the theme directly on
     * VictoryAxis. If you are wrapping VictoryAxis in VictoryChart, VictoryStack, or
     * VictoryGroup, please call the theme on the outermost wrapper component instead.
-    * @example theme={VictoryTheme.grayscale}
-    * http://www.github.com/FormidableLabs/victory-core/tree/master/src/victory-theme/grayscale.js
+    * @examples theme={VictoryTheme.material}
     */
     theme: PropTypes.object,
     /**

--- a/src/components/victory-bar/victory-bar.js
+++ b/src/components/victory-bar/victory-bar.js
@@ -324,7 +324,7 @@ export default class VictoryBar extends React.Component {
      * Any of these props may be overridden by passing in props to the supplied component,
      * or modified or ignored within the custom component itself. If a dataComponent is
      * not provided, VictoryBar will use the default VictoryContainer component.
-     * @example <VictoryContainer title="Chart of Dog Breeds" desc="This chart shows how
+     * @examples <VictoryContainer title="Chart of Dog Breeds" desc="This chart shows how
      * popular each dog breed is by percentage in Seattle." />
      */
     containerComponent: PropTypes.element,
@@ -334,8 +334,7 @@ export default class VictoryBar extends React.Component {
     * When using VictoryBar as a solo component, implement the theme directly on
     * VictoryBar. If you are wrapping VictoryBar in VictoryChart, VictoryStack, or
     * VictoryGroup, please call the theme on the outermost wrapper component instead.
-    * @example theme={VictoryTheme.grayscale}
-    * http://www.github.com/FormidableLabs/victory-core/tree/master/src/victory-theme/grayscale.js
+    * @examples theme={VictoryTheme.material}
     */
     theme: PropTypes.object,
     /**

--- a/src/components/victory-candlestick/victory-candlestick.js
+++ b/src/components/victory-candlestick/victory-candlestick.js
@@ -378,7 +378,7 @@ export default class VictoryCandlestick extends React.Component {
      * Any of these props may be overridden by passing in props to the supplied component,
      * or modified or ignored within the custom component itself. If a dataComponent is
      * not provided, VictoryCandlestick will use the default VictoryContainer component.
-     * @example <VictoryContainer title="Chart of Dog Breeds" desc="This chart shows how
+     * @examples <VictoryContainer title="Chart of Dog Breeds" desc="This chart shows how
      * popular each dog breed is by percentage in Seattle." />
      */
     containerComponent: PropTypes.element,
@@ -388,7 +388,7 @@ export default class VictoryCandlestick extends React.Component {
     * candleColors prop takes an object with keys positive and negative, which each take
     * a string that should be a color. Positive is for data points where close is higher
     * than open, and defaults to white, and negative (close < open) defaults to black.
-    * @example: candleColors={{positive: "purple", negative: "blue"}}
+    * @examples candleColors={{positive: "purple", negative: "blue"}}
     */
     candleColors: PropTypes.shape({
       positive: PropTypes.string,
@@ -406,8 +406,7 @@ export default class VictoryCandlestick extends React.Component {
     * When using VictoryCandlestick as a solo component, implement the theme directly on
     * VictoryCandlestick. If you are wrapping VictoryScatter in VictoryChart, VictoryStack, or
     * VictoryGroup, please call the theme on the outermost wrapper component instead.
-    * @example theme={VictoryTheme.grayscale}
-    * http://www.github.com/FormidableLabs/victory-core/tree/master/src/victory-theme/grayscale.js
+    * @examples theme={VictoryTheme.material}
     */
     theme: PropTypes.object
   };

--- a/src/components/victory-chart/victory-chart.js
+++ b/src/components/victory-chart/victory-chart.js
@@ -195,7 +195,7 @@ export default class VictoryChart extends React.Component {
      * Any of these props may be overridden by passing in props to the supplied component,
      * or modified or ignored within the custom component itself. If a dataComponent is
      * not provided, VictoryChart will use the default VictoryContainer component.
-     * @example <VictoryContainer title="Chart of Dog Breeds" desc="This chart shows how
+     * @examples <VictoryContainer title="Chart of Dog Breeds" desc="This chart shows how
      * popular each dog breed is by percentage in Seattle." />
      */
     containerComponent: PropTypes.element,
@@ -204,8 +204,7 @@ export default class VictoryChart extends React.Component {
     * You can create this object yourself, or you can use a theme provided by Victory.
     * When using VictoryChart, either alone or as a wrapper for other components,
     * you will only need to implement the theme on VictoryChart itself.
-    * @example theme={VictoryTheme.grayscale}
-    * http://www.github.com/FormidableLabs/victory-core/tree/master/src/victory-theme/grayscale.js
+    * @examples theme={VictoryTheme.material}
     */
     theme: PropTypes.object,
     /**

--- a/src/components/victory-errorbar/victory-errorbar.js
+++ b/src/components/victory-errorbar/victory-errorbar.js
@@ -323,7 +323,7 @@ export default class VictoryErrorBar extends React.Component {
      * Any of these props may be overridden by passing in props to the supplied component,
      * or modified or ignored within the custom component itself. If a dataComponent is
      * not provided, VictoryErrorBar will use the default VictoryContainer component.
-     * @example <VictoryContainer title="Chart of Dog Breeds" desc="This chart shows how
+     * @examples <VictoryContainer title="Chart of Dog Breeds" desc="This chart shows how
      * popular each dog breed is by percentage in Seattle." />
      */
     containerComponent: PropTypes.element,
@@ -333,8 +333,7 @@ export default class VictoryErrorBar extends React.Component {
     * When using VictoryErrorBar as a solo component, implement the theme directly on
     * VictoryErrorBar. If you are wrapping VictoryErrorBar in VictoryChart, VictoryStack, or
     * VictoryGroup, please call the theme on the outermost wrapper component instead.
-    * @example theme={VictoryTheme.grayscale}
-    * http://www.github.com/FormidableLabs/victory-core/tree/master/src/victory-theme/grayscale.js
+    * @examples theme={VictoryTheme.material}
     */
     theme: PropTypes.object,
     /**

--- a/src/components/victory-group/victory-group.js
+++ b/src/components/victory-group/victory-group.js
@@ -263,7 +263,7 @@ export default class VictoryGroup extends React.Component {
      * Any of these props may be overridden by passing in props to the supplied component,
      * or modified or ignored within the custom component itself. If a dataComponent is
      * not provided, VictoryGroup will use the default VictoryContainer component.
-     * @example <VictoryContainer title="Chart of Dog Breeds" desc="This chart shows how
+     * @examples <VictoryContainer title="Chart of Dog Breeds" desc="This chart shows how
      * popular each dog breed is by percentage in Seattle." />
      */
     containerComponent: PropTypes.element,
@@ -273,8 +273,7 @@ export default class VictoryGroup extends React.Component {
     * When using VictoryGrou as the outermost wrapper for your chart, implement the theme
     * directly on VictoyrGroup. If you are wrapping VictoryGroup in VictoryChart,
     * please call the theme on the wrapper component instead.
-    * @example theme={VictoryTheme.grayscale}
-    * http://www.github.com/FormidableLabs/victory-core/tree/master/src/victory-theme/grayscale.js
+    * @examples theme={VictoryTheme.material}
     */
     theme: PropTypes.object,
     /**

--- a/src/components/victory-line/victory-line.js
+++ b/src/components/victory-line/victory-line.js
@@ -332,7 +332,7 @@ export default class VictoryLine extends React.Component {
      * Any of these props may be overridden by passing in props to the supplied component,
      * or modified or ignored within the custom component itself. If a dataComponent is
      * not provided, VictoryLine will use the default VictoryContainer component.
-     * @example <VictoryContainer title="Chart of Dog Breeds" desc="This chart shows how
+     * @examples <VictoryContainer title="Chart of Dog Breeds" desc="This chart shows how
      * popular each dog breed is by percentage in Seattle." />
      */
     containerComponent: PropTypes.element,
@@ -342,8 +342,7 @@ export default class VictoryLine extends React.Component {
     * When using VictoryLine as a solo component, implement the theme directly on
     * VictoryLine. If you are wrapping VictoryLine in VictoryChart, VictoryStack, or
     * VictoryGroup, please call the theme on the outermost wrapper component instead.
-    * @example theme={VictoryTheme.grayscale}
-    * http://www.github.com/FormidableLabs/victory-core/tree/master/src/victory-theme/grayscale.js
+    * @examples theme={VictoryTheme.material}
     */
     theme: PropTypes.object,
     /**

--- a/src/components/victory-scatter/victory-scatter.js
+++ b/src/components/victory-scatter/victory-scatter.js
@@ -343,7 +343,7 @@ export default class VictoryScatter extends React.Component {
      * Any of these props may be overridden by passing in props to the supplied component,
      * or modified or ignored within the custom component itself. If a dataComponent is
      * not provided, VictoryScatter will use the default VictoryContainer component.
-     * @example <VictoryContainer title="Chart of Dog Breeds" desc="This chart shows how
+     * @examples <VictoryContainer title="Chart of Dog Breeds" desc="This chart shows how
      * popular each dog breed is by percentage in Seattle." />
      */
     containerComponent: PropTypes.element,
@@ -353,8 +353,7 @@ export default class VictoryScatter extends React.Component {
     * When using VictoryScatter as a solo component, implement the theme directly on
     * VictoryScatter. If you are wrapping VictoryScatter in VictoryChart, VictoryStack, or
     * VictoryGroup, please call the theme on the outermost wrapper component instead.
-    * @example theme={VictoryTheme.grayscale}
-    * http://www.github.com/FormidableLabs/victory-core/tree/master/src/victory-theme/grayscale.js
+    * @examples theme={VictoryTheme.material}
     */
     theme: PropTypes.object,
     /**

--- a/src/components/victory-stack/victory-stack.js
+++ b/src/components/victory-stack/victory-stack.js
@@ -261,7 +261,7 @@ export default class VictoryStack extends React.Component {
      * Any of these props may be overridden by passing in props to the supplied component,
      * or modified or ignored within the custom component itself. If a dataComponent is
      * not provided, VictoryStack will use the default VictoryContainer component.
-     * @example <VictoryContainer title="Chart of Dog Breeds" desc="This chart shows how
+     * @examples <VictoryContainer title="Chart of Dog Breeds" desc="This chart shows how
      * popular each dog breed is by percentage in Seattle." />
      */
     containerComponent: PropTypes.element,
@@ -271,8 +271,7 @@ export default class VictoryStack extends React.Component {
     * When using VictoryStack to wrap a chart component, implement the theme directly on
     * VictoryStack. If you are wrapping VictoryStack in VictoryChart,
     * please call the theme on the wrapper component instead.
-    * @example theme={VictoryTheme.grayscale}
-    * http://www.github.com/FormidableLabs/victory-core/tree/master/src/victory-theme/grayscale.js
+    * @examples theme={VictoryTheme.material}
     */
     theme: PropTypes.object,
     /**


### PR DESCRIPTION
Resolves https://github.com/FormidableLabs/victory-docs/issues/38

- Move repeated `<Style rules={VictoryTheme />` to `app.js` and delete from every `docs.js` 
- Spellcheck: `@example` should be `@examples` 
- `VictoryTheme.grayscale` no longer exists, so replaced it with `VictoryTheme.material` and removed the link (which looked kinda weird in the Props Table anyway, and with a Theme page it should be easier to see it in full glory)  

/cc @ebrillhart @kylecesmat @bmathews 