### PR TITLE
Handle empty data array or single data point

### DIFF
--- a/demo/components/victory-area-demo.js
+++ b/demo/components/victory-area-demo.js
@@ -320,6 +320,16 @@ export default class App extends React.Component {
           />
         </VictoryStack>
 
+        <VictoryChart
+          style={style}
+          theme={VictoryTheme.material}
+        >
+          <VictoryArea
+            style={style}
+            data={[]}
+          />
+        </VictoryChart>
+
       </div>
     );
   }

--- a/demo/components/victory-bar-demo.js
+++ b/demo/components/victory-bar-demo.js
@@ -454,6 +454,12 @@ export default class App extends React.Component {
             y={"x"}
           />
         </VictoryChart>
+
+        <VictoryChart>
+          <VictoryBar
+            data={[]}
+          />
+        </VictoryChart>
       </div>
     );
   }

--- a/demo/components/victory-bar-demo.js
+++ b/demo/components/victory-bar-demo.js
@@ -457,7 +457,7 @@ export default class App extends React.Component {
 
         <VictoryChart>
           <VictoryBar
-            data={[]}
+            data={[{x: 1, y: 3}]}
           />
         </VictoryChart>
       </div>

--- a/demo/components/victory-bar-demo.js
+++ b/demo/components/victory-bar-demo.js
@@ -114,6 +114,7 @@ export default class App extends React.Component {
     return (
       <div className="demo">
         <h1>VictoryBar</h1>
+
         <ChartWrap scale={{x: "log", y: "linear"}}>
           <VictoryBar
             scale={{x: "log", y: "linear"}}
@@ -519,7 +520,7 @@ export default class App extends React.Component {
 
         <VictoryChart>
           <VictoryBar
-            data={[{x: 1, y: 3}]}
+            data={[]}
           />
         </VictoryChart>
       </div>

--- a/demo/components/victory-candlestick-demo.js
+++ b/demo/components/victory-candlestick-demo.js
@@ -177,6 +177,12 @@ export default class App extends React.Component {
           size={1}
         />
 
+        <VictoryChart>
+          <VictoryCandlestick
+            data={[]}
+          />
+        </VictoryChart>
+
       </div>
     );
   }

--- a/demo/components/victory-errorbar-demo.js
+++ b/demo/components/victory-errorbar-demo.js
@@ -151,6 +151,15 @@ export default class App extends React.Component {
             data={this.state.data}
           />
         </VictoryChart>
+
+        <VictoryChart
+          theme={VictoryTheme.material}
+        >
+          <VictoryErrorBar
+            style={style}
+            data={[{x: 1, y: 2, errorX: .5, errorY: .25}]}
+          />
+        </VictoryChart>
       </div>
     );
   }

--- a/demo/components/victory-errorbar-demo.js
+++ b/demo/components/victory-errorbar-demo.js
@@ -157,7 +157,7 @@ export default class App extends React.Component {
         >
           <VictoryErrorBar
             style={style}
-            data={[{x: 1, y: 2, errorX: .5, errorY: .25}]}
+            data={[]}
           />
         </VictoryChart>
       </div>

--- a/demo/components/victory-line-demo.js
+++ b/demo/components/victory-line-demo.js
@@ -249,7 +249,7 @@ export default class App extends React.Component {
       >
           <VictoryLine
             style={{parent: parentStyle}}
-            data={[]}
+            data={[{x: 2, y: 3}]}
             label="Hello"
           />
       </VictoryChart>

--- a/demo/components/victory-line-demo.js
+++ b/demo/components/victory-line-demo.js
@@ -242,6 +242,17 @@ export default class App extends React.Component {
             y={(d) => (d.y + 15)}
           />
       </VictoryChart>
+
+      <VictoryChart
+        style={{parent: parentStyle}}
+        theme={VictoryTheme.material}
+      >
+          <VictoryLine
+            style={{parent: parentStyle}}
+            data={[]}
+            label="Hello"
+          />
+      </VictoryChart>
       </div>
     );
   }

--- a/demo/components/victory-line-demo.js
+++ b/demo/components/victory-line-demo.js
@@ -314,8 +314,7 @@ export default class App extends React.Component {
       >
           <VictoryLine
             style={{parent: parentStyle}}
-            data={[{x: 2, y: 3}]}
-            label="Hello"
+            data={[]}
           />
       </VictoryChart>
       </div>

--- a/demo/components/victory-scatter-demo.js
+++ b/demo/components/victory-scatter-demo.js
@@ -1,7 +1,7 @@
 /*global window:false */
 import React from "react";
 import { merge, random, range } from "lodash";
-import {VictoryScatter, VictoryChart, VictoryAxis} from "../../src/index";
+import {VictoryScatter, VictoryChart} from "../../src/index";
 import {VictoryLabel} from "victory-core";
 import bubbleData from "./bubble-data.js";
 import symbolData from "./symbol-data.js";

--- a/demo/components/victory-scatter-demo.js
+++ b/demo/components/victory-scatter-demo.js
@@ -1,7 +1,7 @@
 /*global window:false */
 import React from "react";
 import { merge, random, range } from "lodash";
-import {VictoryScatter, VictoryChart} from "../../src/index";
+import {VictoryScatter, VictoryChart, VictoryAxis} from "../../src/index";
 import {VictoryLabel} from "victory-core";
 import bubbleData from "./bubble-data.js";
 import symbolData from "./symbol-data.js";
@@ -235,6 +235,15 @@ export default class App extends React.Component {
           x="a.x"
           y="a.b[0]y"
         />
+
+        <VictoryChart>
+          <VictoryScatter
+            style={style}
+            theme={VictoryTheme.material}
+            data={[{x: 3, y: 4}]}
+          />
+        </VictoryChart>
+
       </div>
     );
   }

--- a/demo/components/victory-scatter-demo.js
+++ b/demo/components/victory-scatter-demo.js
@@ -240,7 +240,7 @@ export default class App extends React.Component {
           <VictoryScatter
             style={style}
             theme={VictoryTheme.material}
-            data={[{x: 3, y: 4}]}
+            data={[]}
           />
         </VictoryChart>
 

--- a/src/components/victory-area/helper-methods.js
+++ b/src/components/victory-area/helper-methods.js
@@ -26,9 +26,9 @@ export default {
 
     const labelProps = {
       key: "area-label",
-      x: scale.x(lastData.x) + labelStyle.padding,
-      y: scale.y(lastData.y1),
-      y0: scale.y(lastData.y0),
+      x: lastData ? scale.x(lastData.x) + labelStyle.padding : 0,
+      y: lastData ? scale.y(lastData.y1) : 0,
+      y0: lastData ? scale.y(lastData.y0) : 0,
       style: labelStyle,
       textAnchor: labelStyle.textAnchor || "start",
       verticalAnchor: labelStyle.verticalAnchor || "middle",
@@ -72,7 +72,7 @@ export default {
 
     if (data.length < 2) {
       Log.warn("Area requires at least two data points.");
-      data = Data.generateData(props);
+      data = [];
     }
 
     const defaultMin = Scale.getScaleType(props, "y") === "log" ? 1 / Number.MAX_SAFE_INTEGER : 0;

--- a/src/components/victory-area/helper-methods.js
+++ b/src/components/victory-area/helper-methods.js
@@ -1,5 +1,5 @@
 import { last } from "lodash";
-import { Helpers } from "victory-core";
+import { Helpers, Log } from "victory-core";
 import Data from "../../helpers/data";
 import Domain from "../../helpers/domain";
 import Scale from "../../helpers/scale";
@@ -68,7 +68,13 @@ export default {
   },
 
   getDataWithBaseline(props, domain) {
-    const data = Data.getData(props);
+    let data = Data.getData(props);
+
+    if (data.length < 2) {
+      Log.warn("Area requires at least two data points.");
+      data = Data.generateData(props);
+    }
+
     const minY = Math.min(...domain.y) > 0 ? Math.min(...domain.y) : 0;
     return data.map((datum) => {
       const y1 = datum.yOffset ? datum.yOffset + datum.y : datum.y;

--- a/src/components/victory-candlestick/helper-methods.js
+++ b/src/components/victory-candlestick/helper-methods.js
@@ -1,5 +1,5 @@
 import { assign, pick, omit, defaults } from "lodash";
-import { Helpers, Events } from "victory-core";
+import { Helpers, Events, Log } from "victory-core";
 import Scale from "../../helpers/scale";
 import Domain from "../../helpers/domain";
 
@@ -72,7 +72,8 @@ export default {
     if (props.data && props.data.length > 0) {
       data = props.data;
     } else {
-      data = this.generateData(props);
+      Log.warn("This is an empty dataset.");
+      data = [];
     }
 
     const accessor = {
@@ -97,19 +98,6 @@ export default {
     });
   },
 
-  generateData(props) {
-    // create an array of values evenly spaced across the x domain that include domain min/max
-    const domain = props.domain ? (props.domain.x || props.domain) :
-      Scale.getBaseScale(props, "x").domain();
-    const samples = 8;
-    const max = Math.max(...domain);
-    const values = Array(...Array(samples)).map((val, index) => {
-      const v = (max / samples) * index + Math.min(...domain);
-      return { x: v, open: v, close: v + 2, high: v + 3, low: v - 1};
-    });
-    return values;
-  },
-
   getDomain(props, axis) {
     let domain;
     if (props.domain && props.domain[axis]) {
@@ -123,6 +111,11 @@ export default {
          memo.concat(...datum[axis]) : memo.concat(datum[axis]);
       },
       []);
+
+      if (allData.length < 1) {
+        return Scale.getBaseScale(props, axis).domain();
+      }
+
       const min = Math.min(...allData);
       const max = Math.max(...allData);
       if (min === max) {

--- a/src/components/victory-candlestick/helper-methods.js
+++ b/src/components/victory-candlestick/helper-methods.js
@@ -66,7 +66,14 @@ export default {
   },
 
   getData(props) {
-    const data = props.data;
+    let data;
+
+    if (props.data && props.data.length > 0) {
+      data = props.data;
+    } else {
+      data = this.generateData(props);
+    }
+
     const accessor = {
       x: Helpers.createAccessor(props.x),
       open: Helpers.createAccessor(props.open),
@@ -89,6 +96,19 @@ export default {
     });
   },
 
+  generateData(props) {
+    // create an array of values evenly spaced across the x domain that include domain min/max
+    const domain = props.domain ? (props.domain.x || props.domain) :
+      Scale.getBaseScale(props, "x").domain();
+    const samples = 8;
+    const max = Math.max(...domain);
+    const values = Array(...Array(samples)).map((val, index) => {
+      const v = (max / samples) * index + Math.min(...domain);
+      return { x: v, open: v, close: v + 2, high: v + 3, low: v - 1};
+    });
+    return values;
+  },
+
   getDomain(props, axis) {
     let domain;
     if (props.domain && props.domain[axis]) {
@@ -105,7 +125,7 @@ export default {
       const min = Math.min(...allData);
       const max = Math.max(...allData);
       if (min === max) {
-        const adjustedMax = max === 0 ? 1 : max;
+        const adjustedMax = max === 0 ? 1 : max + max;
         return [0, adjustedMax];
       }
       domain = [min, max];

--- a/src/components/victory-errorbar/helper-methods.js
+++ b/src/components/victory-errorbar/helper-methods.js
@@ -84,12 +84,25 @@ export default {
   },
 
   getErrorData(props) {
-    if (props.data) {
+    if (props.data && props.data.length > 0) {
       return this.formatErrorData(props.data, props);
     } else {
       const generatedData = (props.errorX || props.errorY) && this.generateData(props);
       return this.formatErrorData(generatedData, props);
     }
+  },
+
+  generateData(props) {
+    // create an array of values evenly spaced across the x domain that include domain min/max
+    const domain = props.domain ? (props.domain.x || props.domain) :
+      Scale.getBaseScale(props, "x").domain();
+    const samples = 8;
+    const max = Math.max(...domain);
+    const values = Array(...Array(samples)).map((val, index) => {
+      const v = (max / samples) * index + Math.min(...domain);
+      return { x: v, y: v, errorX: v / 2, errorY: v / 4 };
+    });
+    return values[samples - 1].x === max ? values : values.concat([{ x: max, y: max }]);
   },
 
   formatErrorData(dataset, props) {

--- a/src/components/victory-line/helper-methods.js
+++ b/src/components/victory-line/helper-methods.js
@@ -1,5 +1,5 @@
 import { sortBy, defaults, last } from "lodash";
-import { Helpers } from "victory-core";
+import { Helpers, Log } from "victory-core";
 import Data from "../../helpers/data";
 import Domain from "../../helpers/domain";
 import Scale from "../../helpers/scale";
@@ -46,7 +46,13 @@ export default {
   },
 
   getCalculatedValues(props) {
-    const dataset = Data.getData(props);
+    let dataset = Data.getData(props);
+
+    if (Data.getData(props).length < 2) {
+      Log.warn("VictoryLine needs at least two data points to render properly.");
+      dataset = Data.generateData(props);
+    }
+
     const dataSegments = this.getDataSegments(dataset);
     const range = {
       x: Helpers.getRange(props, "x"),

--- a/src/components/victory-line/helper-methods.js
+++ b/src/components/victory-line/helper-methods.js
@@ -25,8 +25,8 @@ export default {
     const labelStyle = this.getLabelStyle(baseLabelStyle, dataStyle);
 
     const labelProps = {
-      x: scale.x(lastData.x) + labelStyle.padding,
-      y: scale.y(lastData.y),
+      x: lastData ? scale.x(lastData.x) + labelStyle.padding : 0,
+      y: lastData ? scale.y(lastData.y) : 0,
       style: labelStyle,
       textAnchor: labelStyle.textAnchor || "start",
       verticalAnchor: labelStyle.verticalAnchor || "middle",
@@ -50,7 +50,7 @@ export default {
 
     if (Data.getData(props).length < 2) {
       Log.warn("VictoryLine needs at least two data points to render properly.");
-      dataset = Data.generateData(props);
+      dataset = [];
     }
 
     const dataSegments = this.getDataSegments(dataset);

--- a/src/helpers/data.js
+++ b/src/helpers/data.js
@@ -52,7 +52,7 @@ export default {
     // create an array of values evenly spaced across the x domain that include domain min/max
     const domain = props.domain ? (props.domain.x || props.domain) :
       Scale.getBaseScale(props, "x").domain();
-    const samples = props.samples || 2;
+    const samples = props.samples || 1;
     const max = Math.max(...domain);
     const values = Array(...Array(samples)).map((val, index) => {
       const v = (max / samples) * index + Math.min(...domain);

--- a/src/helpers/data.js
+++ b/src/helpers/data.js
@@ -52,7 +52,7 @@ export default {
     // create an array of values evenly spaced across the x domain that include domain min/max
     const domain = props.domain ? (props.domain.x || props.domain) :
       Scale.getBaseScale(props, "x").domain();
-    const samples = props.samples || 1;
+    const samples = props.samples || 2;
     const max = Math.max(...domain);
     const values = Array(...Array(samples)).map((val, index) => {
       const v = (max / samples) * index + Math.min(...domain);

--- a/src/helpers/data.js
+++ b/src/helpers/data.js
@@ -40,7 +40,7 @@ export default {
   },
 
   getData(props) {
-    if (props.data) {
+    if (props.data && props.data.length > 0) {
       return this.formatData(props.data, props);
     } else {
       const generatedData = (props.x || props.y) && this.generateData(props);

--- a/src/helpers/data.js
+++ b/src/helpers/data.js
@@ -1,5 +1,5 @@
 import { assign, uniq } from "lodash";
-import { Helpers, Collection } from "victory-core";
+import { Helpers, Collection, Log } from "victory-core";
 import Scale from "./scale";
 
 export default {
@@ -40,8 +40,13 @@ export default {
   },
 
   getData(props) {
-    if (props.data && props.data.length > 0) {
-      return this.formatData(props.data, props);
+    if (props.data) {
+      if (props.data.length < 1) {
+        Log.warn("This is an empty dataset.");
+        return [];
+      } else {
+        return this.formatData(props.data, props);
+      }
     } else {
       const generatedData = (props.x || props.y) && this.generateData(props);
       return this.formatData(generatedData, props);

--- a/src/helpers/domain.js
+++ b/src/helpers/domain.js
@@ -74,6 +74,11 @@ export default {
   getDomainFromData(props, axis, dataset) {
     const currentAxis = Axis.getCurrentAxis(axis, props.horizontal);
     const allData = flatten(dataset).map((datum) => datum[currentAxis]);
+
+    if (allData.length < 1) {
+      return Scale.getBaseScale(props, axis).domain();
+    }
+
     const min = Collection.getMinValue(allData);
     const max = Collection.getMaxValue(allData);
     // TODO: is this the correct behavior, or should we just error. How do we

--- a/src/helpers/domain.js
+++ b/src/helpers/domain.js
@@ -55,7 +55,7 @@ export default {
     // TODO: is this the correct behavior, or should we just error. How do we
     // handle charts with just one data point?
     if (min === max) {
-      const adjustedMax = max === 0 ? 1 : max;
+      const adjustedMax = max === 0 ? 1 : max + max;
       return [0, adjustedMax];
     }
     return [min, max];


### PR DESCRIPTION
This allows all chart components to handle either an empty data array or a single data point. One aspect of weirdness I'm getting right now is that line is handling having a single data point fine in that nothing breaks and the label is where it's supposed to be (and the dataset generates properly)... but the line just doesn't show up. Thoughts?

@boygirl 

addresses https://github.com/FormidableLabs/victory/issues/191