### PR TITLE
clean up scale type checking, use light check for log scales

### DIFF
--- a/src/components/victory-area/helper-methods.js
+++ b/src/components/victory-area/helper-methods.js
@@ -59,34 +59,32 @@ export default {
       x: Domain.getDomainWithZero(props, "x"),
       y: Domain.getDomainWithZero(props, "y")
     };
-    const scale = {
+    return {
       x: Scale.getBaseScale(props, "x").domain(domain.x).range(range.x),
       y: Scale.getBaseScale(props, "y").domain(domain.y).range(range.y)
     };
-
-    return {scale, domain};
   },
 
   getCalculatedValues(props, fallbackProps) {
     const defaultStyles = props.theme && props.theme.area ? props.theme.area
     : fallbackProps.style;
     const style = Helpers.getStyles(props.style, defaultStyles, "auto", "100%");
-    const {scale, domain} = this.getScale(props);
+    const scale = this.getScale(props);
 
-    const data = this.getDataWithBaseline(props, domain);
+    const data = this.getDataWithBaseline(props, scale);
     return { style, data, scale };
   },
 
-  getDataWithBaseline(props, domain) {
+  getDataWithBaseline(props, scale) {
     let data = Data.getData(props);
 
     if (data.length < 2) {
       Log.warn("Area requires at least two data points.");
       data = [];
     }
-
-    const defaultMin = Scale.getScaleType(props, "y") === "log" ? 1 / Number.MAX_SAFE_INTEGER : 0;
-    const minY = Math.min(...domain.y) > 0 ? Math.min(...domain.y) : defaultMin;
+    const defaultMin = Scale.getType(scale.y) === "log" ? 1 / Number.MAX_SAFE_INTEGER : 0;
+    const domainY = scale.y.domain();
+    const minY = Math.min(...domainY) > 0 ? Math.min(...domainY) : defaultMin;
 
     return data.map((datum) => {
       const y1 = datum.yOffset ? datum.yOffset + datum.y : datum.y;

--- a/src/components/victory-area/victory-area.js
+++ b/src/components/victory-area/victory-area.js
@@ -43,7 +43,7 @@ export default class VictoryArea extends React.Component {
       beforeClipPathWidth: (data, child, exitingNodes) => {
         const filterExit = filter(data, (datum) => { return !exitingNodes[datum.x]; });
         const xVals = filterExit.map((datum) => {
-          return child.type.getScale(child.props).scale.x(datum.x);
+          return child.type.getScale(child.props).x(datum.x);
         });
         const clipPath = min(xVals) + max(xVals);
         return clipPath;
@@ -56,7 +56,7 @@ export default class VictoryArea extends React.Component {
       beforeClipPathWidth: (data, child, enteringNodes) => {
         const filterEnter = filter(data, (datum) => { return !enteringNodes[datum.x]; });
         const xVals = filterEnter.map((datum) => {
-          return child.type.getScale(child.props).scale.x(datum.x);
+          return child.type.getScale(child.props).x(datum.x);
         });
         const clipPath = min(xVals) + max(xVals);
         return clipPath;
@@ -64,7 +64,7 @@ export default class VictoryArea extends React.Component {
       },
       afterClipPathWidth: (data, child) => {
         const xVals = data.map((datum) => {
-          return child.type.getScale(child.props).scale.x(datum.x);
+          return child.type.getScale(child.props).x(datum.x);
         });
         const clipPath = min(xVals) + max(xVals);
         return clipPath;

--- a/src/components/victory-bar/helper-methods.js
+++ b/src/components/victory-bar/helper-methods.js
@@ -6,7 +6,10 @@ import Scale from "../../helpers/scale";
 
 export default {
 
-  getScale(props) {
+  getScale(props, fallbackProps) {
+    if (fallbackProps) {
+      props = Helpers.modifyProps(props, fallbackProps);
+    }
     const { horizontal } = props;
     const range = {
       x: Helpers.getRange(props, "x"),
@@ -35,7 +38,7 @@ export default {
 
   getBarPosition(props, datum, scale) {
     const currentAxis = props.horizontal ? "x" : "y";
-    const defaultMin = Scale.getScaleType(props, currentAxis) === "log" ?
+    const defaultMin = Scale.getType(scale[currentAxis]) === "log" ?
       1 / Number.MAX_SAFE_INTEGER : 0;
     const yOffset = datum.yOffset || 0;
     const xOffset = datum.xOffset || 0;

--- a/test/client/spec/components/victory-area/helper-methods.spec.js
+++ b/test/client/spec/components/victory-area/helper-methods.spec.js
@@ -22,34 +22,40 @@ describe("victory-area/helper-methods", () => {
     const stackedData = [
       {x: 1, y: 1, yOffset: 1}, {x: 2, y: 1, yOffset: 1}
     ];
-    const domain = {x: [0, 10], y: [0, 10]};
+    const defaultDomain = {x: [0, 10], y: [0, 10]};
     const nonZeroDomain = {x: [0, 10], y: [1, 10]};
     const negativeDomain = {x: [0, 10], y: [-1, 10]};
+    const scale = (domain) => {
+      return {
+        x: { domain: () => domain.x },
+        y: { domain: () => domain.y }
+      };
+    };
 
     it("should return the minimum if yOffset is not present", () => {
       const props = {data};
-      const result = AreaHelpers.getDataWithBaseline(props, domain);
+      const result = AreaHelpers.getDataWithBaseline(props, scale(defaultDomain));
       const expectedResult = [{y0: 0, y1: 1, x: 1, y: 1}, {y0: 0, y1: 1, x: 2, y: 1}];
       expect(result).to.eql(expectedResult);
     });
 
     it("should return the domain minimum when it is greater than zero", () => {
       const props = {data};
-      const result = AreaHelpers.getDataWithBaseline(props, nonZeroDomain);
+      const result = AreaHelpers.getDataWithBaseline(props, scale(nonZeroDomain));
       const expectedResult = [{y0: 1, y1: 1, x: 1, y: 1}, {y0: 1, y1: 1, x: 2, y: 1}];
       expect(result).to.eql(expectedResult);
     });
 
     it("should return zero when the domain minimum is negative", () => {
       const props = {data};
-      const result = AreaHelpers.getDataWithBaseline(props, negativeDomain);
+      const result = AreaHelpers.getDataWithBaseline(props, scale(negativeDomain));
       const expectedResult = [{y0: 0, y1: 1, x: 1, y: 1}, {y0: 0, y1: 1, x: 2, y: 1}];
       expect(result).to.eql(expectedResult);
     });
 
     it("should return yOffset if present", () => {
       const props = {data: stackedData};
-      const result = AreaHelpers.getDataWithBaseline(props, domain);
+      const result = AreaHelpers.getDataWithBaseline(props, scale(defaultDomain));
       const expectedResult = [
         {y0: 1, y1: 2, x: 1, y: 1, yOffset: 1}, {y0: 1, y1: 2, x: 2, y: 1, yOffset: 1}
       ];

--- a/test/client/spec/helpers/scale.spec.js
+++ b/test/client/spec/helpers/scale.spec.js
@@ -105,7 +105,7 @@ describe("helpers/scale", () => {
     let sandbox;
     beforeEach(() => {
       sandbox = sinon.sandbox.create();
-      sandbox.spy(Scale, "getScaleFromProps");
+      sandbox.spy(Scale, "getScaleTypeFromProps");
       sandbox.spy(Scale, "getScaleTypeFromData");
     });
     afterEach(() => {
@@ -115,15 +115,23 @@ describe("helpers/scale", () => {
     it("returns 'log' for log scales", () => {
       const props = {scale: {x: d3Scale.scaleLog()}};
       const scaleType = Scale.getScaleType(props, "x");
-      expect(Scale.getScaleFromProps).calledWith(props, "x").and.returned(props.scale.x);
+      expect(Scale.getScaleTypeFromProps).calledWith(props, "x").and.returned("log");
       expect(Scale.getScaleTypeFromData).not.called;
       expect(scaleType).to.equal("log");
+    });
+
+    it("returns a string value given a string prop", () => {
+      const props = {scale: {x: "linear"}};
+      const scaleType = Scale.getScaleType(props, "x");
+      expect(Scale.getScaleTypeFromProps).calledWith(props, "x").and.returned(props.scale.x);
+      expect(Scale.getScaleTypeFromData).not.called;
+      expect(scaleType).to.equal("linear");
     });
 
     it("uses data to distinguish between time and linear scales", () => {
       const props = {scale: {x: d3Scale.scaleLinear()}};
       const scaleType = Scale.getScaleType(props, "x");
-      expect(Scale.getScaleFromProps).calledWith(props, "x").and.returned(props.scale.x);
+      expect(Scale.getScaleTypeFromProps).calledWith(props, "x").and.returned(undefined);
       expect(Scale.getScaleTypeFromData).calledWith(props, "x").and.returned("linear");
       expect(scaleType).to.equal("linear");
     });
@@ -131,7 +139,7 @@ describe("helpers/scale", () => {
     it("returns 'linear' when no scale is set", () => {
       const props = {};
       const scaleType = Scale.getScaleType(props, "x");
-      expect(Scale.getScaleFromProps).calledWith(props, "x").and.returned(undefined);
+      expect(Scale.getScaleTypeFromProps).calledWith(props, "x").and.returned(undefined);
       expect(Scale.getScaleTypeFromData).calledWith(props, "x").and.returned("linear");
       expect(scaleType).to.equal("linear");
     });
@@ -139,7 +147,7 @@ describe("helpers/scale", () => {
     it("returns 'time' when no scale is set, and data contains dates", () => {
       const props = {x: "x", y: "y", data: [{x: new Date("2016-01-13"), y: 1}]};
       const scaleType = Scale.getScaleType(props, "x");
-      expect(Scale.getScaleFromProps).calledWith(props, "x").and.returned(undefined);
+      expect(Scale.getScaleTypeFromProps).calledWith(props, "x").and.returned(undefined);
       expect(Scale.getScaleTypeFromData).calledWith(props, "x").and.returned("time");
       expect(scaleType).to.equal("time");
     });


### PR DESCRIPTION
cc/ @kenwheeler 

This PR 
- fixes #341 
- tidies up scale calculation in victory-area. 
- Log scale checking for bar and area position calculations now use the a less expensive method for determining the scale type.
- Adds test case from https://github.com/FormidableLabs/victory-chart/compare/scale-value-perf-fix?expand=1
- Cleans up tests to reflect code changes