### PR TITLE
Simplify themes and fallback props

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "d3-scale": "^1.0.0",
     "d3-shape": "^1.0.0",
     "lodash": "^4.12.0",
-    "victory-core": "^4.5.0"
+    "victory-core": "^5.0.0"
   },
   "devDependencies": {
     "builder-victory-component-dev": "^2.3.0",

--- a/src/components/helpers/clip-path.js
+++ b/src/components/helpers/clip-path.js
@@ -45,12 +45,7 @@ export default class ClipPath extends React.Component {
         left: PropTypes.number,
         right: PropTypes.number
       })
-    ]),
-    /**
-     * The barWidth props specifies the barWidth of the bars this should be given when the
-     * component is using in bar type charts
-     */
-    barWidth: PropTypes.number
+    ])
   };
 
   static defaultProps = {
@@ -72,16 +67,15 @@ export default class ClipPath extends React.Component {
     } = this.props;
 
     const padding = Helpers.getPadding(this.props);
-    const modifiedBarWidth = barWidth || 0;
 
-    const totalPadding = (side) => padding[side] - clipPadding[side];
+    const totalPadding = (side) => padding[side] - (clipPadding[side] || 0);
 
     return (
       <defs>
         <clipPath id={clipId}>
           <rect
-            x={totalPadding("left") - modifiedBarWidth}
-            y={totalPadding("top") - modifiedBarWidth}
+            x={totalPadding("left")}
+            y={totalPadding("top")}
             width={clipWidth - totalPadding("left") - totalPadding("right")}
             height={clipHeight - totalPadding("top") - totalPadding("bottom")}
           />

--- a/src/components/helpers/clip-path.js
+++ b/src/components/helpers/clip-path.js
@@ -62,7 +62,6 @@ export default class ClipPath extends React.Component {
       clipId,
       clipWidth,
       clipHeight,
-      barWidth,
       clipPadding
     } = this.props;
 

--- a/src/components/victory-area/area.js
+++ b/src/components/victory-area/area.js
@@ -76,7 +76,8 @@ export default class Area extends React.Component {
   }
 
   render() {
-    const { style, events, groupComponent } = this.props;
+    const { events, groupComponent } = this.props;
+    const style = assign({fill: "black"}, this.props.style);
     const area = this.renderArea(this.getAreaPath(this.props), style, events);
     const line = this.renderLine(this.getLinePath(this.props), style, events);
     return React.cloneElement(groupComponent, {}, area, line);

--- a/src/components/victory-area/helper-methods.js
+++ b/src/components/victory-area/helper-methods.js
@@ -23,10 +23,11 @@ export default {
     const text = Helpers.evaluateProp(label, data);
     const lastData = last(data);
     const labelStyle = Helpers.evaluateStyle(style.labels, data);
+    const labelPadding = labelStyle.padding || 0;
 
     const labelProps = {
       key: "area-label",
-      x: lastData ? scale.x(lastData.x) + labelStyle.padding : 0,
+      x: lastData ? scale.x(lastData.x) + labelPadding : 0,
       y: lastData ? scale.y(lastData.y1) : 0,
       y0: lastData ? scale.y(lastData.y0) : 0,
       style: labelStyle,

--- a/src/components/victory-area/helper-methods.js
+++ b/src/components/victory-area/helper-methods.js
@@ -7,9 +7,9 @@ import Scale from "../../helpers/scale";
 export default {
 
   getBaseProps(props, fallbackProps) {
-    const modifiedProps = Helpers.modifyProps(props, fallbackProps);
-    const {scale, style, data} = this.getCalculatedValues(modifiedProps, fallbackProps);
-    const {interpolation, label, width, height, groupComponent} = modifiedProps;
+    props = Helpers.modifyProps(props, fallbackProps, "area");
+    const {scale, style, data} = this.getCalculatedValues(props, fallbackProps);
+    const {interpolation, label, width, height, groupComponent} = props;
 
     const dataProps = {
       groupComponent,
@@ -49,9 +49,7 @@ export default {
   },
 
   getScale(props, fallbackProps) {
-    if (fallbackProps) {
-      props = Helpers.modifyProps(props, fallbackProps);
-    }
+    props = Helpers.modifyProps(props, fallbackProps, "area");
     const range = {
       x: Helpers.getRange(props, "x"),
       y: Helpers.getRange(props, "y")
@@ -66,9 +64,9 @@ export default {
     };
   },
 
-  getCalculatedValues(props, fallbackProps) {
-    const defaultStyles = props.theme && props.theme.area ? props.theme.area
-    : fallbackProps.style;
+  getCalculatedValues(props) {
+    const { theme } = props;
+    const defaultStyles = theme && theme.area && theme.area.style ? theme.area.style : {};
     const style = Helpers.getStyles(props.style, defaultStyles, "auto", "100%");
     const scale = this.getScale(props);
 

--- a/src/components/victory-area/helper-methods.js
+++ b/src/components/victory-area/helper-methods.js
@@ -22,7 +22,7 @@ export default {
 
     const text = Helpers.evaluateProp(label, data);
     const lastData = last(data);
-    const labelStyle = Helpers.evaluateStyle(style.labels, data);
+    const labelStyle = Helpers.evaluateStyle(style.labels, data) || {};
     const labelPadding = labelStyle.padding || 0;
 
     const labelProps = {

--- a/src/components/victory-area/victory-area.js
+++ b/src/components/victory-area/victory-area.js
@@ -11,24 +11,8 @@ import {
 } from "victory-core";
 
 const fallbackProps = {
-  props: {
-    width: 450,
-    height: 300,
-    clipHeight: 300,
-    clipWidth: 450
-  },
-  style: {
-    data: {
-      fill: "#252525"
-    },
-    labels: {
-      fill: "#252525",
-      fontFamily: "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
-      fontSize: 14,
-      letterSpacing: "0.04em",
-      padding: 10
-    }
-  }
+  width: 450,
+  height: 300,
 };
 
 export default class VictoryArea extends React.Component {
@@ -477,18 +461,15 @@ export default class VictoryArea extends React.Component {
     );
   }
 
-  renderGroup(children, modifiedProps, style) {
-    const { clipPathComponent } = modifiedProps;
+  renderGroup(children, props, style) {
+    const { clipPathComponent } = props;
 
-    const clipComponent = React.cloneElement(clipPathComponent, assign(
-      {},
-      {
-        padding: modifiedProps.padding,
-        clipId: modifiedProps.clipId,
-        clipWidth: modifiedProps.clipWidth || modifiedProps.width,
-        clipHeight: modifiedProps.clipHeight || modifiedProps.height
-      }
-    ));
+    const clipComponent = React.cloneElement(clipPathComponent, {
+      padding: props.padding,
+      clipId: props.clipId,
+      clipWidth: props.clipWidth || props.width,
+      clipHeight: props.clipHeight || props.height
+    });
 
     return React.cloneElement(
       this.props.groupComponent,
@@ -500,8 +481,8 @@ export default class VictoryArea extends React.Component {
 
   render() {
     const clipId = this.props.clipId || Math.round(Math.random() * 10000);
-    const modifiedProps = Helpers.modifyProps(assign({}, this.props, {clipId}), fallbackProps);
-    const { animate, style, standalone } = modifiedProps;
+    const props = Helpers.modifyProps(assign({clipId}, this.props), fallbackProps, "area");
+    const { animate, style, standalone } = props;
 
     if (animate) {
       const whitelist = [
@@ -509,20 +490,20 @@ export default class VictoryArea extends React.Component {
       ];
       return (
         <VictoryTransition animate={animate} animationWhitelist={whitelist}>
-          {React.createElement(this.constructor, modifiedProps)}
+          {React.createElement(this.constructor, props)}
         </VictoryTransition>
       );
     }
 
-    const styleObject = modifiedProps.theme && modifiedProps.theme.area ? modifiedProps.theme.area
-    : fallbackProps.style;
+    const styleObject = props.theme && props.theme.area ?
+      props.theme.area.style : {};
 
     const baseStyles = Helpers.getStyles(style, styleObject, "auto", "100%");
 
     const group = this.renderGroup(
-      this.renderData(modifiedProps), modifiedProps, baseStyles.parent
+      this.renderData(props), props, baseStyles.parent
     );
 
-    return standalone ? this.renderContainer(modifiedProps, group) : group;
+    return standalone ? this.renderContainer(props, group) : group;
   }
 }

--- a/src/components/victory-area/victory-area.js
+++ b/src/components/victory-area/victory-area.js
@@ -483,7 +483,7 @@ export default class VictoryArea extends React.Component {
   render() {
     const clipId = this.props.clipId || Math.round(Math.random() * 10000);
     const props = Helpers.modifyProps(assign({clipId}, this.props), fallbackProps, "area");
-    const { animate, style, standalone } = props;
+    const { animate, style, standalone, theme } = props;
 
     if (animate) {
       const whitelist = [
@@ -496,8 +496,7 @@ export default class VictoryArea extends React.Component {
       );
     }
 
-    const styleObject = props.theme && props.theme.area ?
-      props.theme.area.style : {};
+    const styleObject = theme && theme.area ? theme.area.style : {};
 
     const baseStyles = Helpers.getStyles(style, styleObject, "auto", "100%");
 

--- a/src/components/victory-area/victory-area.js
+++ b/src/components/victory-area/victory-area.js
@@ -7,12 +7,14 @@ import Domain from "../../helpers/domain";
 import ClipPath from "../helpers/clip-path";
 import {
   PropTypes as CustomPropTypes, Helpers, Events, VictoryTransition, VictoryLabel,
-  VictoryContainer
+  VictoryContainer, VictoryTheme
 } from "victory-core";
 
 const fallbackProps = {
   width: 450,
   height: 300,
+  padding: 50,
+  interpolation: "linear"
 };
 
 export default class VictoryArea extends React.Component {
@@ -370,16 +372,15 @@ export default class VictoryArea extends React.Component {
   static defaultProps = {
     dataComponent: <Area/>,
     labelComponent: <VictoryLabel/>,
-    padding: 50,
     scale: "linear",
     samples: 50,
     standalone: true,
-    interpolation: "linear",
     x: "x",
     y: "y",
     containerComponent: <VictoryContainer />,
     groupComponent: <g/>,
-    clipPathComponent: <ClipPath/>
+    clipPathComponent: <ClipPath/>,
+    theme: VictoryTheme.grayscale
   };
 
   static getDomain = Domain.getDomainWithZero.bind(Domain);

--- a/src/components/victory-axis/axis-line.js
+++ b/src/components/victory-axis/axis-line.js
@@ -1,4 +1,5 @@
 import React, { PropTypes } from "react";
+import { assign } from "lodash";
 
 export default class AxisLine extends React.Component {
   static propTypes = {
@@ -17,7 +18,8 @@ export default class AxisLine extends React.Component {
   }
 
   render() {
-    const { x1, x2, y1, y2, style, events} = this.props;
+    const { x1, x2, y1, y2, events} = this.props;
+    const style = assign({stroke: "black"}, this.props.style);
     return this.renderAxisLine({x1, x2, y1, y2}, style, events);
   }
 }

--- a/src/components/victory-axis/helper-methods.js
+++ b/src/components/victory-axis/helper-methods.js
@@ -134,8 +134,8 @@ export default {
   },
 
   getBaseProps(props, fallbackProps) {
-    const modifiedProps = Helpers.modifyProps(props, fallbackProps);
-    const calculatedValues = this.getCalculatedValues(modifiedProps, fallbackProps);
+    props = Helpers.modifyProps(props, fallbackProps, "axis");
+    const calculatedValues = this.getCalculatedValues(props);
     const {
       style, orientation, isVertical, scale, ticks, tickFormat,
       stringTicks, anchors
@@ -143,16 +143,16 @@ export default {
 
     const {
       globalTransform, gridOffset, gridEdge
-    } = this.getLayoutProps(modifiedProps, calculatedValues);
+    } = this.getLayoutProps(props, calculatedValues);
 
-    const axisProps = this.getAxisProps(modifiedProps, calculatedValues, globalTransform);
-    const axisLabelProps = this.getAxisLabelProps(modifiedProps, calculatedValues, globalTransform);
+    const axisProps = this.getAxisProps(props, calculatedValues, globalTransform);
+    const axisLabelProps = this.getAxisLabelProps(props, calculatedValues, globalTransform);
 
     const childProps = { parent: {
-      style: style.parent, ticks, scale, width: modifiedProps.width, height: modifiedProps.height
+      style: style.parent, ticks, scale, width: props.width, height: props.height
     }};
     for (let index = 0, len = ticks.length; index < len; index++) {
-      const tick = stringTicks ? modifiedProps.tickValues[(ticks[index]) - 1] : ticks[index];
+      const tick = stringTicks ? props.tickValues[(ticks[index]) - 1] : ticks[index];
 
       const styles = this.getEvaluatedStyles(style, tick, index);
       const tickLayout = {
@@ -183,9 +183,9 @@ export default {
     return childProps;
   },
 
-  getCalculatedValues(props, fallbackProps) {
-    const defaultStyles = props.theme && props.theme.axis && props.theme.axis.style ?
-      props.theme.axis.style : fallbackProps.style;
+  getCalculatedValues(props) {
+    const { theme } = props;
+    const defaultStyles = theme && theme.axis && theme.axis.style ? theme.axis.style : {};
     const style = this.getStyles(props, defaultStyles);
     const padding = Helpers.getPadding(props);
     const orientation = props.orientation || (props.dependentAxis ? "left" : "bottom");

--- a/src/components/victory-axis/helper-methods.js
+++ b/src/components/victory-axis/helper-methods.js
@@ -54,6 +54,7 @@ export default {
 
   getStyles(props, styleObject) {
     const style = props.style || {};
+    styleObject = styleObject || {};
     const parentStyleProps = { height: "auto", width: "100%" };
     return {
       parent: defaults(parentStyleProps, style.parent, styleObject.parent),
@@ -183,7 +184,8 @@ export default {
   },
 
   getCalculatedValues(props, fallbackProps) {
-    const defaultStyles = props.theme && props.theme.axis ? props.theme.axis : fallbackProps.style;
+    const defaultStyles = props.theme && props.theme.axis && props.theme.axis.style ?
+      props.theme.axis.style : fallbackProps.style;
     const style = this.getStyles(props, defaultStyles);
     const padding = Helpers.getPadding(props);
     const orientation = props.orientation || (props.dependentAxis ? "left" : "bottom");
@@ -271,7 +273,8 @@ export default {
     }
     const isVertical = Axis.isVertical(props);
     // TODO: magic numbers
-    return props.label ? (labelStyle.fontSize * (isVertical ? 2.3 : 1.6)) : 0;
+    const fontSize = labelStyle.fontSize || 14;
+    return props.label ? (fontSize * (isVertical ? 2.3 : 1.6)) : 0;
   },
 
   getOffset(props, calculatedValues) {
@@ -280,7 +283,7 @@ export default {
     } = calculatedValues;
     const xPadding = orientation === "right" ? padding.right : padding.left;
     const yPadding = orientation === "top" ? padding.top : padding.bottom;
-    const fontSize = style.axisLabel.fontSize;
+    const fontSize = style.axisLabel.fontSize || 14;
     const offsetX = (props.offsetX !== null) && (props.offsetX !== undefined)
       ? props.offsetX : xPadding;
     const offsetY = (props.offsetY !== null) && (props.offsetY !== undefined)
@@ -288,7 +291,7 @@ export default {
     const tickSizes = ticks.map((data) => {
       const tick = stringTicks ? props.tickValues[data - 1] : data;
       const tickStyle = Helpers.evaluateStyle(style.ticks, tick);
-      return tickStyle.size;
+      return tickStyle.size || 0;
     });
     const totalPadding = fontSize + (2 * Math.max(...tickSizes)) + labelPadding;
     const minimumPadding = 1.2 * fontSize; // TODO: magic numbers
@@ -311,13 +314,15 @@ export default {
   },
 
   getTickPosition(style, orientation, isVertical) {
-    const tickSpacing = style.size + style.padding;
+    const size = style.size || 0;
+    const padding = style.padding || 0;
+    const tickSpacing = size + padding;
     const sign = orientationSign[orientation];
     return {
       x: isVertical ? sign * tickSpacing : 0,
-      x2: isVertical ? sign * style.size : 0,
+      x2: isVertical ? sign * size : 0,
       y: isVertical ? 0 : sign * tickSpacing,
-      y2: isVertical ? 0 : sign * style.size
+      y2: isVertical ? 0 : sign * size
     };
   },
 

--- a/src/components/victory-axis/victory-axis.js
+++ b/src/components/victory-axis/victory-axis.js
@@ -2,7 +2,7 @@ import { assign, defaults, isFunction, partialRight } from "lodash";
 import React, { PropTypes } from "react";
 import {
   PropTypes as CustomPropTypes, Helpers, Events, VictoryTransition, VictoryLabel,
-  VictoryContainer
+  VictoryContainer, VictoryTheme
 } from "victory-core";
 import AxisLine from "./axis-line";
 import AxisHelpers from "./helper-methods";
@@ -10,7 +10,8 @@ import Axis from "../../helpers/axis";
 
 const fallbackProps = {
   width: 450,
-  height: 300
+  height: 300,
+  padding: 50
 };
 
 export default class VictoryAxis extends React.Component {
@@ -330,9 +331,9 @@ export default class VictoryAxis extends React.Component {
     tickLabelComponent: <VictoryLabel/>,
     tickComponent: <AxisLine type={"tick"}/>,
     gridComponent: <AxisLine type={"grid"}/>,
-    padding: 50,
     scale: "linear",
     standalone: true,
+    theme: VictoryTheme.grayscale,
     tickCount: 5,
     containerComponent: <VictoryContainer />,
     groupComponent: <g/>
@@ -473,8 +474,8 @@ export default class VictoryAxis extends React.Component {
   }
 
   render() {
-    const modifiedProps = Helpers.modifyProps(this.props, fallbackProps, "axis");
-    const { animate, standalone } = modifiedProps;
+    const props = Helpers.modifyProps(this.props, fallbackProps, "axis");
+    const { animate, standalone, theme } = props;
     if (animate) {
       // Do less work by having `VictoryAnimation` tween only values that
       // make sense to tween. In the future, allow customization of animated
@@ -485,22 +486,21 @@ export default class VictoryAxis extends React.Component {
       ];
       return (
         <VictoryTransition animate={animate} animationWhitelist={whitelist}>
-          {React.createElement(this.constructor, modifiedProps)}
+          {React.createElement(this.constructor, props)}
         </VictoryTransition>
       );
     }
 
-    const styleObject = modifiedProps.theme && modifiedProps.theme.axis ? modifiedProps.theme.axis
-    : fallbackProps.style;
-    const style = AxisHelpers.getStyles(modifiedProps, styleObject);
+    const styleObject = theme && theme.axis && theme.axis.style ? theme.axis.style : {};
+    const style = AxisHelpers.getStyles(props, styleObject);
     const children = [
-      ...this.renderGridAndTicks(modifiedProps),
-      this.renderLine(modifiedProps),
-      this.renderLabel(modifiedProps)
+      ...this.renderGridAndTicks(props),
+      this.renderLine(props),
+      this.renderLabel(props)
     ];
 
     const group = this.renderGroup(children, style.parent);
 
-    return standalone ? this.renderContainer(modifiedProps, group) : group;
+    return standalone ? this.renderContainer(props, group) : group;
   }
 }

--- a/src/components/victory-axis/victory-axis.js
+++ b/src/components/victory-axis/victory-axis.js
@@ -9,47 +9,8 @@ import AxisHelpers from "./helper-methods";
 import Axis from "../../helpers/axis";
 
 const fallbackProps = {
-  props: {
-    width: 450,
-    height: 300
-  },
-  style: {
-    axis: {
-      fill: "none",
-      stroke: "#252525",
-      strokeWidth: 1,
-      strokeLinecap: "round"
-    },
-    axisLabel: {
-      fill: "#252525",
-      fontFamily: "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
-      fontSize: 14,
-      letterSpacing: "0.04em",
-      padding: 25,
-      stroke: "transparent"
-    },
-    grid: {
-      fill: "none",
-      stroke: "transparent",
-      strokeLinecap: "round"
-    },
-    ticks: {
-      fill: "none",
-      padding: 10,
-      size: 1,
-      stroke: "none",
-      strokeWidth: 1,
-      strokeLinecap: "round"
-    },
-    tickLabels: {
-      fill: "#252525",
-      fontFamily: "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
-      fontSize: 14,
-      letterSpacing: "0.04em",
-      padding: 10,
-      stroke: "transparent"
-    }
-  }
+  width: 450,
+  height: 300
 };
 
 export default class VictoryAxis extends React.Component {
@@ -512,7 +473,7 @@ export default class VictoryAxis extends React.Component {
   }
 
   render() {
-    const modifiedProps = Helpers.modifyProps(this.props, fallbackProps);
+    const modifiedProps = Helpers.modifyProps(this.props, fallbackProps, "axis");
     const { animate, standalone } = modifiedProps;
     if (animate) {
       // Do less work by having `VictoryAnimation` tween only values that

--- a/src/components/victory-bar/bar.js
+++ b/src/components/victory-bar/bar.js
@@ -1,4 +1,5 @@
 import React, { PropTypes } from "react";
+import { assign } from "lodash";
 import BarHelpers from "./helper-methods";
 
 export default class Bar extends React.Component {
@@ -64,10 +65,10 @@ export default class Bar extends React.Component {
 
   render() {
     // TODO better bar width calculation
-    const { events, style} = this.props;
     const barWidth = BarHelpers.getBarWidth(this.props);
     const path = typeof this.props.x === "number" ?
       this.getBarPath(this.props, barWidth) : undefined;
-    return this.renderBar(path, style, events);
+    const style = assign({fill: "black", stroke: "none"}, this.props.style);
+    return this.renderBar(path, style, this.props.events);
   }
 }

--- a/src/components/victory-bar/helper-methods.js
+++ b/src/components/victory-bar/helper-methods.js
@@ -54,7 +54,7 @@ export default {
 
   getBarStyle(datum, baseStyle) {
     const styleData = omit(datum, [
-      "xName", "yName", "x", "y", "label"
+      "xName", "yName", "x", "y", "label", "errorX", "errorY", "eventKey"
     ]);
     return Helpers.evaluateStyle(defaults({}, styleData, baseStyle), datum);
   },

--- a/src/components/victory-bar/helper-methods.js
+++ b/src/components/victory-bar/helper-methods.js
@@ -99,8 +99,8 @@ export default {
   },
 
   getCalculatedValues(props, fallbackProps) {
-    const defaultStyles = props.theme && props.theme.scatter ? props.theme.scatter
-    : fallbackProps.style;
+    const defaultStyles = props.theme && props.theme.bar && props.theme.bar.style ?
+      props.theme.bar.style : fallbackProps.style;
     const style = Helpers.getStyles(props.style, defaultStyles, "auto", "100%");
     const data = Events.addEventKeys(props, Data.getData(props));
     const scale = this.getScale(props);

--- a/src/components/victory-bar/helper-methods.js
+++ b/src/components/victory-bar/helper-methods.js
@@ -7,9 +7,7 @@ import Scale from "../../helpers/scale";
 export default {
 
   getScale(props, fallbackProps) {
-    if (fallbackProps) {
-      props = Helpers.modifyProps(props, fallbackProps);
-    }
+    props = Helpers.modifyProps(props, fallbackProps, "bar");
     const { horizontal } = props;
     const range = {
       x: Helpers.getRange(props, "x"),
@@ -98,9 +96,9 @@ export default {
     };
   },
 
-  getCalculatedValues(props, fallbackProps) {
-    const defaultStyles = props.theme && props.theme.bar && props.theme.bar.style ?
-      props.theme.bar.style : fallbackProps.style;
+  getCalculatedValues(props) {
+    const { theme } = props;
+    const defaultStyles = theme && theme.bar && theme.bar.style ? theme.bar.style : {};
     const style = Helpers.getStyles(props.style, defaultStyles, "auto", "100%");
     const data = Events.addEventKeys(props, Data.getData(props));
     const scale = this.getScale(props);
@@ -108,14 +106,14 @@ export default {
   },
 
   getBaseProps(props, fallbackProps) {
-    const modifiedProps = Helpers.modifyProps(props, fallbackProps);
-    const {style, data, scale } = this.getCalculatedValues(modifiedProps, fallbackProps);
-    const { horizontal, width, height, padding } = modifiedProps;
+    props = Helpers.modifyProps(props, fallbackProps, "bar");
+    const {style, data, scale } = this.getCalculatedValues(props);
+    const { horizontal, width, height, padding } = props;
     const childProps = {parent: { scale, width, height, data, style: style.parent }};
     for (let index = 0, len = data.length; index < len; index++) {
       const datum = data[index];
       const eventKey = datum.eventKey || index;
-      const position = this.getBarPosition(modifiedProps, datum, scale);
+      const position = this.getBarPosition(props, datum, scale);
       const dataProps = assign(
         {
           style: this.getBarStyle(datum, style.data),
@@ -138,7 +136,7 @@ export default {
         x: horizontal ? position.y + labelPadding.x : position.x + labelPadding.x,
         y: horizontal ? position.x + labelPadding.y : position.y - labelPadding.y,
         y0: position.y0,
-        text: this.getLabel(modifiedProps, datum, index),
+        text: this.getLabel(props, datum, index),
         index,
         scale,
         datum: dataProps.datum,

--- a/src/components/victory-bar/victory-bar.js
+++ b/src/components/victory-bar/victory-bar.js
@@ -7,12 +7,13 @@ import Domain from "../../helpers/domain";
 import ClipPath from "../helpers/clip-path";
 import {
   PropTypes as CustomPropTypes, Helpers, Events, VictoryTransition, VictoryLabel,
-  VictoryContainer
+  VictoryContainer, VictoryTheme
 } from "victory-core";
 
 const fallbackProps = {
   width: 450,
-  height: 300
+  height: 300,
+  padding: 50
 };
 
 const defaultData = [
@@ -349,14 +350,14 @@ export default class VictoryBar extends React.Component {
     data: defaultData,
     dataComponent: <Bar/>,
     labelComponent: <VictoryLabel/>,
-    padding: 50,
     scale: "linear",
     standalone: true,
     x: "x",
     y: "y",
     containerComponent: <VictoryContainer/>,
     groupComponent: <g/>,
-    clipPathComponent: <ClipPath/>
+    clipPathComponent: <ClipPath/>,
+    theme: VictoryTheme.grayscale
   };
 
   static getDomain = Domain.getDomainWithZero.bind(Domain);
@@ -464,8 +465,8 @@ export default class VictoryBar extends React.Component {
 
   render() {
     const clipId = this.props.clipId || Math.round(Math.random() * 10000);
-    const props = Helpers.modifyProps(assign({}, this.props, {clipId}), fallbackProps);
-    const { animate, style, standalone } = modifiedProps;
+    const props = Helpers.modifyProps(assign({clipId}, this.props), fallbackProps, "bar");
+    const { animate, style, standalone, theme } = props;
 
     if (animate) {
       const whitelist = [
@@ -473,19 +474,18 @@ export default class VictoryBar extends React.Component {
       ];
       return (
         <VictoryTransition animate={animate} animationWhitelist={whitelist}>
-          {React.createElement(this.constructor, modifiedProps)}
+          {React.createElement(this.constructor, props)}
         </VictoryTransition>
       );
     }
 
-    const styleObject = modifiedProps.theme && modifiedProps.theme.bar ? modifiedProps.theme.bar
-    : fallbackProps.style;
+    const styleObject = theme && theme.bar && theme.bar.style ? theme.bar.style : {};
 
     const baseStyles = Helpers.getStyles(style, styleObject, "auto", "100%");
     const group = this.renderGroup(
-      this.renderData(modifiedProps), modifiedProps, baseStyles
+      this.renderData(props), props, baseStyles
     );
 
-    return standalone ? this.renderContainer(modifiedProps, group) : group;
+    return standalone ? this.renderContainer(props, group) : group;
   }
 }

--- a/src/components/victory-bar/victory-bar.js
+++ b/src/components/victory-bar/victory-bar.js
@@ -470,7 +470,6 @@ export default class VictoryBar extends React.Component {
     const clipId = this.props.clipId || Math.round(Math.random() * 10000);
     const props = Helpers.modifyProps(assign({clipId}, this.props), fallbackProps, "bar");
     const { animate, style, standalone, theme } = props;
-
     if (animate) {
       const whitelist = [
         "data", "domain", "height", "padding", "style", "width", "clipWidth", "clipHeight"

--- a/src/components/victory-bar/victory-bar.js
+++ b/src/components/victory-bar/victory-bar.js
@@ -447,13 +447,16 @@ export default class VictoryBar extends React.Component {
   }
 
   renderGroup(children, props, style) {
-    const { clipPathComponent } = props;
+    const { clipPathComponent, horizontal } = props;
     const barWidth = BarHelpers.getBarWidth(props);
+    const clipPadding = horizontal ?
+      {"top": barWidth, bottom: barWidth} : {left: barWidth, right: barWidth};
     const clipComponent = React.cloneElement(clipPathComponent, {
       padding: props.padding,
       clipId: props.clipId,
-      clipWidth: (props.clipWidth || props.width) + barWidth * 2,
-      clipHeight: (props.clipHeight || props.height) + barWidth * 2
+      clipWidth: (props.clipWidth || props.width),
+      clipHeight: (props.clipHeight || props.height),
+      clipPadding
     });
     return React.cloneElement(
       props.groupComponent,

--- a/src/components/victory-bar/victory-bar.js
+++ b/src/components/victory-bar/victory-bar.js
@@ -11,29 +11,8 @@ import {
 } from "victory-core";
 
 const fallbackProps = {
-  props: {
-    height: 300,
-    width: 450,
-    clipHeight: 300,
-    clipWidth: 450
-  },
-  style: {
-    data: {
-      fill: "#242424",
-      opacity: 1,
-      padding: 10,
-      stroke: "transparent",
-      strokeWidth: 0,
-      width: 8
-    },
-    labels: {
-      fill: "#252525",
-      fontFamily: "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
-      fontSize: 14,
-      letterSpacing: "0.04em",
-      padding: 10
-    }
-  }
+  width: 450,
+  height: 300
 };
 
 const defaultData = [
@@ -466,22 +445,17 @@ export default class VictoryBar extends React.Component {
     );
   }
 
-  renderGroup(children, modifiedProps, style) {
-    const { clipPathComponent } = modifiedProps;
-    const barWidth = BarHelpers.getBarWidth(modifiedProps);
-    const clipComponent = React.cloneElement(clipPathComponent, assign(
-      {},
-      {
-        padding: modifiedProps.padding,
-        clipId: modifiedProps.clipId,
-        barWidth,
-        clipWidth: (modifiedProps.clipWidth || modifiedProps.width) + barWidth * 2,
-        clipHeight: (modifiedProps.clipHeight || modifiedProps.height) + barWidth * 2
-      }
-    ));
-
+  renderGroup(children, props, style) {
+    const { clipPathComponent } = props;
+    const barWidth = BarHelpers.getBarWidth(props);
+    const clipComponent = React.cloneElement(clipPathComponent, {
+      padding: props.padding,
+      clipId: props.clipId,
+      clipWidth: (props.clipWidth || props.width) + barWidth * 2,
+      clipHeight: (props.clipHeight || props.height) + barWidth * 2
+    });
     return React.cloneElement(
-      this.props.groupComponent,
+      props.groupComponent,
       { role: "presentation", style: style.parent},
       children,
       clipComponent
@@ -490,7 +464,7 @@ export default class VictoryBar extends React.Component {
 
   render() {
     const clipId = this.props.clipId || Math.round(Math.random() * 10000);
-    const modifiedProps = Helpers.modifyProps(assign({}, this.props, {clipId}), fallbackProps);
+    const props = Helpers.modifyProps(assign({}, this.props, {clipId}), fallbackProps);
     const { animate, style, standalone } = modifiedProps;
 
     if (animate) {

--- a/src/components/victory-candlestick/candle.js
+++ b/src/components/victory-candlestick/candle.js
@@ -33,7 +33,8 @@ export default class Candle extends React.Component {
   }
 
   getCandleProps(props) {
-    const { width, candleHeight, x, y, data, style, events, role} = props;
+    const { width, candleHeight, x, y, data, events, role} = props;
+    const style = assign({stroke: "black"}, props.style);
     const padding = props.padding.left || props.padding;
     const candleWidth = style.width || 0.5 * (width - 2 * padding) / data.length;
     const candleX = x - candleWidth / 2;
@@ -41,7 +42,8 @@ export default class Candle extends React.Component {
   }
 
   getWickProps(props) {
-    const {x, y1, y2, style, events, role} = props;
+    const {x, y1, y2, events, role} = props;
+    const style = assign({stroke: "black"}, props.style);
     return assign({x1: x, x2: x, y1, y2, style, role}, events);
   }
 

--- a/src/components/victory-candlestick/helper-methods.js
+++ b/src/components/victory-candlestick/helper-methods.js
@@ -5,12 +5,10 @@ import Domain from "../../helpers/domain";
 
 export default {
   getBaseProps(props, fallbackProps) { // eslint-disable-line max-statements
-    const modifiedProps = props.theme && props.theme.candlestick ?
-    Helpers.modifyProps(props, fallbackProps, props.theme.candlestick.props) :
-    Helpers.modifyProps(props, fallbackProps);
-    const calculatedValues = this.getCalculatedValues(modifiedProps, fallbackProps);
+    props = Helpers.modifyProps(props, fallbackProps, "candlestick");
+    const calculatedValues = this.getCalculatedValues(props);
     const { data, style, scale } = calculatedValues;
-    const { groupComponent, width, height, padding } = modifiedProps;
+    const { groupComponent, width, height, padding } = props;
     const childProps = {parent: {scale, width, height, data, style: style.parent}};
     for (let index = 0, len = data.length; index < len; index++) {
       const datum = data[index];
@@ -20,13 +18,13 @@ export default {
       const y2 = scale.y(datum.low);
       const candleHeight = Math.abs(scale.y(datum.open) - scale.y(datum.close));
       const y = scale.y(Math.max(datum.open, datum.close));
-      const dataStyle = this.getDataStyles(datum, style.data, modifiedProps);
+      const dataStyle = this.getDataStyles(datum, style.data, props);
       const dataProps = {
         x, y, y1, y2, candleHeight, scale, data, datum, groupComponent,
         index, style: dataStyle, padding, width
       };
 
-      const text = this.getLabelText(modifiedProps, datum, index);
+      const text = this.getLabelText(props, datum, index);
       const labelStyle = this.getLabelStyle(style.labels, dataProps);
       const labelProps = {
         style: labelStyle,
@@ -48,8 +46,11 @@ export default {
     return childProps;
   },
 
-  getCalculatedValues(props, fallbackProps) {
-    const style = Helpers.getStyles(props.style, fallbackProps.style, "auto", "100%");
+  getCalculatedValues(props) {
+    const { theme } = props;
+    const defaultStyle = theme && theme.candlestick && theme.candlestick.style ?
+      theme.candlestick.style : {};
+    const style = Helpers.getStyles(props.style, defaultStyle, "auto", "100%");
     const data = Events.addEventKeys(props, this.getData(props));
     const range = {
       x: Helpers.getRange(props, "x"),

--- a/src/components/victory-candlestick/helper-methods.js
+++ b/src/components/victory-candlestick/helper-methods.js
@@ -129,7 +129,7 @@ export default {
   },
 
   getDataStyles(datum, style, props) {
-    style = style || {}
+    style = style || {};
     const stylesFromData = omit(datum, [
       "x", "y", "size", "name", "label", "open", "close", "high", "low"
     ]);

--- a/src/components/victory-candlestick/helper-methods.js
+++ b/src/components/victory-candlestick/helper-methods.js
@@ -129,6 +129,7 @@ export default {
   },
 
   getDataStyles(datum, style, props) {
+    style = style || {}
     const stylesFromData = omit(datum, [
       "x", "y", "size", "name", "label", "open", "close", "high", "low"
     ]);
@@ -136,7 +137,7 @@ export default {
       props.candleColors.negative : props.candleColors.positive;
     const fill = datum.fill || style.fill || candleColor;
     const strokeColor = datum.stroke || style.stroke;
-    const stroke = this.isTransparent(strokeColor) ? fill : strokeColor;
+    const stroke = this.isTransparent(strokeColor) ? fill : strokeColor || "black";
     const baseDataStyle = defaults({}, stylesFromData, {stroke, fill}, style);
     return Helpers.evaluateStyle(baseDataStyle, datum);
   },
@@ -148,6 +149,7 @@ export default {
   },
 
   getLabelStyle(labelStyle, dataProps) {
+    labelStyle = labelStyle || {};
     const { datum, size, style } = dataProps;
     const matchedStyle = pick(style, ["opacity", "fill"]);
     const padding = labelStyle.padding || size * 0.25;

--- a/src/components/victory-candlestick/victory-candlestick.js
+++ b/src/components/victory-candlestick/victory-candlestick.js
@@ -8,30 +8,8 @@ import {
 import CandlestickHelpers from "./helper-methods";
 
 const fallbackProps = {
-  props: {
-    height: 300,
-    width: 450,
-    candleColors: {
-      positive: "#ffffff",
-      negative: "#252525"
-    }
-  },
-  style: {
-    data: {
-      opacity: 1,
-      strokeWidth: 1,
-      stroke: "#252525"
-    },
-    labels: {
-      fill: "#252525",
-      fontFamily: "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
-      fontSize: 14,
-      letterSpacing: "0.04em",
-      padding: 10,
-      stroke: "transparent",
-      textAnchor: "end"
-    }
-  }
+  width: 450,
+  height: 300
 };
 
 const defaultData = [

--- a/src/components/victory-candlestick/victory-candlestick.js
+++ b/src/components/victory-candlestick/victory-candlestick.js
@@ -3,13 +3,18 @@ import { assign, defaults, isFunction, partialRight } from "lodash";
 import Candle from "./candle";
 import {
   PropTypes as CustomPropTypes, Helpers, Events, VictoryTransition, VictoryLabel,
-  VictoryContainer
+  VictoryContainer, VictoryTheme
 } from "victory-core";
 import CandlestickHelpers from "./helper-methods";
 
 const fallbackProps = {
   width: 450,
-  height: 300
+  height: 300,
+  padding: 50,
+  candleColors: {
+    positive: "#ffffff",
+    negative: "#252525"
+  }
 };
 
 const defaultData = [
@@ -399,7 +404,6 @@ export default class VictoryCandlestick extends React.Component {
   };
 
   static defaultProps = {
-    padding: 50,
     samples: 50,
     scale: "linear",
     data: defaultData,
@@ -412,7 +416,8 @@ export default class VictoryCandlestick extends React.Component {
     dataComponent: <Candle/>,
     labelComponent: <VictoryLabel/>,
     containerComponent: <VictoryContainer/>,
-    groupComponent: <g/>
+    groupComponent: <g/>,
+    theme: VictoryTheme.grayscale
   };
 
   static getDomain = CandlestickHelpers.getDomain.bind(CandlestickHelpers);
@@ -511,11 +516,9 @@ export default class VictoryCandlestick extends React.Component {
   }
 
   render() {
-    const modifiedProps = this.props.theme && this.props.theme.candlestick
-      ? Helpers.modifyProps(this.props, fallbackProps, this.props.theme.candlestick.props)
-      : Helpers.modifyProps(this.props, fallbackProps);
+    const props = Helpers.modifyProps(this.props, fallbackProps, "candlestick");
 
-    const { animate, standalone, style } = modifiedProps;
+    const { animate, standalone, style, theme } = props;
     // If animating, return a `VictoryAnimation` element that will create
     // a new `VictoryCandlestick` with nearly identical props, except (1) tweened
     // and (2) `animate` set to null so we don't recurse forever.
@@ -529,14 +532,15 @@ export default class VictoryCandlestick extends React.Component {
       ];
       return (
         <VictoryTransition animate={animate} animationWhitelist={whitelist}>
-          {React.createElement(this.constructor, modifiedProps)}
+          {React.createElement(this.constructor, props)}
         </VictoryTransition>
       );
     }
+    const styleObject = theme && theme.candlestick && theme.candlestick.style ?
+      theme.candlestick.style : {};
+    const baseStyle = Helpers.getStyles(style, styleObject, "auto", "100%");
 
-    const baseStyle = Helpers.getStyles(style, fallbackProps.style, "auto", "100%");
-
-    const group = this.renderGroup(this.renderData(modifiedProps), baseStyle.parent);
-    return standalone ? this.renderContainer(modifiedProps, group) : group;
+    const group = this.renderGroup(this.renderData(props), baseStyle.parent);
+    return standalone ? this.renderContainer(props, group) : group;
   }
 }

--- a/src/components/victory-chart/victory-chart.js
+++ b/src/components/victory-chart/victory-chart.js
@@ -11,7 +11,8 @@ import Wrapper from "../../helpers/wrapper";
 
 const fallbackProps = {
   width: 450,
-  height: 300
+  height: 300,
+  padding: 50
 };
 
 export default class VictoryChart extends React.Component {
@@ -226,11 +227,10 @@ export default class VictoryChart extends React.Component {
   };
 
   static defaultProps = {
-    padding: 50,
     standalone: true,
     containerComponent: <VictoryContainer/>,
     groupComponent: <g/>,
-    theme: VictoryTheme.material,
+    theme: VictoryTheme.grayscale,
     defaultAxes: {
       independent: <VictoryAxis/>,
       dependent: <VictoryAxis dependentAxis/>

--- a/src/components/victory-chart/victory-chart.js
+++ b/src/components/victory-chart/victory-chart.js
@@ -395,7 +395,7 @@ export default class VictoryChart extends React.Component {
   render() {
     const props = this.state && this.state.nodesWillExit ?
       this.state.oldProps : this.props;
-    const modifiedProps = Helpers.modifyProps(props, fallbackProps);
+    const modifiedProps = Helpers.modifyProps(props, fallbackProps, "chart");
     const childComponents = ChartHelpers.getChildComponents(modifiedProps,
       modifiedProps.defaultAxes);
     const calculatedProps = this.getCalculatedProps(modifiedProps, childComponents);

--- a/src/components/victory-chart/victory-chart.js
+++ b/src/components/victory-chart/victory-chart.js
@@ -1,7 +1,7 @@
 import { defaults } from "lodash";
 import React, { PropTypes } from "react";
 import {
-  PropTypes as CustomPropTypes, Helpers, VictorySharedEvents, VictoryContainer
+  PropTypes as CustomPropTypes, Helpers, VictorySharedEvents, VictoryContainer, VictoryTheme
 } from "victory-core";
 import VictoryAxis from "../victory-axis/victory-axis";
 import ChartHelpers from "./helper-methods";
@@ -10,10 +10,8 @@ import Scale from "../../helpers/scale";
 import Wrapper from "../../helpers/wrapper";
 
 const fallbackProps = {
-  props: {
-    width: 450,
-    height: 300
-  }
+  width: 450,
+  height: 300
 };
 
 export default class VictoryChart extends React.Component {
@@ -232,6 +230,7 @@ export default class VictoryChart extends React.Component {
     standalone: true,
     containerComponent: <VictoryContainer/>,
     groupComponent: <g/>,
+    theme: VictoryTheme.material,
     defaultAxes: {
       independent: <VictoryAxis/>,
       dependent: <VictoryAxis dependentAxis/>

--- a/src/components/victory-errorbar/errorbar.js
+++ b/src/components/victory-errorbar/errorbar.js
@@ -28,6 +28,10 @@ export default class ErrorBar extends React.Component {
     groupComponent: PropTypes.element
   };
 
+  static defaultProps = {
+    borderWidth: 10
+  }
+
   renderErrorBar(error) {
     const {
       x,

--- a/src/components/victory-errorbar/errorbar.js
+++ b/src/components/victory-errorbar/errorbar.js
@@ -1,5 +1,6 @@
 /* eslint-disable max-statements */
 import React, { PropTypes } from "react";
+import { assign } from "lodash";
 
 export default class ErrorBar extends React.Component {
   constructor(props) {
@@ -33,19 +34,14 @@ export default class ErrorBar extends React.Component {
   }
 
   renderErrorBar(error) {
-    const {
-      x,
-      y,
-      borderWidth,
-      groupComponent
-    } = this.props;
-
+    const { x, y, borderWidth, groupComponent, events} = this.props;
+    const style = assign({stroke: "black"}, this.props.style);
     return React.cloneElement(groupComponent, {},
       error.errorRight ?
         <line
           ref="borderRight"
-          {...this.props.events}
-          style={this.props.style}
+          {...events}
+          style={style}
           x1={error.errorRight}
           x2={error.errorRight}
           y1={y - borderWidth}
@@ -56,8 +52,8 @@ export default class ErrorBar extends React.Component {
       error.errorLeft ?
         <line
           ref="borderLeft"
-          {...this.props.events}
-          style={this.props.style}
+          {...events}
+          style={style}
           x1={error.errorLeft}
           x2={error.errorLeft}
           y1={y - borderWidth}
@@ -68,8 +64,8 @@ export default class ErrorBar extends React.Component {
       error.errorBottom ?
         <line
           ref="borderBottom"
-          {...this.props.events}
-          style={this.props.style}
+          {...events}
+          style={style}
           x1={x - borderWidth}
           x2={x + borderWidth}
           y1={error.errorBottom}
@@ -80,8 +76,8 @@ export default class ErrorBar extends React.Component {
       error.errorTop ?
         <line
           ref="borderTop"
-          {...this.props.events}
-          style={this.props.style}
+          {...events}
+          style={style}
           x1={x - borderWidth}
           x2={x + borderWidth}
           y1={error.errorTop}
@@ -92,8 +88,8 @@ export default class ErrorBar extends React.Component {
       error.errorTop ?
         <line
           ref="crossTop"
-          {...this.props.events}
-          style={this.props.style}
+          {...events}
+          style={style}
           x1={x}
           x2={x}
           y1={y}
@@ -105,8 +101,8 @@ export default class ErrorBar extends React.Component {
       error.errorBottom ?
         <line
           ref="crossBottom"
-          {...this.props.events}
-          style={this.props.style}
+          {...events}
+          style={style}
           x1={x}
           x2={x}
           y1={y}
@@ -118,8 +114,8 @@ export default class ErrorBar extends React.Component {
       error.errorLeft ?
         <line
           ref="crossLeft"
-          {...this.props.events}
-          style={this.props.style}
+          {...events}
+          style={style}
           x1={x}
           x2={error.errorLeft}
           y1={y}
@@ -130,8 +126,8 @@ export default class ErrorBar extends React.Component {
       error.errorRight ?
         <line
           ref="crossRight"
-          {...this.props.events}
-          style={this.props.style}
+          {...events}
+          style={style}
           x1={x}
           x2={error.errorRight}
           y1={y}
@@ -147,7 +143,6 @@ export default class ErrorBar extends React.Component {
       errorY,
       scale
     } = this.props;
-
     let rangeX;
     let rangeY;
     let positiveErrorX;

--- a/src/components/victory-errorbar/helper-methods.js
+++ b/src/components/victory-errorbar/helper-methods.js
@@ -7,10 +7,10 @@ import Data from "../../helpers/data";
 
 export default {
   getBaseProps(props, fallbackProps) {
-    modifiedProps = Helpers.modifyProps(props, fallbackProps, "errorbar");
-    const calculatedValues = this.getCalculatedValues(modifiedProps, fallbackProps);
+    props = Helpers.modifyProps(props, fallbackProps, "errorbar");
+    const calculatedValues = this.getCalculatedValues(props, fallbackProps);
     const { data, style, scale } = calculatedValues;
-    const { groupComponent, height, width, borderWidth } = modifiedProps;
+    const { groupComponent, height, width, borderWidth } = props;
     const childProps = { parent: {style: style.parent, scale, data, height, width} };
     for (let index = 0, len = data.length; index < len; index++) {
       const datum = data[index];
@@ -25,13 +25,12 @@ export default {
         errorY: this.getErrors(datum, scale, "y")
       };
 
-      const labelStyle = this.getLabelStyle(style.labels, dataProps) || {};
-      const labelPadding = labelStyle.padding || 0;
+      const labelStyle = this.getLabelStyle(style.labels, dataProps);
       const labelProps = {
         style: labelStyle,
-        x: x - labelPadding,
-        y: y - labelPadding,
-        text: this.getLabelText(modifiedProps, datum, index),
+        x: x - (labelStyle.padding || 0),
+        y: y - (labelStyle.padding || 0),
+        text: this.getLabelText(props, datum, index),
         index,
         scale,
         datum: dataProps.datum,
@@ -165,9 +164,9 @@ export default {
   getCalculatedValues(props, fallbackProps) {
     const defaultStyles = props.theme && props.theme.errorbar && props.theme.errorbar.style ?
       props.theme.errorbar.style : fallbackProps.style;
-    const style = Helpers.getStyles(props.style, defaultStyles, "auto", "100%");
-    const assignData = Object.assign(Data.getData(props), this.getErrorData(props));
-    const data = Events.addEventKeys(props, assignData);
+    const style = Helpers.getStyles(props.style, defaultStyles, "auto", "100%") || {};
+    const dataWithErrors = assign(Data.getData(props), this.getErrorData(props));
+    const data = Events.addEventKeys(props, dataWithErrors);
     const range = {
       x: Helpers.getRange(props, "x"),
       y: Helpers.getRange(props, "y")
@@ -204,6 +203,6 @@ export default {
     const matchedStyle = pick(style, ["opacity", "fill"]);
     const padding = labelStyle.padding || size * 0.25;
     const baseLabelStyle = defaults({}, labelStyle, matchedStyle, {padding});
-    return Helpers.evaluateStyle(baseLabelStyle, datum);
+    return Helpers.evaluateStyle(baseLabelStyle, datum) || {};
   }
 };

--- a/src/components/victory-errorbar/helper-methods.js
+++ b/src/components/victory-errorbar/helper-methods.js
@@ -162,8 +162,8 @@ export default {
   },
 
   getCalculatedValues(props, fallbackProps) {
-    const defaultStyles = props.theme && props.theme.errorbar ? props.theme.errorbar
-    : fallbackProps.style;
+    const defaultStyles = props.theme && props.theme.errorbar && props.theme.errorbar.style ?
+      props.theme.errorbar.style : fallbackProps.style;
     const style = Helpers.getStyles(props.style, defaultStyles, "auto", "100%");
     const assignData = Object.assign(Data.getData(props), this.getErrorData(props));
     const data = Events.addEventKeys(props, assignData);

--- a/src/components/victory-errorbar/helper-methods.js
+++ b/src/components/victory-errorbar/helper-methods.js
@@ -7,7 +7,7 @@ import Data from "../../helpers/data";
 
 export default {
   getBaseProps(props, fallbackProps) {
-    const modifiedProps = Helpers.modifyProps(props, fallbackProps);
+    modifiedProps = Helpers.modifyProps(props, fallbackProps, "errorbar");
     const calculatedValues = this.getCalculatedValues(modifiedProps, fallbackProps);
     const { data, style, scale } = calculatedValues;
     const { groupComponent, height, width, borderWidth } = modifiedProps;
@@ -25,11 +25,12 @@ export default {
         errorY: this.getErrors(datum, scale, "y")
       };
 
-      const labelStyle = this.getLabelStyle(style.labels, dataProps);
+      const labelStyle = this.getLabelStyle(style.labels, dataProps) || {};
+      const labelPadding = labelStyle.padding || 0;
       const labelProps = {
         style: labelStyle,
-        x: x - labelStyle.padding,
-        y: y - labelStyle.padding,
+        x: x - labelPadding,
+        y: y - labelPadding,
         text: this.getLabelText(modifiedProps, datum, index),
         index,
         scale,
@@ -198,6 +199,7 @@ export default {
   },
 
   getLabelStyle(labelStyle, dataProps) {
+    labelStyle = labelStyle || {};
     const { datum, size, style } = dataProps;
     const matchedStyle = pick(style, ["opacity", "fill"]);
     const padding = labelStyle.padding || size * 0.25;

--- a/src/components/victory-errorbar/helper-methods.js
+++ b/src/components/victory-errorbar/helper-methods.js
@@ -161,9 +161,9 @@ export default {
     return [min, max];
   },
 
-  getCalculatedValues(props, fallbackProps) {
+  getCalculatedValues(props) {
     const defaultStyles = props.theme && props.theme.errorbar && props.theme.errorbar.style ?
-      props.theme.errorbar.style : fallbackProps.style;
+      props.theme.errorbar.style : {};
     const style = Helpers.getStyles(props.style, defaultStyles, "auto", "100%") || {};
     const dataWithErrors = assign(Data.getData(props), this.getErrorData(props));
     const data = Events.addEventKeys(props, dataWithErrors);

--- a/src/components/victory-errorbar/victory-errorbar.js
+++ b/src/components/victory-errorbar/victory-errorbar.js
@@ -9,27 +9,8 @@ import Data from "../../helpers/data";
 import ErrorBarHelpers from "./helper-methods";
 
 const fallbackProps = {
-  props: {
-    width: 450,
-    height: 300
-  },
-  style: {
-    data: {
-      fill: "none",
-      opacity: 1,
-      strokeWidth: 2,
-      stroke: "#252525"
-    },
-    labels: {
-      fill: "#252525",
-      fontFamily: "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
-      fontSize: 14,
-      letterSpacing: "0.04em",
-      padding: 10,
-      stroke: "transparent",
-      textAnchor: "start"
-    }
-  }
+  width: 450,
+  height: 300
 };
 
 const defaultData = [
@@ -368,7 +349,6 @@ export default class VictoryErrorBar extends React.Component {
     y: "y",
     errorX: "errorX",
     errorY: "errorY",
-    borderWidth: 10,
     dataComponent: <ErrorBar/>,
     labelComponent: <VictoryLabel/>,
     containerComponent: <VictoryContainer/>,

--- a/src/components/victory-errorbar/victory-errorbar.js
+++ b/src/components/victory-errorbar/victory-errorbar.js
@@ -1,7 +1,7 @@
 import React, { PropTypes } from "react";
 import {
   PropTypes as CustomPropTypes, Helpers, Events, VictoryTransition, VictoryLabel,
-  VictoryContainer
+  VictoryContainer, VictoryTheme
 } from "victory-core";
 import { assign, defaults, isFunction, partialRight } from "lodash";
 import ErrorBar from "./errorbar";
@@ -10,7 +10,8 @@ import ErrorBarHelpers from "./helper-methods";
 
 const fallbackProps = {
   width: 450,
-  height: 300
+  height: 300,
+  padding: 50
 };
 
 const defaultData = [
@@ -342,7 +343,6 @@ export default class VictoryErrorBar extends React.Component {
 
   static defaultProps = {
     data: defaultData,
-    padding: 50,
     scale: "linear",
     standalone: true,
     x: "x",
@@ -352,7 +352,8 @@ export default class VictoryErrorBar extends React.Component {
     dataComponent: <ErrorBar/>,
     labelComponent: <VictoryLabel/>,
     containerComponent: <VictoryContainer/>,
-    groupComponent: <g/>
+    groupComponent: <g/>,
+    theme: VictoryTheme.grayscale
   };
 
   static getDomain = ErrorBarHelpers.getDomain.bind(ErrorBarHelpers);
@@ -450,8 +451,8 @@ export default class VictoryErrorBar extends React.Component {
   }
 
   render() {
-    const modifiedProps = Helpers.modifyProps(this.props, fallbackProps);
-    const { animate, style, standalone } = modifiedProps;
+    const props = Helpers.modifyProps(this.props, fallbackProps, "errorbar");
+    const { animate, style, standalone, theme } = props;
     if (animate) {
       // Do less work by having `VictoryAnimation` tween only values that
       // make sense to tween. In the future, allow customization of animated
@@ -462,18 +463,17 @@ export default class VictoryErrorBar extends React.Component {
       ];
       return (
         <VictoryTransition animate={this.props.animate} animationWhitelist={whitelist}>
-          {React.createElement(this.constructor, modifiedProps)}
+          {React.createElement(this.constructor, props)}
         </VictoryTransition>
       );
     }
 
-    const styleObject = modifiedProps.theme && modifiedProps.theme.errorbar
-    ? modifiedProps.theme.errorbar
-    : fallbackProps.style;
+    const styleObject = theme && theme.errorbar && theme.errorbar.style ?
+      theme.errorbar.style : {};
 
     const baseStyle = Helpers.getStyles(style, styleObject, "auto", "100%");
 
-    const group = this.renderGroup(this.renderData(modifiedProps), baseStyle.parent);
-    return standalone ? this.renderContainer(modifiedProps, group) : group;
+    const group = this.renderGroup(this.renderData(props), baseStyle.parent);
+    return standalone ? this.renderContainer(props, group) : group;
   }
 }

--- a/src/components/victory-group/victory-group.js
+++ b/src/components/victory-group/victory-group.js
@@ -7,16 +7,8 @@ import Axis from "../../helpers/axis";
 import Wrapper from "../../helpers/wrapper";
 
 const fallbackProps = {
-  props: {
-    width: 450,
-    height: 300
-  },
-  style: {
-    data: {
-      width: 8,
-      padding: 6
-    }
-  }
+  width: 450,
+  height: 300
 };
 
 export default class VictoryGroup extends React.Component {

--- a/src/components/victory-group/victory-group.js
+++ b/src/components/victory-group/victory-group.js
@@ -1,14 +1,17 @@
 import { assign, defaults } from "lodash";
 import React, { PropTypes } from "react";
 import { PropTypes as CustomPropTypes, Helpers, VictorySharedEvents,
-  VictoryContainer } from "victory-core";
+  VictoryContainer, VictoryTheme
+} from "victory-core";
 import Scale from "../../helpers/scale";
 import Axis from "../../helpers/axis";
 import Wrapper from "../../helpers/wrapper";
 
 const fallbackProps = {
   width: 450,
-  height: 300
+  height: 300,
+  padding: 50,
+  offset: 0
 };
 
 export default class VictoryGroup extends React.Component {
@@ -290,11 +293,10 @@ export default class VictoryGroup extends React.Component {
 
   static defaultProps = {
     scale: "linear",
-    offset: 0,
-    padding: 50,
     standalone: true,
     containerComponent: <VictoryContainer/>,
-    groupComponent: <g/>
+    groupComponent: <g/>,
+    theme: VictoryTheme.grayscale
   };
 
   static getDomain = Wrapper.getDomain.bind(Wrapper);

--- a/src/components/victory-group/victory-group.js
+++ b/src/components/victory-group/victory-group.js
@@ -451,19 +451,21 @@ export default class VictoryGroup extends React.Component {
   render() {
     const props = this.state && this.state.nodesWillExit ?
       this.state.oldProps : this.props;
-    const modifiedProps = Helpers.modifyProps(props, fallbackProps);
-    const style = Helpers.getStyles(modifiedProps.style, fallbackProps.style, "auto", "100%");
+    const modifiedProps = Helpers.modifyProps(props, fallbackProps, "group");
+    const { theme, standalone, events, eventKey } = modifiedProps;
+    const defaultStyle = theme && theme.group && theme.group.style ? theme.group.style : {};
+    const style = Helpers.getStyles(modifiedProps.style, defaultStyle, "auto", "100%");
     const childComponents = React.Children.toArray(modifiedProps.children);
     const calculatedProps = this.getCalculatedProps(modifiedProps, childComponents, style,
       fallbackProps.props);
 
-    const container = modifiedProps.standalone && this.getContainer(modifiedProps, calculatedProps);
+    const container = standalone && this.getContainer(modifiedProps, calculatedProps);
     const newChildren = this.getNewChildren(modifiedProps, childComponents, calculatedProps);
     if (modifiedProps.events) {
       return (
         <VictorySharedEvents
-          events={modifiedProps.events}
-          eventKey={modifiedProps.eventKey}
+          events={events}
+          eventKey={eventKey}
           container={container}
         >
           {newChildren}
@@ -472,6 +474,6 @@ export default class VictoryGroup extends React.Component {
     }
     const group = this.renderGroup(newChildren, style.parent);
 
-    return modifiedProps.standalone ? React.cloneElement(container, container.props, group) : group;
+    return standalone ? React.cloneElement(container, container.props, group) : group;
   }
 }

--- a/src/components/victory-line/helper-methods.js
+++ b/src/components/victory-line/helper-methods.js
@@ -7,12 +7,12 @@ import Scale from "../../helpers/scale";
 export default {
 
   getBaseProps(props, fallbackProps) {
+    props = Helpers.modifyProps(props, fallbackProps, "line");
     const defaultStyles = props.theme && props.theme.line && props.theme.line.style ?
-      props.theme.line.style : fallbackProps.style;
-    const modifiedProps = Helpers.modifyProps(props, fallbackProps);
-    const {scale, dataSegments, dataset} = this.getCalculatedValues(modifiedProps);
-    const style = Helpers.getStyles(modifiedProps.style, defaultStyles, "auto", "100%");
-    const {interpolation, label, width, height} = modifiedProps;
+      props.theme.line.style : {};
+    const {scale, dataSegments, dataset} = this.getCalculatedValues(props);
+    const style = Helpers.getStyles(props.style, defaultStyles, "auto", "100%");
+    const {interpolation, label, width, height} = props;
     const dataStyle = Helpers.evaluateStyle(style.data, dataset);
     const dataProps = {
       scale,

--- a/src/components/victory-line/helper-methods.js
+++ b/src/components/victory-line/helper-methods.js
@@ -7,7 +7,8 @@ import Scale from "../../helpers/scale";
 export default {
 
   getBaseProps(props, fallbackProps) {
-    const defaultStyles = props.theme && props.theme.line ? props.theme.line : fallbackProps.style;
+    const defaultStyles = props.theme && props.theme.line && props.theme.line.style ?
+      props.theme.line.style : fallbackProps.style;
     const modifiedProps = Helpers.modifyProps(props, fallbackProps);
     const {scale, dataSegments, dataset} = this.getCalculatedValues(modifiedProps);
     const style = Helpers.getStyles(modifiedProps.style, defaultStyles, "auto", "100%");

--- a/src/components/victory-line/line-segment.js
+++ b/src/components/victory-line/line-segment.js
@@ -1,4 +1,5 @@
 import React, { PropTypes } from "react";
+import { assign } from "lodash";
 import * as d3Shape from "d3-shape";
 
 export default class LineSegment extends React.Component {
@@ -41,6 +42,7 @@ export default class LineSegment extends React.Component {
       .curve(d3Shape[this.toNewName(interpolation)])
       .x((d) => xScale(d.x))
       .y((d) => yScale(d.y));
-    return this.renderLine(lineFunction(data), style, events);
+    const lineStyle = assign({fill: "none", stroke: "black"}, style);
+    return this.renderLine(lineFunction(data), lineStyle, events);
   }
 }

--- a/src/components/victory-line/victory-line.js
+++ b/src/components/victory-line/victory-line.js
@@ -7,12 +7,14 @@ import Domain from "../../helpers/domain";
 import Data from "../../helpers/data";
 import {
   PropTypes as CustomPropTypes, Helpers, Events, VictoryTransition, VictoryLabel,
-  VictoryContainer
+  VictoryContainer, VictoryTheme
 } from "victory-core";
 
 const fallbackProps = {
   width: 450,
-  height: 300
+  height: 300,
+  padding: 50,
+  interpolation: "linear"
 };
 
 export default class VictoryLine extends React.Component {
@@ -372,8 +374,6 @@ export default class VictoryLine extends React.Component {
   };
 
   static defaultProps = {
-    interpolation: "linear",
-    padding: 50,
     samples: 50,
     scale: "linear",
     standalone: true,
@@ -383,7 +383,8 @@ export default class VictoryLine extends React.Component {
     labelComponent: <VictoryLabel/>,
     containerComponent: <VictoryContainer/>,
     groupComponent: <g/>,
-    clipPathComponent: <ClipPath/>
+    clipPathComponent: <ClipPath/>,
+    theme: VictoryTheme.grayscale
   };
 
   static getDomain = Domain.getDomain.bind(Domain);

--- a/src/components/victory-line/victory-line.js
+++ b/src/components/victory-line/victory-line.js
@@ -498,7 +498,7 @@ export default class VictoryLine extends React.Component {
   render() {
     const clipId = Math.round(Math.random() * 10000);
     const props = Helpers.modifyProps(assign({clipId}, this.props), fallbackProps, "line");
-    const { animate, style, standalone } = props;
+    const { animate, style, standalone, theme } = props;
 
     if (animate) {
       // Do less work by having `VictoryAnimation` tween only values that
@@ -516,8 +516,7 @@ export default class VictoryLine extends React.Component {
       );
     }
 
-    const styleObject = props.theme && props.theme.line && props.theme.line.style ?
-      props.theme.line.style : {};
+    const styleObject = theme && theme.line && theme.line.style ? theme.line.style : {};
 
     const baseStyles = Helpers.getStyles(style, styleObject, "auto", "100%");
     const group = this.renderGroup(

--- a/src/components/victory-line/victory-line.js
+++ b/src/components/victory-line/victory-line.js
@@ -11,30 +11,8 @@ import {
 } from "victory-core";
 
 const fallbackProps = {
-  props: {
-    height: 300,
-    width: 450,
-    clipHeight: 300,
-    clipWidth: 450
-  },
-  style: {
-    data: {
-      fill: "none",
-      opacity: 1,
-      strokeWidth: 2,
-      stroke: "#252525"
-    },
-    labels: {
-      fill: "#252525",
-      fontFamily: "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
-      fontSize: 14,
-      letterSpacing: "0.04em",
-      padding: 10,
-      strokeWidth: 0,
-      stroke: "transparent",
-      textAnchor: "start"
-    }
-  }
+  width: 450,
+  height: 300
 };
 
 export default class VictoryLine extends React.Component {
@@ -501,15 +479,12 @@ export default class VictoryLine extends React.Component {
   renderGroup(children, modifiedProps, style) {
     const { clipPathComponent } = modifiedProps;
 
-    const clipComponent = React.cloneElement(clipPathComponent, assign(
-      {},
-      {
-        padding: modifiedProps.padding,
-        clipId: modifiedProps.clipId,
-        clipWidth: modifiedProps.clipWidth || modifiedProps.width,
-        clipHeight: modifiedProps.clipHeight || modifiedProps.height
-      }
-    ));
+    const clipComponent = React.cloneElement(clipPathComponent, {
+      padding: modifiedProps.padding,
+      clipId: modifiedProps.clipId,
+      clipWidth: modifiedProps.clipWidth || modifiedProps.width,
+      clipHeight: modifiedProps.clipHeight || modifiedProps.height
+    });
 
     return React.cloneElement(
       this.props.groupComponent,
@@ -521,8 +496,8 @@ export default class VictoryLine extends React.Component {
 
   render() {
     const clipId = Math.round(Math.random() * 10000);
-    const modifiedProps = Helpers.modifyProps(assign({}, this.props, {clipId}), fallbackProps);
-    const { animate, style, standalone } = modifiedProps;
+    const props = Helpers.modifyProps(assign({clipId}, this.props), fallbackProps, "line");
+    const { animate, style, standalone } = props;
 
     if (animate) {
       // Do less work by having `VictoryAnimation` tween only values that
@@ -535,19 +510,19 @@ export default class VictoryLine extends React.Component {
       ];
       return (
         <VictoryTransition animate={animate} animationWhitelist={whitelist}>
-          {React.createElement(this.constructor, modifiedProps)}
+          {React.createElement(this.constructor, props)}
         </VictoryTransition>
       );
     }
 
-    const styleObject = modifiedProps.theme && modifiedProps.theme.line ? modifiedProps.theme.line
-    : fallbackProps.style;
+    const styleObject = props.theme && props.theme.line && props.theme.line.style ?
+      props.theme.line.style : {};
 
     const baseStyles = Helpers.getStyles(style, styleObject, "auto", "100%");
     const group = this.renderGroup(
-      this.renderData(modifiedProps), modifiedProps, baseStyles.parent
+      this.renderData(props), props, baseStyles.parent
     );
 
-    return standalone ? this.renderContainer(modifiedProps, group) : group;
+    return standalone ? this.renderContainer(props, group) : group;
   }
 }

--- a/src/components/victory-scatter/helper-methods.js
+++ b/src/components/victory-scatter/helper-methods.js
@@ -47,8 +47,8 @@ export default {
   },
 
   getCalculatedValues(props, fallbackProps) {
-    const defaultStyles = props.theme && props.theme.scatter ? props.theme.scatter
-    : fallbackProps.style;
+    const defaultStyles = props.theme && props.theme.scatter && props.theme.scatter.style ?
+      props.theme.scatter.style : fallbackProps.style;
     const style = Helpers.getStyles(props.style, defaultStyles, "auto", "100%");
     const data = Events.addEventKeys(props, Data.getData(props));
     const range = {

--- a/src/components/victory-scatter/helper-methods.js
+++ b/src/components/victory-scatter/helper-methods.js
@@ -6,11 +6,11 @@ import Data from "../../helpers/data";
 
 export default {
   getBaseProps(props, fallbackProps) {
-    const modifiedProps = Helpers.modifyProps(props, fallbackProps);
-    const calculatedValues = this.getCalculatedValues(modifiedProps, fallbackProps);
+    props = Helpers.modifyProps(props, fallbackProps, "scatter");
+    const calculatedValues = this.getCalculatedValues(props);
     const { data, style, scale } = calculatedValues;
     const childProps = { parent: {
-      style: style.parent, scale, data, height: modifiedProps.height, width: modifiedProps.width
+      style: style.parent, scale, data, height: props.height, width: props.width
     }};
     for (let index = 0, len = data.length; index < len; index++) {
       const datum = data[index];
@@ -19,12 +19,12 @@ export default {
       const y = scale.y(datum.y);
       const dataProps = {
         x, y, datum, index, scale,
-        size: this.getSize(datum, modifiedProps, calculatedValues),
-        symbol: this.getSymbol(datum, modifiedProps),
+        size: this.getSize(datum, props, calculatedValues),
+        symbol: this.getSymbol(datum, props),
         style: this.getDataStyles(datum, style.data)
       };
 
-      const text = this.getLabelText(modifiedProps, datum, index);
+      const text = this.getLabelText(props, datum, index);
       const labelStyle = this.getLabelStyle(style.labels, dataProps);
       const labelProps = {
         style: labelStyle,
@@ -46,9 +46,9 @@ export default {
     return childProps;
   },
 
-  getCalculatedValues(props, fallbackProps) {
+  getCalculatedValues(props) {
     const defaultStyles = props.theme && props.theme.scatter && props.theme.scatter.style ?
-      props.theme.scatter.style : fallbackProps.style;
+      props.theme.scatter.style : {};
     const style = Helpers.getStyles(props.style, defaultStyles, "auto", "100%");
     const data = Events.addEventKeys(props, Data.getData(props));
     const range = {

--- a/src/components/victory-scatter/victory-scatter.js
+++ b/src/components/victory-scatter/victory-scatter.js
@@ -10,27 +10,8 @@ import {
 import ScatterHelpers from "./helper-methods";
 
 const fallbackProps = {
-  props: {
-    width: 450,
-    height: 300
-  },
-  style: {
-    data: {
-      fill: "#242424",
-      opacity: 1,
-      stroke: "transparent",
-      strokeWidth: 0
-    },
-    labels: {
-      fill: "#252525",
-      fontFamily: "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
-      fontSize: 14,
-      letterSpacing: "0.04em",
-      padding: 10,
-      stroke: "transparent",
-      textAnchor: "middle"
-    }
-  }
+  width: 450,
+  height: 300
 };
 
 export default class VictoryScatter extends React.Component {

--- a/src/components/victory-scatter/victory-scatter.js
+++ b/src/components/victory-scatter/victory-scatter.js
@@ -5,13 +5,16 @@ import Domain from "../../helpers/domain";
 import Data from "../../helpers/data";
 import {
   PropTypes as CustomPropTypes, Helpers, Events, VictoryTransition, VictoryLabel,
-  VictoryContainer
+  VictoryContainer, VictoryTheme
 } from "victory-core";
 import ScatterHelpers from "./helper-methods";
 
 const fallbackProps = {
   width: 450,
-  height: 300
+  height: 300,
+  padding: 50,
+  size: 3,
+  symbol: "circle"
 };
 
 export default class VictoryScatter extends React.Component {
@@ -355,18 +358,16 @@ export default class VictoryScatter extends React.Component {
   };
 
   static defaultProps = {
-    padding: 50,
     samples: 50,
     scale: "linear",
-    size: 3,
     standalone: true,
-    symbol: "circle",
     x: "x",
     y: "y",
     dataComponent: <Point/>,
     labelComponent: <VictoryLabel/>,
     containerComponent: <VictoryContainer/>,
-    groupComponent: <g/>
+    groupComponent: <g/>,
+    theme: VictoryTheme.grayscale
   };
 
   static getDomain = Domain.getDomain.bind(Domain);

--- a/src/components/victory-stack/victory-stack.js
+++ b/src/components/victory-stack/victory-stack.js
@@ -1,14 +1,16 @@
 import { assign, uniq, defaults } from "lodash";
 import React, { PropTypes } from "react";
 import {
-  PropTypes as CustomPropTypes, Helpers, Log, VictorySharedEvents, VictoryContainer
+  PropTypes as CustomPropTypes, Helpers, Log, VictorySharedEvents, VictoryContainer,
+  VictoryTheme
 } from "victory-core";
 import Scale from "../../helpers/scale";
 import Wrapper from "../../helpers/wrapper";
 
 const fallbackProps = {
   width: 450,
-  height: 300
+  height: 300,
+  padding: 50
 };
 
 export default class VictoryStack extends React.Component {
@@ -288,10 +290,10 @@ export default class VictoryStack extends React.Component {
 
   static defaultProps = {
     scale: "linear",
-    padding: 50,
     standalone: true,
     containerComponent: <VictoryContainer/>,
-    groupComponent: <g/>
+    groupComponent: <g/>,
+    theme: VictoryTheme. grayscale
   };
 
   static getDomain = Wrapper.getStackedDomain.bind(Wrapper);

--- a/src/components/victory-stack/victory-stack.js
+++ b/src/components/victory-stack/victory-stack.js
@@ -1,8 +1,7 @@
-import { assign, uniq, defaults } from "lodash";
+import { assign, defaults } from "lodash";
 import React, { PropTypes } from "react";
 import {
-  PropTypes as CustomPropTypes, Helpers, Log, VictorySharedEvents, VictoryContainer,
-  VictoryTheme
+  PropTypes as CustomPropTypes, Helpers, VictorySharedEvents, VictoryContainer, VictoryTheme
 } from "victory-core";
 import Scale from "../../helpers/scale";
 import Wrapper from "../../helpers/wrapper";
@@ -424,16 +423,13 @@ export default class VictoryStack extends React.Component {
   render() {
     const props = this.state && this.state.nodesWillExit ?
       this.state.oldProps : this.props;
-    const modifiedProps = Helpers.modifyProps(props, fallbackProps);
+    const modifiedProps = Helpers.modifyProps(props, fallbackProps, "stack");
     const { theme, standalone, events, eventKey} = modifiedProps;
     const fallbackStyle = theme && theme.stack && theme.stack.style ?
       theme.stack.style : {};
     const style = Helpers.getStyles(modifiedProps.style, fallbackStyle, "auto", "100%");
     const childComponents = React.Children.toArray(modifiedProps.children);
-    const types = uniq(childComponents.map((child) => child.type.role));
-    if (types.some((type) => type === "group-wrapper")) {
-      Log.warn("It is not possible to stack groups.");
-    }
+
     const calculatedProps = this.getCalculatedProps(modifiedProps, childComponents, style);
 
     const container = standalone && this.getContainer(modifiedProps, calculatedProps);

--- a/src/components/victory-stack/victory-stack.js
+++ b/src/components/victory-stack/victory-stack.js
@@ -7,16 +7,8 @@ import Scale from "../../helpers/scale";
 import Wrapper from "../../helpers/wrapper";
 
 const fallbackProps = {
-  props: {
-    width: 450,
-    height: 300
-  },
-  style: {
-    data: {
-      width: 8,
-      padding: 6
-    }
-  }
+  width: 450,
+  height: 300
 };
 
 export default class VictoryStack extends React.Component {
@@ -431,7 +423,10 @@ export default class VictoryStack extends React.Component {
     const props = this.state && this.state.nodesWillExit ?
       this.state.oldProps : this.props;
     const modifiedProps = Helpers.modifyProps(props, fallbackProps);
-    const style = Helpers.getStyles(modifiedProps.style, fallbackProps.style, "auto", "100%");
+    const { theme, standalone, events, eventKey} = modifiedProps;
+    const fallbackStyle = theme && theme.stack && theme.stack.style ?
+      theme.stack.style : {};
+    const style = Helpers.getStyles(modifiedProps.style, fallbackStyle, "auto", "100%");
     const childComponents = React.Children.toArray(modifiedProps.children);
     const types = uniq(childComponents.map((child) => child.type.role));
     if (types.some((type) => type === "group-wrapper")) {
@@ -439,13 +434,13 @@ export default class VictoryStack extends React.Component {
     }
     const calculatedProps = this.getCalculatedProps(modifiedProps, childComponents, style);
 
-    const container = modifiedProps.standalone && this.getContainer(modifiedProps, calculatedProps);
+    const container = standalone && this.getContainer(modifiedProps, calculatedProps);
     const newChildren = this.getNewChildren(modifiedProps, childComponents, calculatedProps);
-    if (modifiedProps.events) {
+    if (events) {
       return (
         <VictorySharedEvents
-          events={modifiedProps.events}
-          eventKey={modifiedProps.eventKey}
+          events={events}
+          eventKey={eventKey}
           container={container}
         >
           {newChildren}


### PR DESCRIPTION
*Depends on https://github.com/FormidableLabs/victory-core/pull/110*

This PR:
- removes all styles from `fallbackProps` across all components
- adds `theme: VictoryTheme.grayscale` to defaultProps
- adds checks for missing / expected style objects

TODO
- [x] themes for VictoryGroup and VictoryStack