### PR TITLE
Width of victory bar is always 8

### DIFF
--- a/src/components/victory-bar/helper-methods.js
+++ b/src/components/victory-bar/helper-methods.js
@@ -30,10 +30,13 @@ export default {
   getBarWidth(props) {
     const {style, width, data} = props;
     const padding = props.padding.left || props.padding;
-    const barWidth = (style && style.width) || data.length === 0 ?
-      8 : 0.3 * (width - 2 * padding) / data.length;
-
-    return barWidth;
+    if (style && style.width) {
+      return style.width;
+    }
+    if (data.length !== 0) {
+      return 0.3 * (width - 2 * padding) / data.length;
+    }
+    return 8;
   },
 
   getBarPosition(props, datum, scale) {


### PR DESCRIPTION
Instead we should use the width from style when it's specified.