### PR TITLE
Enhance victory group

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -10,6 +10,7 @@ import ScatterDemo from "./components/victory-scatter-demo";
 import ErrorBarDemo from "./components/victory-errorbar-demo";
 import CandlestickDemo from "./components/victory-candlestick-demo";
 import EventsDemo from "./components/events-demo";
+import GroupDemo from "./components/group-demo";
 import { Router, Route, Link, hashHistory } from "react-router";
 
 const content = document.getElementById("content");
@@ -33,6 +34,7 @@ const App = React.createClass({
           <li><Link to="/errorbar">Victory Error Bar Demo</Link></li>
           <li><Link to="/candlestick">Victory Candlestick Demo</Link></li>
           <li><Link to="/events">Events Demo</Link></li>
+          <li><Link to="/group">Group Demo</Link></li>
         </ul>
         {this.props.children}
       </div>
@@ -52,6 +54,7 @@ ReactDOM.render((
       <Route path="errorbar" component={ErrorBarDemo}/>
       <Route path="candlestick" component={CandlestickDemo}/>
       <Route path="events" component={EventsDemo}/>
+      <Route path="group" component={GroupDemo}/>
     </Route>
   </Router>
 ), content);

--- a/demo/components/group-demo.js
+++ b/demo/components/group-demo.js
@@ -1,6 +1,7 @@
 import React from "react";
 import {
-  VictoryChart, VictoryArea, VictoryStack, VictoryBar, VictoryLine, VictoryGroup, VictoryScatter
+  VictoryChart, VictoryStack, VictoryBar, VictoryLine,
+  VictoryGroup, VictoryScatter, VictoryErrorBar
 } from "../../src/index";
 import { range, random } from "lodash";
 
@@ -49,41 +50,58 @@ class App extends React.Component {
     return (
       <div className="demo">
         <div style={containerStyle}>
-          <VictoryChart style={chartStyle}>
-            <VictoryStack colorScale="qualitative">
+          <VictoryChart style={chartStyle} domainPadding={20}>
+            <VictoryStack
+              style={{
+                data: {strokeDasharray: "10, 5"}
+              }}
+              colorScale="qualitative"
+            >
               <VictoryGroup
                 data={[
                   {x: 1, y: 3},
                   {x: 2, y: 4},
                   {x: 3, y: 2}
                 ]}
+                style={{
+                  data: {width: 40, opacity: 0.6}
+                }}
               >
-                <VictoryArea/>
-                <VictoryScatter/>
+                <VictoryBar/>
+                <VictoryLine/>
               </VictoryGroup>
               <VictoryGroup
-                style={chartStyle}
-                colorScale="qualitative"
                 data={[
                   {x: 1, y: 4},
                   {x: 2, y: 5},
                   {x: 3, y: 1}
                 ]}
+                style={{
+                  data: {width: 20, opacity: 0.8}
+                }}
               >
-                <VictoryArea/>
-                <VictoryScatter/>
+                <VictoryBar/>
+                <VictoryLine/>
               </VictoryGroup>
               <VictoryGroup
-                style={chartStyle}
-                colorScale="qualitative"
                 data={[
-                  {x: 1, y: 1},
+                  {x: 1, y: 3},
                   {x: 2, y: 2},
                   {x: 3, y: 5}
                 ]}
+                style={{
+                  data: {width: 10, opacity: 1}
+                }}
               >
-                <VictoryArea/>
-                <VictoryScatter/>
+                <VictoryBar/>
+                <VictoryLine/>
+                <VictoryScatter
+                  symbol={"plus"}
+                  size={10}
+                  style={{
+                    data: {fill: "tomato"}
+                  }}
+                />
               </VictoryGroup>
             </VictoryStack>
           </VictoryChart>
@@ -92,15 +110,19 @@ class App extends React.Component {
             <VictoryGroup
               colorScale={"qualitative"}
               data={[
-                {x: 1, y: 3},
-                {x: 2, y: 4},
-                {x: 3, y: 2},
-                {x: 4, y: 5}
+                {x: 1, y: 3, errorX: 0.2, errorY: 0.5},
+                {x: 2, y: 4, errorX: 0.3, errorY: 0.3},
+                {x: 3, y: 2, errorX: 0.2, errorY: 0.2},
+                {x: 4, y: 5, errorX: 0.3, errorY: 0.5}
               ]}
             >
               <VictoryLine/>
-              <VictoryScatter/>
               <VictoryBar/>
+              <VictoryErrorBar
+                style={{
+                  data: {stroke: "tomato"}
+                }}
+              />
             </VictoryGroup>
           </VictoryChart>
 

--- a/demo/components/group-demo.js
+++ b/demo/components/group-demo.js
@@ -1,0 +1,74 @@
+import React from "react";
+import {
+  VictoryChart, VictoryArea, VictoryStack, VictoryBar, VictoryLine, VictoryGroup, VictoryScatter
+} from "../../src/index";
+import { range, random } from "lodash";
+
+
+class App extends React.Component {
+
+  getGroupData() {
+    return range(5).map(() => {
+      return [
+        {
+          x: "rabbits",
+          y: random(1, 5)
+        },
+        {
+          x: "cats",
+          y: random(1, 10)
+        },
+        {
+          x: "dogs",
+          y: random(1, 15)
+        }
+      ];
+    });
+  }
+
+  getMultiData() {
+    const bars = random(3, 5);
+    return range(4).map(() => {
+      return range(bars).map((bar) => {
+        return {x: bar + 1, y: random(2, 10)};
+      });
+    });
+  }
+
+  render() {
+    const containerStyle = {
+      display: "flex",
+      flexDirection: "row",
+      flexWrap: "wrap",
+      alignItems: "center",
+      justifyContent: "center"
+    };
+
+    const chartStyle = {parent: {border: "1px solid #ccc", margin: "2%", maxWidth: "40%"}};
+
+    return (
+      <div className="demo">
+        <div style={containerStyle}>
+
+
+
+            <VictoryGroup
+              style={chartStyle}
+              data={[
+                {x: 1, y: 3},
+                {x: 2, y: 4},
+                {x: 3, y: 2}
+              ]}
+            >
+              <VictoryArea style={{data: {fill: "tomato"}}}/>
+              <VictoryScatter style={{data: {fill: "blue"}}}/>
+            </VictoryGroup>
+
+
+        </div>
+      </div>
+    );
+  }
+}
+
+export default App;

--- a/demo/components/group-demo.js
+++ b/demo/components/group-demo.js
@@ -49,21 +49,60 @@ class App extends React.Component {
     return (
       <div className="demo">
         <div style={containerStyle}>
+          <VictoryChart style={chartStyle}>
+            <VictoryStack colorScale="qualitative">
+              <VictoryGroup
+                data={[
+                  {x: 1, y: 3},
+                  {x: 2, y: 4},
+                  {x: 3, y: 2}
+                ]}
+              >
+                <VictoryArea/>
+                <VictoryScatter/>
+              </VictoryGroup>
+              <VictoryGroup
+                style={chartStyle}
+                colorScale="qualitative"
+                data={[
+                  {x: 1, y: 4},
+                  {x: 2, y: 5},
+                  {x: 3, y: 1}
+                ]}
+              >
+                <VictoryArea/>
+                <VictoryScatter/>
+              </VictoryGroup>
+              <VictoryGroup
+                style={chartStyle}
+                colorScale="qualitative"
+                data={[
+                  {x: 1, y: 1},
+                  {x: 2, y: 2},
+                  {x: 3, y: 5}
+                ]}
+              >
+                <VictoryArea/>
+                <VictoryScatter/>
+              </VictoryGroup>
+            </VictoryStack>
+          </VictoryChart>
 
-
-
+          <VictoryChart style={chartStyle}>
             <VictoryGroup
-              style={chartStyle}
+              colorScale={"qualitative"}
               data={[
                 {x: 1, y: 3},
                 {x: 2, y: 4},
-                {x: 3, y: 2}
+                {x: 3, y: 2},
+                {x: 4, y: 5}
               ]}
             >
-              <VictoryArea style={{data: {fill: "tomato"}}}/>
-              <VictoryScatter style={{data: {fill: "blue"}}}/>
+              <VictoryLine/>
+              <VictoryScatter/>
+              <VictoryBar/>
             </VictoryGroup>
-
+          </VictoryChart>
 
         </div>
       </div>

--- a/docs/app.js
+++ b/docs/app.js
@@ -22,6 +22,7 @@ const App = React.createClass({
           <li><Link to="/candlestick">Victory Candlestick Docs</Link></li>
           <li><Link to="/errorbar">Victory ErrorBar Docs</Link></li>
           <li><Link to="/theme">Victory Theme Docs</Link></li>
+          <li><Link to="/group">Victory Group Docs</Link></li>
         </ul>
         {this.props.children}
         <Style rules={VictoryTheme} />

--- a/docs/entry.js
+++ b/docs/entry.js
@@ -11,6 +11,7 @@ import ScatterDocs from "./victory-scatter/docs";
 import CandlestickDocs from "./victory-candlestick/docs";
 import ErrorBarDocs from "./victory-errorbar/docs";
 import ThemeDocs from "./victory-theme/docs";
+import GroupDocs from "./victory-group/docs";
 
 const content = document.getElementById("content");
 
@@ -26,6 +27,7 @@ ReactDOM.render((
       <Route path="candlestick" component={CandlestickDocs}/>
       <Route path="errorbar" component={ErrorBarDocs}/>
       <Route path="theme" component={ThemeDocs}/>
+      <Route path="group" component={GroupDocs}/>
     </Route>
   </Router>
 ), content);

--- a/docs/victory-area/ecology.md
+++ b/docs/victory-area/ecology.md
@@ -156,7 +156,7 @@ The sensible defaults VictoryArea provides makes it easy to get started, but eve
 
 ### Data Markers
 
-To create markers and labels for individual data points along an area, just compose VictoryArea with VictoryScatter. VictoryGroup can help!
+To create markers and labels for individual data points along an area, just compose VictoryArea with VictoryScatter. Use VictoryGroup for convenience.
 
 ```playground
 <VictoryGroup

--- a/docs/victory-area/ecology.md
+++ b/docs/victory-area/ecology.md
@@ -156,37 +156,28 @@ The sensible defaults VictoryArea provides makes it easy to get started, but eve
 
 ### Data Markers
 
-To create markers and labels for individual data points along an area, just compose VictoryArea with VictoryScatter.
+To create markers and labels for individual data points along an area, just compose VictoryArea with VictoryScatter. VictoryGroup can help!
 
 ```playground
-<svg height={300} width={500}>
+<VictoryGroup
+  style={{
+    data: {fill: "teal"}
+  }}
+  data={[
+    {x: 1, y: 3},
+    {x: 2, y: 2},      
+    {x: 3, y: 4},
+    {x: 4, y: 3},
+    {x: 5, y: 5}
+  ]}
+>
   <VictoryArea
-    width={500}
-    height={300}
-    standalone={false}
     style={{
-      data: {
-        fill: "teal",
-        opacity: 0.3
-      }
+      data: {opacity: 0.3}
     }}
-    data={[
-      {x: 0, y: 0},
-      {x: 1, y: 3},
-      {x: 2, y: 2},      
-      {x: 3, y: 4},
-      {x: 4, y: 3},
-      {x: 5, y: 5}
-    ]}
   />
   <VictoryScatter
-    width={500}
-    height={300}
-    standalone={false}
     style={{
-      data: {
-        fill: "teal",
-      },
       labels: {
         fill: "teal",
         fontSize: 14,
@@ -195,18 +186,10 @@ To create markers and labels for individual data points along an area, just comp
     }}
     size={4}
     labels={[
-     "a", "b", "c", "d", "e", "f"
-    ]}
-    data={[
-      {x: 0, y: 0},
-      {x: 1, y: 3},
-      {x: 2, y: 2},      
-      {x: 3, y: 4},
-      {x: 4, y: 3},
-      {x: 5, y: 5}
+     "a", "b", "c", "d", "e"
     ]}
   />
-</svg>
+</VictoryGroup>
 ```
 
 ### Events

--- a/docs/victory-group/docs.js
+++ b/docs/victory-group/docs.js
@@ -1,0 +1,33 @@
+import React from "react";
+import ReactDOM from "react-dom";
+import Ecology from "ecology";
+import { merge } from "lodash";
+import Radium from "radium";
+import * as docgen from "react-docgen";
+import {
+  VictoryLine, VictoryScatter, VictoryGroup, VictoryBar, VictoryChart, VictoryStack
+} from "../../src/index";
+import { appendLinkIcon, ecologyPlaygroundLoading } from "formidable-landers";
+
+class Docs extends React.Component {
+  render() {
+    return (
+      <div>
+        <Ecology
+          overview={require("!!raw!./ecology.md")}
+          source={docgen.parse(require("!!raw!../../src/components/victory-line/victory-line"))}
+          scope={{
+            React, ReactDOM, VictoryLine, VictoryScatter, VictoryGroup, VictoryBar,
+            VictoryChart, VictoryStack
+          }}
+          playgroundtheme="elegant"
+          customRenderers={merge(appendLinkIcon, ecologyPlaygroundLoading)}
+          exportGist
+          copyToClipboard
+        />
+      </div>
+    );
+  }
+}
+
+export default Radium(Docs);

--- a/docs/victory-group/ecology.md
+++ b/docs/victory-group/ecology.md
@@ -1,0 +1,136 @@
+VictoryGroup
+=============
+
+`VictoryGroup` is a helper for composing other victory components. It is useful for grouping several components together when they need to operate as a set. `VictoryGroup` provides some of the same functionality as `VictoryChart`-- reconciling the domain and range of its children, and coordiating shared events and animations. `VictoryGroup` also makes it convenient to create several components with the same data or shared styles. Grouped components may be used with `VictoryChart` and can be stacked as a set when nested within `VictoryStack`
+
+## Example: Grouped Bars
+
+Use `VictoryGroup` to group several `VictoryBar` components by x value. The `offset` prop on `VictoryGroup` controls the spacing between each series of bars in a group. Use the `colorScale` prop to automatically differentiate between each series.
+
+```playground
+<VictoryChart>
+  <VictoryGroup
+    offset={20}
+    colorScale={[
+      "tomato",
+      "gold",
+      "cyan"
+    ]}
+  >
+    <VictoryBar
+      data={[
+        {x: 1, y: 1},
+        {x: 2, y: 2},
+        {x: 3, y: 3}
+      ]}
+    />
+    <VictoryBar
+      data={[
+        {x: 1, y: 2},
+        {x: 2, y: 1},
+        {x: 3, y: 1}
+      ]}
+    />
+    <VictoryBar
+      data={[
+        {x: 1, y: 3},
+        {x: 2, y: 4},
+        {x: 3, y: 2}
+      ]}
+    />
+  </VictoryGroup>
+</VictoryChart>
+```
+
+
+## Example: Sharing Data and Styles
+
+`VictoryGroup` can be used to pass data and shared styles to several components. In the example below `VictoryLine` with `VictoryScatter` are used together to create a line with data markers and labels. `VictoryGroup` provides data and coordinates the domain and range of its two children.
+
+```playground
+<VictoryGroup
+  style={{
+    data: {
+      strokeWidth: 3,
+    }  
+  }}
+  data={[
+    {x: 1, y: 3},
+    {x: 2, y: 2},      
+    {x: 3, y: 4},
+    {x: 4, y: 3},
+    {x: 5, y: 5}
+  ]}
+>
+  <VictoryLine
+    interpolation={"cardinal"}
+    style={{
+      data: {
+        stroke: "#822722"
+      }  
+  }} 
+  />
+  <VictoryScatter
+    style={{
+      data: {
+        stroke: "white",
+        fill: "#822722"
+      },
+      labels: {
+        fill: "#822722",
+        fontSize: 18,
+        padding: 12
+      }
+    }}
+    size={6}
+    labels={[
+     "a", "b", "c", "d", "e"
+    ]}
+  />
+</VictoryGroup>
+```
+
+## Example: Stacking Sets of Components
+
+`VictoryGroup` can also be used within `VictoryStack`, allowing sets of components to be stacked together. In the example below, each stack contains `VictoryLine` and `VictoryBar` components
+
+```playground
+<VictoryStack
+  style={{
+    data: {strokeDasharray: "10, 5"}
+  }}
+  colorScale="qualitative"
+>
+  <VictoryGroup
+    data={[
+      {x: 1, y: 3},
+      {x: 2, y: 4},
+      {x: 3, y: 2}
+    ]}
+  >
+    <VictoryBar/>
+    <VictoryLine/>
+  </VictoryGroup>
+  <VictoryGroup
+    data={[
+      {x: 1, y: 4},
+      {x: 2, y: 5},
+      {x: 3, y: 1}
+    ]}
+  >
+    <VictoryBar/>
+    <VictoryLine/>
+  </VictoryGroup>
+  <VictoryGroup
+    data={[
+      {x: 1, y: 3},
+      {x: 2, y: 2},
+      {x: 3, y: 5}
+    ]}
+  >
+    <VictoryBar/>
+    <VictoryLine/>
+  </VictoryGroup>
+</VictoryStack>
+```
+

--- a/docs/victory-line/docs.js
+++ b/docs/victory-line/docs.js
@@ -4,7 +4,7 @@ import Ecology from "ecology";
 import { merge, random } from "lodash";
 import Radium from "radium";
 import * as docgen from "react-docgen";
-import { VictoryLine, VictoryScatter } from "../../src/index";
+import { VictoryLine, VictoryScatter, VictoryGroup } from "../../src/index";
 import { appendLinkIcon, ecologyPlaygroundLoading } from "formidable-landers";
 
 class Docs extends React.Component {
@@ -14,7 +14,7 @@ class Docs extends React.Component {
         <Ecology
           overview={require("!!raw!./ecology.md")}
           source={docgen.parse(require("!!raw!../../src/components/victory-line/victory-line"))}
-          scope={{ merge, random, React, ReactDOM, VictoryLine, VictoryScatter }}
+          scope={{ merge, random, React, ReactDOM, VictoryLine, VictoryScatter, VictoryGroup }}
           playgroundtheme="elegant"
           customRenderers={merge(appendLinkIcon, ecologyPlaygroundLoading)}
           exportGist

--- a/docs/victory-line/ecology.md
+++ b/docs/victory-line/ecology.md
@@ -89,7 +89,7 @@ Add labels, style the data, change the interpolation, add a custom domain:
 
 ### Data Markers
 
-To create markers and labels for individual data points along a line, just compose VictoryLine with VictoryScatter. VictoryGroup can help!
+To create markers and labels for individual data points along a line, just compose VictoryLine with VictoryScatter; you can use VictoryGroup to help with this.
 
 ```playground
 <VictoryGroup

--- a/docs/victory-line/ecology.md
+++ b/docs/victory-line/ecology.md
@@ -89,39 +89,32 @@ Add labels, style the data, change the interpolation, add a custom domain:
 
 ### Data Markers
 
-To create markers and labels for individual data points along a line, just compose VictoryLine with VictoryScatter.
+To create markers and labels for individual data points along a line, just compose VictoryLine with VictoryScatter. VictoryGroup can help!
 
 ```playground
-<svg height={300} width={500}>
+<VictoryGroup
+  style={{
+    data: {strokeWidth: 3}  
+  }}
+  data={[
+    {x: 1, y: 3},
+    {x: 2, y: 2},      
+    {x: 3, y: 4},
+    {x: 4, y: 3},
+    {x: 5, y: 5}
+  ]}
+>
   <VictoryLine
-    width={500}
-    height={300}
-    standalone={false}
     interpolation={"cardinal"}
     style={{
-      data: {
-        stroke: "#822722",
-        strokeWidth: 3
-      }
-    }}
-    data={[
-      {x: 0, y: 1},
-      {x: 1, y: 3},
-      {x: 2, y: 2},      
-      {x: 3, y: 4},
-      {x: 4, y: 3},
-      {x: 5, y: 5}
-    ]}
+      data: {stroke: "#822722"}
+    }} 
   />
   <VictoryScatter
-    width={500}
-    height={300}
-    standalone={false}
     style={{
       data: {
         fill: "#822722",
-        stroke: "white",
-        strokeWidth: 3
+        stroke: "white"
       },
       labels: {
         fill: "#822722",
@@ -131,18 +124,10 @@ To create markers and labels for individual data points along a line, just compo
     }}
     size={6}
     labels={[
-     "a", "b", "c", "d", "e", "f"
-    ]}
-    data={[
-      {x: 0, y: 1},
-      {x: 1, y: 3},
-      {x: 2, y: 2},      
-      {x: 3, y: 4},
-      {x: 4, y: 3},
-      {x: 5, y: 5}
+     "a", "b", "c", "d", "e"
     ]}
   />
-</svg>
+</VictoryGroup>
 ```
 
 ### Functional styles

--- a/docs/victory-theme/ecology.md
+++ b/docs/victory-theme/ecology.md
@@ -144,27 +144,23 @@ class App extends React.Component {
       }
     };
 
-    const data = [
-      {x: 1, y: 1},
-      {x: 2, y: 4},
-      {x: 3, y: 2},
-      {x: 4, y: 6},
-      {x: 5, y: 5},
-      {x: 6, y: 9}
-    ];
-
     return (
-      <svg style={{width: "100%", height: "100%"}} viewBox="0 25 350 300">
+      <VictoryGroup
+        data={[
+          {x: 1, y: 1},
+          {x: 2, y: 4},
+          {x: 3, y: 2},
+          {x: 4, y: 6},
+          {x: 5, y: 5},
+          {x: 6, y: 9}
+        ]}
+        theme={myTheme}
+      >
+        <VictoryLine/>
         <VictoryScatter
-          data={data}
-          theme={myTheme}
           labels={["1", "2", "3", "4", "5", "6"]}
         />
-        <VictoryLine
-          data={data}
-          theme={myTheme}
-        />
-      </svg>
+      </VictoryGroup>
     )
   }
 }

--- a/src/components/victory-area/area.js
+++ b/src/components/victory-area/area.js
@@ -25,8 +25,8 @@ export default class Area extends React.Component {
     const yScale = props.scale.y;
     const areaFunction = d3Shape.area()
       .curve(d3Shape[this.toNewName(props.interpolation)])
-      .x((data) => xScale(data.x))
-      .y1((data) => yScale(data.y1))
+      .x((data) => xScale(data.x1 || data.x))
+      .y1((data) => yScale(data.y1 || data.y))
       .y0((data) => yScale(data.y0));
     return areaFunction(props.data);
   }

--- a/src/components/victory-area/helper-methods.js
+++ b/src/components/victory-area/helper-methods.js
@@ -86,9 +86,9 @@ export default {
     const minY = Math.min(...domainY) > 0 ? Math.min(...domainY) : defaultMin;
 
     return data.map((datum) => {
-      const y1 = datum.yOffset ? datum.yOffset + datum.y : datum.y;
-      const y0 = datum.yOffset || minY;
-      return assign({y0, y1}, datum);
+      const y1 = datum.y;
+      const y0 = datum.y0 || minY;
+      return assign({}, datum, {y0, y1});
     });
   }
 };

--- a/src/components/victory-area/helper-methods.js
+++ b/src/components/victory-area/helper-methods.js
@@ -86,7 +86,7 @@ export default {
     const minY = Math.min(...domainY) > 0 ? Math.min(...domainY) : defaultMin;
 
     return data.map((datum) => {
-      const y1 = datum.y;
+      const y1 = datum.y1 || datum.y;
       const y0 = datum.y0 || minY;
       return assign({}, datum, {y0, y1});
     });

--- a/src/components/victory-bar/helper-methods.js
+++ b/src/components/victory-bar/helper-methods.js
@@ -35,18 +35,15 @@ export default {
   getBarPosition(props, datum, scale) {
     const defaultMin = Scale.getType(scale.y) === "log" ?
       1 / Number.MAX_SAFE_INTEGER : 0;
-    const yOffset = datum.yOffset || 0;
-    const xOffset = datum.xOffset || 0;
-    const y0 = yOffset || defaultMin;
-    const y = datum.y + yOffset;
-    const x = datum.x + xOffset;
+
+    const y0 = datum.y0 || defaultMin;
     const formatValue = (value, axis) => {
       return datum[axis] instanceof Date ? new Date(value) : value;
     };
     return {
-      x: scale.x(formatValue(x, "x")),
+      x: scale.x(formatValue(datum.x, "x")),
       y0: scale.y(formatValue(y0, "y")),
-      y: scale.y(formatValue(y, "y"))
+      y: scale.y(formatValue(datum.y, "y"))
     };
   },
 

--- a/src/components/victory-bar/helper-methods.js
+++ b/src/components/victory-bar/helper-methods.js
@@ -41,9 +41,9 @@ export default {
       return datum[axis] instanceof Date ? new Date(value) : value;
     };
     return {
-      x: scale.x(formatValue(datum.x, "x")),
+      x: scale.x(formatValue(datum.x1 || datum.x, "x")),
       y0: scale.y(formatValue(y0, "y")),
-      y: scale.y(formatValue(datum.y, "y"))
+      y: scale.y(formatValue(datum.y1 || datum.y, "y"))
     };
   },
 

--- a/src/components/victory-candlestick/helper-methods.js
+++ b/src/components/victory-candlestick/helper-methods.js
@@ -13,7 +13,7 @@ export default {
     for (let index = 0, len = data.length; index < len; index++) {
       const datum = data[index];
       const eventKey = datum.eventKey || index;
-      const x = scale.x(datum.x);
+      const x = scale.x(datum.x1 || datum.x);
       const y1 = scale.y(datum.high);
       const y2 = scale.y(datum.low);
       const candleHeight = Math.abs(scale.y(datum.open) - scale.y(datum.close));

--- a/src/components/victory-errorbar/helper-methods.js
+++ b/src/components/victory-errorbar/helper-methods.js
@@ -15,8 +15,8 @@ export default {
     for (let index = 0, len = data.length; index < len; index++) {
       const datum = data[index];
       const eventKey = datum.eventKey || index;
-      const x = scale.x(datum.x);
-      const y = scale.y(datum.y);
+      const x = scale.x(datum.x1 || datum.x);
+      const y = scale.y(datum.y1 || datum.y);
 
       const dataProps = {
         x, y, scale, datum, index, groupComponent, borderWidth,

--- a/src/components/victory-group/victory-group.js
+++ b/src/components/victory-group/victory-group.js
@@ -439,7 +439,7 @@ export default class VictoryGroup extends React.Component {
   addOffset(dataset, offset) {
     const xOffset = offset || 0;
     return dataset.map((datum) => {
-      return assign({}, datum, {x: datum.x + xOffset})
+      return assign({}, datum, {x1: datum.x + xOffset});
     });
   }
 

--- a/src/components/victory-group/victory-group.js
+++ b/src/components/victory-group/victory-group.js
@@ -5,6 +5,7 @@ import { PropTypes as CustomPropTypes, Helpers, VictorySharedEvents,
 } from "victory-core";
 import Scale from "../../helpers/scale";
 import Axis from "../../helpers/axis";
+import Data from "../../helpers/data";
 import Wrapper from "../../helpers/wrapper";
 
 const fallbackProps = {
@@ -69,6 +70,15 @@ export default class VictoryGroup extends React.Component {
         "greyscale", "qualitative", "heatmap", "warm", "cool", "red", "green", "blue"
       ])
     ]),
+    /**
+     * The data prop specifies the data to be plotted. Data should be in the form of an array
+     * of data points. Each data point may be any format you wish
+     * (depending on the `x` and `y` accessor props), but by default, an object
+     * with x and y properties is expected.
+     * @examples [{x: 1, y: 2}, {x: 2, y: 3}], [[1, 2], [2, 3]],
+     * [[{x: "a", y: 1}, {x: "b", y: 2}], [{x: "a", y: 2}, {x: "b", y: 3}]]
+     */
+    data: PropTypes.array,
     /**
      * The domain prop describes the range of values your chart will include. This prop can be
      * given as a array of the minimum and maximum expected values for your chart,
@@ -259,6 +269,38 @@ export default class VictoryGroup extends React.Component {
      */
     width: CustomPropTypes.nonNegative,
     /**
+     * The x prop specifies how to access the X value of each data point.
+     * If given as a function, it will be run on each data point, and returned value will be used.
+     * If given as an integer, it will be used as an array index for array-type data points.
+     * If given as a string, it will be used as a property key for object-type data points.
+     * If given as an array of strings, or a string containing dots or brackets,
+     * it will be used as a nested object property path (for details see Lodash docs for _.get).
+     * If `null` or `undefined`, the data value will be used as is (identity function/pass-through).
+     * @examples 0, 'x', 'x.value.nested.1.thing', 'x[2].also.nested', null, d => Math.sin(d)
+     */
+    x: PropTypes.oneOfType([
+      PropTypes.func,
+      CustomPropTypes.allOfType([CustomPropTypes.integer, CustomPropTypes.nonNegative]),
+      PropTypes.string,
+      PropTypes.arrayOf(PropTypes.string)
+    ]),
+    /**
+     * The y prop specifies how to access the Y value of each data point.
+     * If given as a function, it will be run on each data point, and returned value will be used.
+     * If given as an integer, it will be used as an array index for array-type data points.
+     * If given as a string, it will be used as a property key for object-type data points.
+     * If given as an array of strings, or a string containing dots or brackets,
+     * it will be used as a nested object property path (for details see Lodash docs for _.get).
+     * If `null` or `undefined`, the data value will be used as is (identity function/pass-through).
+     * @examples 0, 'y', 'y.value.nested.1.thing', 'y[2].also.nested', null, d => Math.sin(d)
+     */
+    y: PropTypes.oneOfType([
+      PropTypes.func,
+      CustomPropTypes.allOfType([CustomPropTypes.integer, CustomPropTypes.nonNegative]),
+      PropTypes.string,
+      PropTypes.arrayOf(PropTypes.string)
+    ]),
+    /**
      * The containerComponent prop takes an entire component which will be used to
      * create a container element for standalone charts.
      * The new element created from the passed containerComponent wil be provided with
@@ -296,7 +338,9 @@ export default class VictoryGroup extends React.Component {
     standalone: true,
     containerComponent: <VictoryContainer/>,
     groupComponent: <g/>,
-    theme: VictoryTheme.grayscale
+    theme: VictoryTheme.grayscale,
+    x: "x",
+    y: "y"
   };
 
   static getDomain = Wrapper.getDomain.bind(Wrapper);
@@ -388,12 +432,15 @@ export default class VictoryGroup extends React.Component {
     if (role !== "group-wrapper" && role !== "stack-wrapper") {
       return undefined;
     }
-    return props.theme ? colorScaleOptions || props.theme.props.colorScale
+    return props.theme && props.theme.group ? colorScaleOptions || props.theme.group.colorScale
     : colorScaleOptions;
   }
 
-  addOffset(dataset, xOffset) {
-    return dataset.map((datum) => assign({}, datum, {xOffset}));
+  addOffset(dataset, offset) {
+    const xOffset = offset || 0;
+    return dataset.map((datum) => {
+      return assign({}, datum, {x: datum.x + xOffset})
+    });
   }
 
   // the old ones were bad
@@ -403,9 +450,10 @@ export default class VictoryGroup extends React.Component {
     const getAnimationProps = Wrapper.getAnimationProps.bind(this);
     const newChildren = [];
     for (let index = 0, len = childComponents.length; index < len; index++) {
+      const dataset = props.data ? Data.getData(props) : datasets[index];
       const child = childComponents[index];
       const xOffset = this.getXO(props, calculatedProps, datasets, index);
-      const data = this.addOffset(datasets[index], xOffset);
+      const data = this.addOffset(dataset, xOffset);
       const style = Wrapper.getChildStyle(child, index, calculatedProps);
       const labels = props.labels ? this.getLabels(props, datasets, index) : child.props.labels;
       const defaultDomainPadding = horizontal ?

--- a/src/components/victory-line/helper-methods.js
+++ b/src/components/victory-line/helper-methods.js
@@ -26,8 +26,8 @@ export default {
     const labelStyle = this.getLabelStyle(baseLabelStyle, dataStyle);
 
     const labelProps = {
-      x: lastData ? scale.x(lastData.x) + (labelStyle.padding || 0) : 0,
-      y: lastData ? scale.y(lastData.y) : 0,
+      x: lastData ? scale.x(lastData.x1 || lastData.x) + (labelStyle.padding || 0) : 0,
+      y: lastData ? scale.y(lastData.y1 || lastData.y) : 0,
       style: labelStyle,
       textAnchor: labelStyle.textAnchor || "start",
       verticalAnchor: labelStyle.verticalAnchor || "middle",

--- a/src/components/victory-line/line-segment.js
+++ b/src/components/victory-line/line-segment.js
@@ -40,8 +40,8 @@ export default class LineSegment extends React.Component {
     const yScale = scale.y;
     const lineFunction = d3Shape.line()
       .curve(d3Shape[this.toNewName(interpolation)])
-      .x((d) => xScale(d.x))
-      .y((d) => yScale(d.y));
+      .x((d) => xScale(d.x1 || d.x))
+      .y((d) => yScale(d.y1 || d.y));
     const lineStyle = assign({fill: "none", stroke: "black"}, style);
     return this.renderLine(lineFunction(data), lineStyle, events);
   }

--- a/src/components/victory-scatter/helper-methods.js
+++ b/src/components/victory-scatter/helper-methods.js
@@ -15,8 +15,8 @@ export default {
     for (let index = 0, len = data.length; index < len; index++) {
       const datum = data[index];
       const eventKey = datum.eventKey;
-      const x = scale.x(datum.x);
-      const y = scale.y(datum.y);
+      const x = scale.x(datum.x1 || datum.x);
+      const y = scale.y(datum.y1 || datum.y);
       const dataProps = {
         x, y, datum, index, scale,
         size: this.getSize(datum, props, calculatedValues),

--- a/src/components/victory-stack/victory-stack.js
+++ b/src/components/victory-stack/victory-stack.js
@@ -340,8 +340,8 @@ export default class VictoryStack extends React.Component {
       const yOffset = Wrapper.getY0(datum, index, calculatedProps) || 0;
       return assign({}, datum, {
         y0: yOffset,
-        y: datum.y + yOffset,
-        x: datum.x + xOffset
+        y1: datum.y + yOffset,
+        x1: datum.x + xOffset
       });
     });
   }

--- a/src/components/victory-stack/victory-stack.js
+++ b/src/components/victory-stack/victory-stack.js
@@ -335,10 +335,13 @@ export default class VictoryStack extends React.Component {
   }
 
   addLayoutData(props, calculatedProps, datasets, index) { // eslint-disable-line max-params
+    const xOffset = props.xOffset || 0;
     return datasets[index].map((datum) => {
-      return assign(datum, {
-        yOffset: Wrapper.getY0(datum, index, calculatedProps),
-        xOffset: props.xOffset
+      const yOffset = Wrapper.getY0(datum, index, calculatedProps) || 0;
+      return assign({}, datum, {
+        y0: yOffset,
+        y: datum.y + yOffset,
+        x: datum.x + xOffset
       });
     });
   }

--- a/src/helpers/wrapper.js
+++ b/src/helpers/wrapper.js
@@ -152,6 +152,9 @@ export default {
       return style.data.fill;
     }
     colorScale = child.props && child.props.colorScale ? child.props.colorScale : colorScale;
+    if (!colorScale) {
+      return undefined;
+    }
     const colors = Array.isArray(colorScale) ?
       colorScale : Style.getColorScale(colorScale);
     return colors[index % colors.length];

--- a/src/helpers/wrapper.js
+++ b/src/helpers/wrapper.js
@@ -16,6 +16,8 @@ export default {
     const propsDomain = Domain.getDomainFromProps(props, axis);
     if (propsDomain) {
       return propsDomain;
+    } else if (props.data) {
+      return Domain.getDomain(props, axis);
     }
     childComponents = childComponents || React.Children.toArray(props.children);
     return Domain.cleanDomain(this.getDomainFromChildren(props, axis, childComponents),
@@ -113,8 +115,7 @@ export default {
     const getChildData = (children) => {
       return children.map((child) => {
         if (child.type && isFunction(child.type.getData)) {
-          const childData = child.props && child.type.getData(child.props);
-          return childData;
+          return child.props && child.type.getData(child.props);
         } else if (child.props && child.props.children) {
           return flatten(getChildData(React.Children.toArray(child.props.children)));
         }

--- a/test/client/spec/components/victory-area/helper-methods.spec.js
+++ b/test/client/spec/components/victory-area/helper-methods.spec.js
@@ -20,7 +20,7 @@ describe("victory-area/helper-methods", () => {
       {x: 1, y: 1}, {x: 2, y: 1}
     ];
     const stackedData = [
-      {x: 1, y: 1, yOffset: 1}, {x: 2, y: 1, yOffset: 1}
+      {x: 1, y: 1, y0: 1, y1: 2}, {x: 2, y: 1, y0: 1, y1: 2}
     ];
     const defaultDomain = {x: [0, 10], y: [0, 10]};
     const nonZeroDomain = {x: [0, 10], y: [1, 10]};
@@ -56,9 +56,7 @@ describe("victory-area/helper-methods", () => {
     it("should return yOffset if present", () => {
       const props = {data: stackedData};
       const result = AreaHelpers.getDataWithBaseline(props, scale(defaultDomain));
-      const expectedResult = [
-        {y0: 1, y1: 2, x: 1, y: 1, yOffset: 1}, {y0: 1, y1: 2, x: 2, y: 1, yOffset: 1}
-      ];
+      const expectedResult = stackedData;
       expect(result).to.eql(expectedResult);
     });
   });


### PR DESCRIPTION
Closes # 296
This PR adds the ability to groups several components, and provide them with the same data and style them together. This is helpful in grouping VictoryLine with VictoryScatter to provide data markers for example. This PR also adds functionality for stacking any component type (except VictoryCandleStick which has unusual y data)

- [x] Add docs about how to use `VictoryGroup` enhancements.

Example usage: 

```
<VictoryChart style={chartStyle} domainPadding={20}>
  <VictoryStack
    style={{
      data: {strokeDasharray: "10, 5"}
    }}
    colorScale="qualitative"
  >
    <VictoryGroup
      data={[
        {x: 1, y: 3},
        {x: 2, y: 4},
        {x: 3, y: 2}
      ]}
      style={{
        data: {width: 40, opacity: 0.6}
      }}
    >
      <VictoryBar/>
      <VictoryLine/>
    </VictoryGroup>
    <VictoryGroup
      data={[
        {x: 1, y: 4},
        {x: 2, y: 5},
        {x: 3, y: 1}
      ]}
      style={{
        data: {width: 20, opacity: 0.8}
      }}
    >
      <VictoryBar/>
      <VictoryLine/>
    </VictoryGroup>
    <VictoryGroup
      data={[
        {x: 1, y: 3},
        {x: 2, y: 2},
        {x: 3, y: 5}
      ]}
      style={{
        data: {width: 10, opacity: 1}
      }}
    >
      <VictoryBar/>
      <VictoryLine/>
      <VictoryScatter
        symbol={"plus"}
        size={10}
        style={{
          data: {fill: "tomato"}
        }}
      />
    </VictoryGroup>
  </VictoryStack>
</VictoryChart>
```
![screen shot 2016-08-24 at 1 51 22 pm](https://cloud.githubusercontent.com/assets/3719995/17947546/fc552dbe-6a01-11e6-8b89-9cb7c645c6b7.png)
