### PR TITLE
Task optimize performance with labels

### DIFF
--- a/src/components/victory-area/helper-methods.js
+++ b/src/components/victory-area/helper-methods.js
@@ -20,12 +20,28 @@ export default {
       style: Helpers.evaluateStyle(style.data, data)
     };
 
+    const baseProps = {
+      parent: { style: style.parent, width, height, scale, data },
+      all: {
+        data: dataProps
+      }
+    };
+
     const text = Helpers.evaluateProp(label, data);
+    if (text || props.events) {
+      baseProps.all.labels = this.getLabelProps(dataProps, text, style);
+    }
+
+    return baseProps;
+  },
+
+  getLabelProps(dataProps, text, calculatedStyle) {
+    const { data, scale } = dataProps;
     const lastData = last(data);
-    const labelStyle = Helpers.evaluateStyle(style.labels, data) || {};
+    const labelStyle = Helpers.evaluateStyle(calculatedStyle.labels, data) || {};
     const labelPadding = labelStyle.padding || 0;
 
-    const labelProps = {
+    return {
       key: "area-label",
       x: lastData ? scale.x(lastData.x) + labelPadding : 0,
       y: lastData ? scale.y(lastData.y1) : 0,
@@ -37,14 +53,6 @@ export default {
       data,
       scale,
       text
-    };
-
-    return {
-      parent: {style: style.parent, width, height, scale, data},
-      all: {
-        data: dataProps,
-        labels: labelProps
-      }
     };
   },
 

--- a/src/components/victory-area/helper-methods.js
+++ b/src/components/victory-area/helper-methods.js
@@ -28,7 +28,7 @@ export default {
     };
 
     const text = Helpers.evaluateProp(label, data);
-    if (text || props.events) {
+    if (text || props.events || props.sharedEvents) {
       baseProps.all.labels = this.getLabelProps(dataProps, text, style);
     }
 

--- a/src/components/victory-area/victory-area.js
+++ b/src/components/victory-area/victory-area.js
@@ -424,10 +424,7 @@ export default class VictoryArea extends React.Component {
       {}, dataProps, {events: Events.getPartialEvents(dataEvents, "all", dataProps)}
     ));
 
-    const shouldGetLabelProps = (this.baseProps.all.labels && this.baseProps.all.labels.text)
-      || this.props.events;
-
-    if (shouldGetLabelProps) {
+    if (this.baseProps.all.labels || this.props.events) {
       const labelProps = defaults(
         {},
         this.getEventState("all", "labels"),
@@ -435,11 +432,13 @@ export default class VictoryArea extends React.Component {
         labelComponent.props,
         this.baseProps.all.labels
       );
-      const labelEvents = this.getEvents(props, "labels", "all");
-      const areaLabel = React.cloneElement(labelComponent, assign({
-        events: Events.getPartialEvents(labelEvents, "all", labelProps)
-      }, labelProps));
-      return React.cloneElement(groupComponent, {}, areaComponent, areaLabel);
+      if (labelProps && labelProps.text) {
+        const labelEvents = this.getEvents(props, "labels", "all");
+        const areaLabel = React.cloneElement(labelComponent, assign({
+          events: Events.getPartialEvents(labelEvents, "all", labelProps)
+        }, labelProps));
+        return React.cloneElement(groupComponent, {}, areaComponent, areaLabel);
+      }
     }
     return areaComponent;
   }

--- a/src/components/victory-area/victory-area.js
+++ b/src/components/victory-area/victory-area.js
@@ -424,7 +424,7 @@ export default class VictoryArea extends React.Component {
       {}, dataProps, {events: Events.getPartialEvents(dataEvents, "all", dataProps)}
     ));
 
-    if (this.baseProps.all.labels || this.props.events) {
+    if (this.baseProps.all.labels || this.props.events || this.props.sharedEvents) {
       const labelProps = defaults(
         {},
         this.getEventState("all", "labels"),

--- a/src/components/victory-area/victory-area.js
+++ b/src/components/victory-area/victory-area.js
@@ -424,14 +424,17 @@ export default class VictoryArea extends React.Component {
       {}, dataProps, {events: Events.getPartialEvents(dataEvents, "all", dataProps)}
     ));
 
-    const labelProps = defaults(
+    const shouldGetLabelProps = (this.baseProps.all.labels && this.baseProps.all.labels.text)
+      || this.props.events;
+
+    if (shouldGetLabelProps) {
+      const labelProps = defaults(
         {},
         this.getEventState("all", "labels"),
         this.getSharedEventState("all", "labels"),
         labelComponent.props,
         this.baseProps.all.labels
       );
-    if (labelProps && labelProps.text) {
       const labelEvents = this.getEvents(props, "labels", "all");
       const areaLabel = React.cloneElement(labelComponent, assign({
         events: Events.getPartialEvents(labelEvents, "all", labelProps)

--- a/src/components/victory-bar/helper-methods.js
+++ b/src/components/victory-bar/helper-methods.js
@@ -124,28 +124,34 @@ export default {
         position
       );
 
-      const labelStyle = this.getLabelStyle(style.labels, datum);
-      const labelPadding = this.getlabelPadding(labelStyle, datum, horizontal);
-      const anchors = this.getLabelAnchors(datum, horizontal);
-      const labelProps = {
-        style: labelStyle,
-        x: horizontal ? position.y + labelPadding.x : position.x + labelPadding.x,
-        y: horizontal ? position.x + labelPadding.y : position.y - labelPadding.y,
-        y0: position.y0,
-        text: this.getLabel(props, datum, index),
-        index,
-        scale,
-        datum: dataProps.datum,
-        textAnchor: labelStyle.textAnchor || anchors.text,
-        verticalAnchor: labelStyle.verticalAnchor || anchors.vertical,
-        angle: labelStyle.angle
-      };
-
       childProps[eventKey] = {
-        data: dataProps,
-        labels: labelProps
+        data: dataProps
       };
+      const text = this.getLabel(props, datum, index);
+      if (text || props.events) {
+        childProps[eventKey].labels = this.getLabelProps(dataProps, text, style);
+      }
     }
     return childProps;
+  },
+
+  getLabelProps(dataProps, text, calculatedStyle) {
+    const { datum, horizontal, x, y, y0, index, scale } = dataProps;
+    const labelStyle = this.getLabelStyle(calculatedStyle.labels, datum);
+    const labelPadding = this.getlabelPadding(labelStyle, datum, horizontal);
+    const anchors = this.getLabelAnchors(datum, horizontal);
+    return {
+      style: labelStyle,
+      x: horizontal ? y + labelPadding.x : x + labelPadding.x,
+      y: horizontal ? x + labelPadding.y : y - labelPadding.y,
+      y0,
+      text,
+      index,
+      scale,
+      datum,
+      textAnchor: labelStyle.textAnchor || anchors.text,
+      verticalAnchor: labelStyle.verticalAnchor || anchors.vertical,
+      angle: labelStyle.angle
+    };
   }
 };

--- a/src/components/victory-bar/helper-methods.js
+++ b/src/components/victory-bar/helper-methods.js
@@ -64,9 +64,8 @@ export default {
   },
 
   getLabel(props, datum, index) {
-    const propsLabel = Array.isArray(props.labels) ?
-      props.labels[index] : Helpers.evaluateProp(props.labels, datum);
-    return datum.label || propsLabel;
+    return datum.label || (Array.isArray(props.labels) ?
+      props.labels[index] : Helpers.evaluateProp(props.labels, datum));
   },
 
   getLabelAnchors(datum, horizontal) {

--- a/src/components/victory-bar/helper-methods.js
+++ b/src/components/victory-bar/helper-methods.js
@@ -128,7 +128,7 @@ export default {
         data: dataProps
       };
       const text = this.getLabel(props, datum, index);
-      if (text || props.events) {
+      if (text || props.events || props.sharedEvents) {
         childProps[eventKey].labels = this.getLabelProps(dataProps, text, style);
       }
     }

--- a/src/components/victory-bar/victory-bar.js
+++ b/src/components/victory-bar/victory-bar.js
@@ -408,7 +408,7 @@ export default class VictoryBar extends React.Component {
         {}, dataProps, {events: Events.getPartialEvents(dataEvents, key, dataProps)}
       ));
 
-      if (this.baseProps[key].label || this.props.events) {
+      if (this.baseProps[key].labels || this.props.events) {
         const labelProps = defaults(
           {index, key: `${role}-label-${key}`},
           this.getEventState(key, "labels"),

--- a/src/components/victory-bar/victory-bar.js
+++ b/src/components/victory-bar/victory-bar.js
@@ -408,7 +408,7 @@ export default class VictoryBar extends React.Component {
         {}, dataProps, {events: Events.getPartialEvents(dataEvents, key, dataProps)}
       ));
 
-      if (this.baseProps[key].labels || this.props.events) {
+      if (this.baseProps[key].labels || this.props.events || this.props.sharedEvents) {
         const labelProps = defaults(
           {index, key: `${role}-label-${key}`},
           this.getEventState(key, "labels"),

--- a/src/components/victory-bar/victory-bar.js
+++ b/src/components/victory-bar/victory-bar.js
@@ -408,10 +408,7 @@ export default class VictoryBar extends React.Component {
         {}, dataProps, {events: Events.getPartialEvents(dataEvents, key, dataProps)}
       ));
 
-      const shouldGetLabelProps = (this.baseProps[key].labels && this.baseProps[key].labels.text)
-        || this.props.events;
-
-      if (shouldGetLabelProps) {
+      if (this.baseProps[key].label || this.props.events) {
         const labelProps = defaults(
           {index, key: `${role}-label-${key}`},
           this.getEventState(key, "labels"),
@@ -419,10 +416,12 @@ export default class VictoryBar extends React.Component {
           labelComponent.props,
           this.baseProps[key].labels
         );
-        const labelEvents = this.getEvents(props, "labels", key);
-        barLabelComponents[index] = React.cloneElement(labelComponent, assign({
-          events: Events.getPartialEvents(labelEvents, key, labelProps)
-        }, labelProps));
+        if (labelProps && labelProps.text) {
+          const labelEvents = this.getEvents(props, "labels", key);
+          barLabelComponents[index] = React.cloneElement(labelComponent, assign({
+            events: Events.getPartialEvents(labelEvents, key, labelProps)
+          }, labelProps));
+        }
       }
     }
     return barLabelComponents.length > 0 ?

--- a/src/components/victory-bar/victory-bar.js
+++ b/src/components/victory-bar/victory-bar.js
@@ -408,15 +408,17 @@ export default class VictoryBar extends React.Component {
         {}, dataProps, {events: Events.getPartialEvents(dataEvents, key, dataProps)}
       ));
 
-      const labelProps = defaults(
-        {index, key: `${role}-label-${key}`},
-        this.getEventState(key, "labels"),
-        this.getSharedEventState(key, "labels"),
-        labelComponent.props,
-        this.baseProps[key].labels
-      );
+      const shouldGetLabelProps = (this.baseProps[key].labels && this.baseProps[key].labels.text)
+        || this.props.events;
 
-      if (labelProps && labelProps.text) {
+      if (shouldGetLabelProps) {
+        const labelProps = defaults(
+          {index, key: `${role}-label-${key}`},
+          this.getEventState(key, "labels"),
+          this.getSharedEventState(key, "labels"),
+          labelComponent.props,
+          this.baseProps[key].labels
+        );
         const labelEvents = this.getEvents(props, "labels", key);
         barLabelComponents[index] = React.cloneElement(labelComponent, assign({
           events: Events.getPartialEvents(labelEvents, key, labelProps)

--- a/src/components/victory-candlestick/helper-methods.js
+++ b/src/components/victory-candlestick/helper-methods.js
@@ -24,26 +24,32 @@ export default {
         index, style: dataStyle, padding, width
       };
 
-      const text = this.getLabelText(props, datum, index);
-      const labelStyle = this.getLabelStyle(style.labels, dataProps) || {};
-      const labelProps = {
-        style: labelStyle,
-        x: x - (labelStyle.padding || 0),
-        y: y - (labelStyle.padding || 0),
-        text,
-        index,
-        scale,
-        datum: dataProps.datum,
-        textAnchor: labelStyle.textAnchor,
-        verticalAnchor: labelStyle.verticalAnchor || "end",
-        angle: labelStyle.angle
-      };
       childProps[eventKey] = {
-        data: dataProps,
-        labels: labelProps
+        data: dataProps
       };
+      const text = this.getLabelText(props, datum, index);
+      if (text || props.events) {
+        childProps[eventKey].labels = this.getLabelProps(dataProps, text, style);
+      }
     }
     return childProps;
+  },
+
+  getLabelProps(dataProps, text, calculatedStyle) {
+    const {x, y, index, scale, datum } = dataProps;
+    const labelStyle = this.getLabelStyle(calculatedStyle.labels, dataProps) || {};
+    return {
+      style: labelStyle,
+      x: x - (labelStyle.padding || 0),
+      y: y - (labelStyle.padding || 0),
+      text,
+      index,
+      scale,
+      datum,
+      textAnchor: labelStyle.textAnchor,
+      verticalAnchor: labelStyle.verticalAnchor || "end",
+      angle: labelStyle.angle
+    };
   },
 
   getCalculatedValues(props) {

--- a/src/components/victory-candlestick/helper-methods.js
+++ b/src/components/victory-candlestick/helper-methods.js
@@ -144,9 +144,8 @@ export default {
   },
 
   getLabelText(props, datum, index) {
-    const propsLabel = Array.isArray(props.labels) ?
-      props.labels[index] : Helpers.evaluateProp(props.labels, datum);
-    return datum.label || propsLabel;
+    return datum.label || (Array.isArray(props.labels) ?
+      props.labels[index] : Helpers.evaluateProp(props.labels, datum));
   },
 
   getLabelStyle(labelStyle, dataProps) {

--- a/src/components/victory-candlestick/helper-methods.js
+++ b/src/components/victory-candlestick/helper-methods.js
@@ -28,7 +28,7 @@ export default {
         data: dataProps
       };
       const text = this.getLabelText(props, datum, index);
-      if (text || props.events) {
+      if (text || props.events || props.sharedEvents) {
         childProps[eventKey].labels = this.getLabelProps(dataProps, text, style);
       }
     }

--- a/src/components/victory-candlestick/victory-candlestick.js
+++ b/src/components/victory-candlestick/victory-candlestick.js
@@ -468,10 +468,7 @@ export default class VictoryCandlestick extends React.Component {
         {}, dataProps, {events: Events.getPartialEvents(dataEvents, key, dataProps)}
       ));
 
-      const shouldGetLabelProps = (this.baseProps[key].labels && this.baseProps[key].labels.text)
-        || this.props.events;
-
-      if (shouldGetLabelProps) {
+      if (this.baseProps[key].labels || this.props.events) {
         const labelProps = defaults(
           {key: `${role}-label-${key}`, index},
           this.getEventState(key, "labels"),
@@ -479,10 +476,12 @@ export default class VictoryCandlestick extends React.Component {
           this.baseProps[key].labels,
           labelComponent.props
         );
-        const labelEvents = this.getEvents(props, "labels", key);
-        candleLabelComponents[index] = React.cloneElement(labelComponent, assign({
-          events: Events.getPartialEvents(labelEvents, key, labelProps)
-        }, labelProps));
+        if (labelProps && labelProps.text) {
+          const labelEvents = this.getEvents(props, "labels", key);
+          candleLabelComponents[index] = React.cloneElement(labelComponent, assign({
+            events: Events.getPartialEvents(labelEvents, key, labelProps)
+          }, labelProps));
+        }
       }
     }
 

--- a/src/components/victory-candlestick/victory-candlestick.js
+++ b/src/components/victory-candlestick/victory-candlestick.js
@@ -468,15 +468,17 @@ export default class VictoryCandlestick extends React.Component {
         {}, dataProps, {events: Events.getPartialEvents(dataEvents, key, dataProps)}
       ));
 
-      const labelProps = defaults(
-        {key: `${role}-label-${key}`, index},
-        this.getEventState(key, "labels"),
-        this.getSharedEventState(key, "labels"),
-        this.baseProps[key].labels,
-        labelComponent.props
-      );
+      const shouldGetLabelProps = (this.baseProps[key].labels && this.baseProps[key].labels.text)
+        || this.props.events;
 
-      if (labelProps && labelProps.text) {
+      if (shouldGetLabelProps) {
+        const labelProps = defaults(
+          {key: `${role}-label-${key}`, index},
+          this.getEventState(key, "labels"),
+          this.getSharedEventState(key, "labels"),
+          this.baseProps[key].labels,
+          labelComponent.props
+        );
         const labelEvents = this.getEvents(props, "labels", key);
         candleLabelComponents[index] = React.cloneElement(labelComponent, assign({
           events: Events.getPartialEvents(labelEvents, key, labelProps)

--- a/src/components/victory-candlestick/victory-candlestick.js
+++ b/src/components/victory-candlestick/victory-candlestick.js
@@ -468,7 +468,7 @@ export default class VictoryCandlestick extends React.Component {
         {}, dataProps, {events: Events.getPartialEvents(dataEvents, key, dataProps)}
       ));
 
-      if (this.baseProps[key].labels || this.props.events) {
+      if (this.baseProps[key].labels || this.props.events || this.props.sharedEvents) {
         const labelProps = defaults(
           {key: `${role}-label-${key}`, index},
           this.getEventState(key, "labels"),

--- a/src/components/victory-errorbar/helper-methods.js
+++ b/src/components/victory-errorbar/helper-methods.js
@@ -28,7 +28,7 @@ export default {
         data: dataProps
       };
       const text = this.getLabelText(props, datum, index);
-      if (text || props.events) {
+      if (text || props.events || props.sharedEvents) {
         childProps[eventKey].labels = this.getLabelProps(dataProps, text, style);
       }
     }

--- a/src/components/victory-errorbar/helper-methods.js
+++ b/src/components/victory-errorbar/helper-methods.js
@@ -192,9 +192,8 @@ export default {
   },
 
   getLabelText(props, datum, index) {
-    const propsLabel = Array.isArray(props.labels) ?
-      props.labels[index] : Helpers.evaluateProp(props.labels, datum);
-    return datum.label || propsLabel;
+    return datum.label || (Array.isArray(props.labels) ?
+      props.labels[index] : Helpers.evaluateProp(props.labels, datum));
   },
 
   getLabelStyle(labelStyle, dataProps) {

--- a/src/components/victory-errorbar/helper-methods.js
+++ b/src/components/victory-errorbar/helper-methods.js
@@ -8,8 +8,7 @@ import Data from "../../helpers/data";
 export default {
   getBaseProps(props, fallbackProps) {
     props = Helpers.modifyProps(props, fallbackProps, "errorbar");
-    const calculatedValues = this.getCalculatedValues(props, fallbackProps);
-    const { data, style, scale } = calculatedValues;
+    const { data, style, scale } = this.getCalculatedValues(props, fallbackProps);
     const { groupComponent, height, width, borderWidth } = props;
     const childProps = { parent: {style: style.parent, scale, data, height, width} };
     for (let index = 0, len = data.length; index < len; index++) {
@@ -25,26 +24,32 @@ export default {
         errorY: this.getErrors(datum, scale, "y")
       };
 
-      const labelStyle = this.getLabelStyle(style.labels, dataProps) || {};
-      const labelProps = {
-        style: labelStyle,
-        x: x - (labelStyle.padding || 0),
-        y: y - (labelStyle.padding || 0),
-        text: this.getLabelText(props, datum, index),
-        index,
-        scale,
-        datum: dataProps.datum,
-        textAnchor: labelStyle.textAnchor,
-        verticalAnchor: labelStyle.verticalAnchor || "end",
-        angle: labelStyle.angle
-      };
-
       childProps[eventKey] = {
-        data: dataProps,
-        labels: labelProps
+        data: dataProps
       };
+      const text = this.getLabelText(props, datum, index);
+      if (text || props.events) {
+        childProps[eventKey].labels = this.getLabelProps(dataProps, text, style);
+      }
     }
     return childProps;
+  },
+
+  getLabelProps(dataProps, text, calculatedStyle) {
+    const { x, y, index, scale } = dataProps;
+    const labelStyle = this.getLabelStyle(calculatedStyle.labels, dataProps) || {};
+    return {
+      style: labelStyle,
+      x: x - (labelStyle.padding || 0),
+      y: y - (labelStyle.padding || 0),
+      text,
+      index,
+      scale,
+      datum: dataProps.datum,
+      textAnchor: labelStyle.textAnchor,
+      verticalAnchor: labelStyle.verticalAnchor || "end",
+      angle: labelStyle.angle
+    };
   },
 
   getErrorData(props) {

--- a/src/components/victory-errorbar/victory-errorbar.js
+++ b/src/components/victory-errorbar/victory-errorbar.js
@@ -404,10 +404,7 @@ export default class VictoryErrorBar extends React.Component {
         {}, dataProps, {events: Events.getPartialEvents(dataEvents, key, dataProps)}
       ));
 
-      const shouldGetLabelProps = (this.baseProps[key].labels && this.baseProps[key].labels.text)
-        || this.props.events;
-
-      if (shouldGetLabelProps) {
+      if (this.baseProps[key].labels || this.props.events) {
         const labelProps = defaults(
           {key: `${role}-label-${key}`, index},
           this.getEventState(key, "labels"),
@@ -415,11 +412,12 @@ export default class VictoryErrorBar extends React.Component {
           this.baseProps[key].labels,
           labelComponent.props
         );
-        const labelEvents = this.getEvents(props, "labels", key);
-        errorBarLabelComponents[index] = React.cloneElement(labelComponent, assign({
-          events: Events.getPartialEvents(labelEvents, key, labelProps)
-        }, labelProps));
-
+        if (labelProps && labelProps.text) {
+          const labelEvents = this.getEvents(props, "labels", key);
+          errorBarLabelComponents[index] = React.cloneElement(labelComponent, assign({
+            events: Events.getPartialEvents(labelEvents, key, labelProps)
+          }, labelProps));
+        }
       }
     }
 

--- a/src/components/victory-errorbar/victory-errorbar.js
+++ b/src/components/victory-errorbar/victory-errorbar.js
@@ -403,14 +403,18 @@ export default class VictoryErrorBar extends React.Component {
       errorBarComponents[index] = React.cloneElement(dataComponent, assign(
         {}, dataProps, {events: Events.getPartialEvents(dataEvents, key, dataProps)}
       ));
-      const labelProps = defaults(
-        {key: `${role}-label-${key}`, index},
-        this.getEventState(key, "labels"),
-        this.getSharedEventState(key, "labels"),
-        this.baseProps[key].labels,
-        labelComponent.props
-      );
-      if (labelProps && labelProps.text) {
+
+      const shouldGetLabelProps = (this.baseProps[key].labels && this.baseProps[key].labels.text)
+        || this.props.events;
+
+      if (shouldGetLabelProps) {
+        const labelProps = defaults(
+          {key: `${role}-label-${key}`, index},
+          this.getEventState(key, "labels"),
+          this.getSharedEventState(key, "labels"),
+          this.baseProps[key].labels,
+          labelComponent.props
+        );
         const labelEvents = this.getEvents(props, "labels", key);
         errorBarLabelComponents[index] = React.cloneElement(labelComponent, assign({
           events: Events.getPartialEvents(labelEvents, key, labelProps)

--- a/src/components/victory-errorbar/victory-errorbar.js
+++ b/src/components/victory-errorbar/victory-errorbar.js
@@ -404,7 +404,7 @@ export default class VictoryErrorBar extends React.Component {
         {}, dataProps, {events: Events.getPartialEvents(dataEvents, key, dataProps)}
       ));
 
-      if (this.baseProps[key].labels || this.props.events) {
+      if (this.baseProps[key].labels || this.props.events || this.props.sharedEvents) {
         const labelProps = defaults(
           {key: `${role}-label-${key}`, index},
           this.getEventState(key, "labels"),

--- a/src/components/victory-line/victory-line.js
+++ b/src/components/victory-line/victory-line.js
@@ -438,7 +438,7 @@ export default class VictoryLine extends React.Component {
         {}, dataProps, {events: Events.getPartialEvents(dataEvents, "all", dataProps)}
       ));
 
-      if (this.baseProps.all.labels || this.props.events) {
+      if (this.baseProps.all.labels || this.props.events || this.props.sharedEvents) {
         const labelProps = defaults(
           {index, key: `${role}-label-${index}`},
           this.getEventState("all", "labels"),

--- a/src/components/victory-line/victory-line.js
+++ b/src/components/victory-line/victory-line.js
@@ -438,10 +438,7 @@ export default class VictoryLine extends React.Component {
         {}, dataProps, {events: Events.getPartialEvents(dataEvents, "all", dataProps)}
       ));
 
-      const shouldGetLabelProps = (this.baseProps.all.labels && this.baseProps.all.labels.text)
-        || this.props.events;
-
-      if (shouldGetLabelProps) {
+      if (this.baseProps.all.labels || this.props.events) {
         const labelProps = defaults(
           {index, key: `${role}-label-${index}`},
           this.getEventState("all", "labels"),
@@ -450,10 +447,12 @@ export default class VictoryLine extends React.Component {
           labelComponent.props,
           this.baseProps.all.labels
         );
-        const labelEvents = this.getEvents(props, "labels", "all");
-        lineLabelComponents[index] = React.cloneElement(labelComponent, assign({
-          events: Events.getPartialEvents(labelEvents, "all", labelProps)
-        }, labelProps));
+        if (labelProps && labelProps.text) {
+          const labelEvents = this.getEvents(props, "labels", "all");
+          lineLabelComponents[index] = React.cloneElement(labelComponent, assign({
+            events: Events.getPartialEvents(labelEvents, "all", labelProps)
+          }, labelProps));
+        }
       }
     }
     return lineLabelComponents.length > 0 ?

--- a/src/components/victory-line/victory-line.js
+++ b/src/components/victory-line/victory-line.js
@@ -423,7 +423,6 @@ export default class VictoryLine extends React.Component {
     const lineComponents = [];
     const lineLabelComponents = [];
     for (let index = 0, len = dataSegments.length; index < len; index++) {
-    // return dataSegments.map((data, key) => {
       const data = dataSegments[index];
       const role = `${VictoryLine.role}-${index}`;
       const dataEvents = this.getEvents(props, "data", "all");

--- a/src/components/victory-line/victory-line.js
+++ b/src/components/victory-line/victory-line.js
@@ -417,7 +417,7 @@ export default class VictoryLine extends React.Component {
       sharedEvents.getEventState : () => undefined;
   }
 
-  renderData(props) {
+  renderData(props) { // eslint-disable-line max-statements
     const { dataComponent, labelComponent, groupComponent, clipId } = props;
     const dataSegments = LineHelpers.getDataSegments(Data.getData(props));
     const lineComponents = [];
@@ -438,7 +438,11 @@ export default class VictoryLine extends React.Component {
         {}, dataProps, {events: Events.getPartialEvents(dataEvents, "all", dataProps)}
       ));
 
-      const labelProps = defaults(
+      const shouldGetLabelProps = (this.baseProps.all.labels && this.baseProps.all.labels.text)
+        || this.props.events;
+
+      if (shouldGetLabelProps) {
+        const labelProps = defaults(
           {index, key: `${role}-label-${index}`},
           this.getEventState("all", "labels"),
           this.getSharedEventState("all", "labels"),
@@ -446,7 +450,6 @@ export default class VictoryLine extends React.Component {
           labelComponent.props,
           this.baseProps.all.labels
         );
-      if (labelProps && labelProps.text) {
         const labelEvents = this.getEvents(props, "labels", "all");
         lineLabelComponents[index] = React.cloneElement(labelComponent, assign({
           events: Events.getPartialEvents(labelEvents, "all", labelProps)

--- a/src/components/victory-scatter/helper-methods.js
+++ b/src/components/victory-scatter/helper-methods.js
@@ -5,7 +5,7 @@ import Domain from "../../helpers/domain";
 import Data from "../../helpers/data";
 
 export default {
-  getBaseProps(props, fallbackProps) {
+  getBaseProps(props, fallbackProps) { // eslint-disable-line max-statements
     props = Helpers.modifyProps(props, fallbackProps, "scatter");
     const calculatedValues = this.getCalculatedValues(props);
     const { data, style, scale } = calculatedValues;
@@ -25,23 +25,25 @@ export default {
       };
 
       const text = this.getLabelText(props, datum, index);
-      const labelStyle = this.getLabelStyle(style.labels, dataProps) || {};
-      const labelProps = {
-        style: labelStyle,
-        x,
-        y: y - (labelStyle.padding || 0),
-        text,
-        index,
-        scale,
-        datum: dataProps.datum,
-        textAnchor: labelStyle.textAnchor,
-        verticalAnchor: labelStyle.verticalAnchor || "end",
-        angle: labelStyle.angle
-      };
-      childProps[eventKey] = {
-        data: dataProps,
-        labels: labelProps
-      };
+      if (!text && !props.events) {
+        const labelStyle = this.getLabelStyle(style.labels, dataProps) || {};
+        const labelProps = {
+          style: labelStyle,
+          x,
+          y: y - (labelStyle.padding || 0),
+          text,
+          index,
+          scale,
+          datum: dataProps.datum,
+          textAnchor: labelStyle.textAnchor,
+          verticalAnchor: labelStyle.verticalAnchor || "end",
+          angle: labelStyle.angle
+        };
+        childProps[eventKey] = {
+          data: dataProps,
+          labels: labelProps
+        };
+      }
     }
     return childProps;
   },

--- a/src/components/victory-scatter/helper-methods.js
+++ b/src/components/victory-scatter/helper-methods.js
@@ -5,7 +5,7 @@ import Domain from "../../helpers/domain";
 import Data from "../../helpers/data";
 
 export default {
-  getBaseProps(props, fallbackProps) { // eslint-disable-line max-statements
+  getBaseProps(props, fallbackProps) {
     props = Helpers.modifyProps(props, fallbackProps, "scatter");
     const calculatedValues = this.getCalculatedValues(props);
     const { data, style, scale } = calculatedValues;
@@ -24,28 +24,30 @@ export default {
         style: this.getDataStyles(datum, style.data)
       };
 
+      childProps[eventKey] = { data: dataProps };
       const text = this.getLabelText(props, datum, index);
-      if (!text && !props.events) {
-        const labelStyle = this.getLabelStyle(style.labels, dataProps) || {};
-        const labelProps = {
-          style: labelStyle,
-          x,
-          y: y - (labelStyle.padding || 0),
-          text,
-          index,
-          scale,
-          datum: dataProps.datum,
-          textAnchor: labelStyle.textAnchor,
-          verticalAnchor: labelStyle.verticalAnchor || "end",
-          angle: labelStyle.angle
-        };
-        childProps[eventKey] = {
-          data: dataProps,
-          labels: labelProps
-        };
+      if (text || props.events) {
+        childProps[eventKey].labels = this.getLabelProps(dataProps, text, style);
       }
     }
     return childProps;
+  },
+
+  getLabelProps(dataProps, text, calculatedStyle) {
+    const { x, y, index, scale, datum } = dataProps;
+    const labelStyle = this.getLabelStyle(calculatedStyle.labels, dataProps) || {};
+    return {
+      style: labelStyle,
+      x,
+      y: y - (labelStyle.padding || 0),
+      text,
+      index,
+      scale,
+      datum,
+      textAnchor: labelStyle.textAnchor,
+      verticalAnchor: labelStyle.verticalAnchor || "end",
+      angle: labelStyle.angle
+    };
   },
 
   getCalculatedValues(props) {

--- a/src/components/victory-scatter/helper-methods.js
+++ b/src/components/victory-scatter/helper-methods.js
@@ -78,9 +78,8 @@ export default {
   },
 
   getLabelText(props, datum, index) {
-    const propsLabel = Array.isArray(props.labels) ?
-      props.labels[index] : Helpers.evaluateProp(props.labels, datum);
-    return datum.label || propsLabel;
+    return datum.label || (Array.isArray(props.labels) ?
+      props.labels[index] : Helpers.evaluateProp(props.labels, datum));
   },
 
   getLabelStyle(labelStyle, dataProps) {

--- a/src/components/victory-scatter/helper-methods.js
+++ b/src/components/victory-scatter/helper-methods.js
@@ -26,7 +26,7 @@ export default {
 
       childProps[eventKey] = { data: dataProps };
       const text = this.getLabelText(props, datum, index);
-      if (text || props.events) {
+      if (text || props.events || props.sharedEvents) {
         childProps[eventKey].labels = this.getLabelProps(dataProps, text, style);
       }
     }

--- a/src/components/victory-scatter/victory-scatter.js
+++ b/src/components/victory-scatter/victory-scatter.js
@@ -419,14 +419,17 @@ export default class VictoryScatter extends React.Component {
         {}, dataProps, {events: Events.getPartialEvents(dataEvents, key, dataProps)}
       ));
 
-      const labelProps = defaults(
-        {key: `scatter-label-${key}`, index},
-        this.getEventState(key, "labels"),
-        this.getSharedEventState(key, "labels"),
-        labelComponent.props,
-        this.baseProps[key].labels
-      );
-      if (labelProps && labelProps.text) {
+      const shouldGetLabelProps = (this.baseProps[key].labels && this.baseProps[key].labels.text)
+          || this.props.events;
+
+      if (shouldGetLabelProps) {
+        const labelProps = defaults(
+          {key: `scatter-label-${key}`, index},
+          this.getEventState(key, "labels"),
+          this.getSharedEventState(key, "labels"),
+          labelComponent.props,
+          this.baseProps[key].labels
+        );
         const labelEvents = this.getEvents(props, "labels", key);
         pointLabelComponents[index] = React.cloneElement(labelComponent, assign({
           events: Events.getPartialEvents(labelEvents, key, labelProps)

--- a/src/components/victory-scatter/victory-scatter.js
+++ b/src/components/victory-scatter/victory-scatter.js
@@ -406,7 +406,6 @@ export default class VictoryScatter extends React.Component {
     const pointLabelComponents = [];
     for (let index = 0, len = this.dataKeys.length; index < len; index++) {
       const key = this.dataKeys[index];
-    // this.dataKeys.forEach((key, index) => {
       const dataEvents = this.getEvents(props, "data", key);
       const dataProps = defaults(
         {index, key: `${role}-${key}`, role: `${role}-${index}`},

--- a/src/components/victory-scatter/victory-scatter.js
+++ b/src/components/victory-scatter/victory-scatter.js
@@ -419,7 +419,7 @@ export default class VictoryScatter extends React.Component {
         {}, dataProps, {events: Events.getPartialEvents(dataEvents, key, dataProps)}
       ));
 
-      if (this.baseProps[key].labels || this.props.events) {
+      if (this.baseProps[key].labels || this.props.events || this.props.sharedEvents) {
         const labelProps = defaults(
           {key: `scatter-label-${key}`, index},
           this.getEventState(key, "labels"),

--- a/src/components/victory-scatter/victory-scatter.js
+++ b/src/components/victory-scatter/victory-scatter.js
@@ -419,10 +419,7 @@ export default class VictoryScatter extends React.Component {
         {}, dataProps, {events: Events.getPartialEvents(dataEvents, key, dataProps)}
       ));
 
-      const shouldGetLabelProps = (this.baseProps[key].labels && this.baseProps[key].labels.text)
-          || this.props.events;
-
-      if (shouldGetLabelProps) {
+      if (this.baseProps[key].labels || this.props.events) {
         const labelProps = defaults(
           {key: `scatter-label-${key}`, index},
           this.getEventState(key, "labels"),
@@ -430,10 +427,12 @@ export default class VictoryScatter extends React.Component {
           labelComponent.props,
           this.baseProps[key].labels
         );
-        const labelEvents = this.getEvents(props, "labels", key);
-        pointLabelComponents[index] = React.cloneElement(labelComponent, assign({
-          events: Events.getPartialEvents(labelEvents, key, labelProps)
-        }, labelProps));
+        if (labelProps && labelProps.text) {
+          const labelEvents = this.getEvents(props, "labels", key);
+          pointLabelComponents[index] = React.cloneElement(labelComponent, assign({
+            events: Events.getPartialEvents(labelEvents, key, labelProps)
+          }, labelProps));
+        }
       }
     }
 


### PR DESCRIPTION
Addresses #351 

I updated the `getLabel()`/ `getLabelText()` helpers for:

- `<VictoryBar>` 
- `<VictoryCandlestick>` 
- `<VictoryErrorBar>` 
- `<VictoryScatter>` 

to short-circuit when a datum label exists (I did not see similar logic in the other components).

I also added the `if (!text && !props.events)` test mentioned in the issue to address unnecessarily calculating `labelStyle` & `labelProps` for `<VictoryScatter>`

