### PR TITLE
Feature/Fix label overlap issue.

### DIFF
--- a/src/components/victory-axis/victory-axis.js
+++ b/src/components/victory-axis/victory-axis.js
@@ -1,8 +1,8 @@
-import { assign, defaults, isFunction, partialRight } from "lodash";
 import React, { PropTypes } from "react";
+import { assign, defaults, isFunction, partialRight } from "lodash";
 import {
   PropTypes as CustomPropTypes, Helpers, Events, VictoryTransition, VictoryLabel,
-  VictoryContainer, VictoryTheme, Line
+  VictoryContainer, VictoryTheme, Line, TextSize
 } from "victory-core";
 import AxisHelpers from "./helper-methods";
 import Axis from "../../helpers/axis";
@@ -96,6 +96,11 @@ export default class VictoryAxis extends React.Component {
         y: CustomPropTypes.domain
       })
     ]),
+    /**
+     * This fixLabelOverlap prop enable algorithm for overlapped ticks labels.
+     * This prop is useful when ticks amount much more than axis size.
+     */
+    fixLabelOverlap: PropTypes.bool,
     /**
      * The event prop take an array of event objects. Event objects are composed of
      * a target, an eventKey, and eventHandlers. Targets may be any valid style namespace
@@ -335,7 +340,8 @@ export default class VictoryAxis extends React.Component {
     theme: VictoryTheme.grayscale,
     tickCount: 5,
     containerComponent: <VictoryContainer />,
-    groupComponent: <g/>
+    groupComponent: <g/>,
+    fixLabelOverlap: false
   };
 
   static getDomain = AxisHelpers.getDomain.bind(AxisHelpers);
@@ -446,6 +452,42 @@ export default class VictoryAxis extends React.Component {
     return gridAndTickComponents;
   }
 
+  fixLabelOverlap(gridAndTicks, props) {
+    const isVertical = Axis.isVertical(props);
+    const size = isVertical ? props.height : props.width;
+    const isVictoryLabel = (child) => child.type.name === "VictoryLabel";
+    const labels = gridAndTicks.map((gridAndTick) => gridAndTick.props.children)
+     .reduce((accumulator, childArr) => accumulator.concat(childArr))
+     .filter(isVictoryLabel)
+     .map((child) => child.props);
+    const paddingToObject = (padding) =>
+      typeof (padding) === "object"
+        ? Object.assign({}, {top: 0, right: 0, bottom: 0, left: 0}, padding)
+        : {top: padding, right: padding, bottom: padding, left: padding };
+    const labelsSumSize = labels.reduce((sum, label) => {
+      const padding = paddingToObject(label.style.padding);
+      const labelSize = TextSize.approximateTextSize(label.text, {
+        angle: label.angle,
+        fontSize: label.style.fontSize,
+        letterSpacing: label.style.letterSpacing,
+        fontFamily: label.style.fontFamily
+      });
+      return sum + (isVertical
+        ? labelSize.height + padding.top + padding.bottom
+        : labelSize.width + padding.right + padding.left);
+    }, 0);
+    const availiableLabelCount = Math.floor(size * gridAndTicks.length / labelsSumSize);
+    const divider = Math.ceil(gridAndTicks.length / availiableLabelCount) || 1;
+    const getLabelCoord = (gridAndTick) => gridAndTick.props.children
+      .filter(isVictoryLabel)
+      .reduce((prev, child) => (isVertical ? child.props.y : child.props.x) || 0, 0);
+    const sorted = gridAndTicks.sort((a, b) => isVertical
+      ? getLabelCoord(b) - getLabelCoord(a) //ordinat axis has top-bottom orientation
+      : getLabelCoord(a) - getLabelCoord(b) //ordinat axis has left-right orientation
+    );
+    return sorted.filter((gridAndTick, index) => index % divider === 0);
+  }
+
   renderContainer(props, group) {
     const parentEvents = this.getEvents(props, "parent", "parent");
     const parentProps = defaults(
@@ -492,8 +534,12 @@ export default class VictoryAxis extends React.Component {
 
     const styleObject = theme && theme.axis && theme.axis.style ? theme.axis.style : {};
     const style = AxisHelpers.getStyles(props, styleObject);
+    const gridAndTicks = this.renderGridAndTicks(props);
+    const modifiedGridAndTicks = props.fixLabelOverlap
+      ? this.fixLabelOverlap(gridAndTicks, props)
+      : gridAndTicks;
     const children = [
-      ...this.renderGridAndTicks(props),
+      ...modifiedGridAndTicks,
       this.renderLine(props),
       this.renderLabel(props)
     ];


### PR DESCRIPTION
Hello! 
It's partial fix 'label overlapping' , in situation when axis.size < sum(labels.size).
And 'text size' helper, that predict VictoryLabel size based on text and font-style.
I take out filtering code from "renderGridAndTicks" into individual function "fixLabelOverlap", that filter 
"renderGridAndTicks" result.

We discuss about it in Gitter, recently.

> Lauren @boygirl авг. 11 20:05
@deathmandu we could maybe approximate the size of the text based on length, number of lines, font size, padding etc. and filter it in renderGridAndTicks, but it wouldn't be exact. If we went this route, I would want to add a static method to VictoryLabel like getLabelDimensions, and call it in renderGridAndTicks. Option 2 is not viable for us since we use the same code base for victory-native
@traverspinkerton you should style axis stuff on VictoryAxis like...
