### PR TITLE
Remove colon from the VictoryScatter @examples annotation.

### DIFF
--- a/src/components/victory-scatter/victory-scatter.js
+++ b/src/components/victory-scatter/victory-scatter.js
@@ -208,7 +208,7 @@ export default class VictoryScatter extends React.Component {
      * If given as an array, the number of elements in the array should be equal to
      * the length of the data array. Labels may also be added directly to the data object
      * like data={[{x: 1, y: 1, label: "first"}]}.
-     * @examples: ["spring", "summer", "fall", "winter"], (datum) => datum.title
+     * @examples ["spring", "summer", "fall", "winter"], (datum) => datum.title
      */
     labels: PropTypes.oneOfType([
       PropTypes.func,


### PR DESCRIPTION
I noticed the documentation examples for the `<VictoryScatter>` label prop has an extra colon.

This PR removes the colon from the `@examples` notation so that generated docs don't render with an extra colon.

![image](https://cloud.githubusercontent.com/assets/13814048/17988080/c34b744c-6ad8-11e6-80c5-25ae729d658b.png)

cc/ @ebrillhart 