### PR TITLE
Task convert recursive helper methods to loops

### DIFF
--- a/src/helpers/wrapper.js
+++ b/src/helpers/wrapper.js
@@ -233,25 +233,37 @@ export default {
     return strings;
   },
 
-  getStringsFromData(childComponents, axis) {
+  getStringsFromData(childComponents, axis) { // eslint-disable-line max-statements
     const strings = [];
-    const children = childComponents.slice(0);
+    let stringsLength = 0;
 
-    while (children.length > 0) {
-      const child = children.pop();
+    const children = childComponents.slice(0);
+    let childrenLength = children.length;
+
+    while (childrenLength > 0) {
+      const child = children[--childrenLength];
+
       if (child.props && child.props.data) {
-        strings.push(...Helpers.getStringsFromData(child.props, axis));
+        const newStrings = Helpers.getStringsFromData(child.props, axis);
+        const newStringsLength = newStrings.length;
+        for (let index = 0; index < newStringsLength; index++) {
+          strings[stringsLength++] = newStrings[index];
+        }
       } else if (child.type && isFunction(child.type.getData)) {
         const data = flatten(child.type.getData(child.props));
         const attr = axis === "x" ? "xName" : "yName";
         for (let index = 0; index < data.length; index++) {
           const datum = data[index];
           if (datum[attr]) {
-            strings.push(datum[attr]);
+            strings[stringsLength++] = datum[attr];
           }
         }
       } else if (child.props && child.props.children) {
-        children.push(...React.Children.toArray(child.props.children));
+        const newChildren = React.Children.toArray(child.props.children);
+        const newChildrenLength = newChildren.length;
+        for (let index = 0; index < newChildrenLength; index++) {
+          children[childrenLength++] = newChildren[index];
+        }
       }
     }
 

--- a/src/helpers/wrapper.js
+++ b/src/helpers/wrapper.js
@@ -205,16 +205,28 @@ export default {
     };
   },
 
-  getStringsFromCategories(childComponents, axis) {
+  getStringsFromCategories(childComponents, axis) { // eslint-disable-line max-statements
     const strings = [];
-    const children = childComponents.slice(0);
+    let stringsLength = 0;
 
-    while (children.length > 0) {
-      const child = children.pop();
+    const children = childComponents.slice(0);
+    let childrenLength = children.length;
+
+    while (childrenLength > 0) {
+      const child = children[--childrenLength];
+
       if (child.props && child.props.categories) {
-        strings.push(...Data.getStringsFromCategories(child.props, axis));
+        const newStrings = Data.getStringsFromCategories(child.props, axis);
+        const newStringsLength = newStrings.length;
+        for (let index = 0; index < newStringsLength; index++) {
+          strings[stringsLength++] = newStrings[index];
+        }
       } else if (child.props && child.props.children) {
-        children.push(...React.Children.toArray(child.props.children));
+        const newChildren = React.Children.toArray(child.props.children);
+        const newChildrenLength = newChildren.length;
+        for (let index = 0; index < newChildrenLength; index++) {
+          children[childrenLength++] = newChildren[index];
+        }
       }
     }
 

--- a/src/helpers/wrapper.js
+++ b/src/helpers/wrapper.js
@@ -83,17 +83,21 @@ export default {
     return defaults({getTransitions, parentState}, props.animate, child.props.animate);
   },
 
-  getDomainFromChildren(props, axis, childComponents) { // eslint-disable-line max-statements
+  getDomainFromChildren(props, axis, childComponents) { // eslint-disable-line max-statements, complexity, max-len
     const childDomains = [];
+    let childDomainsLength = 0;
+
     const children = childComponents
       ? childComponents.slice(0)
       : React.Children.toArray(props.children);
+    let childrenLength = children.length;
+
     const horizontalChildren = childComponents.some((child) => child.props.horizontal);
     const horizontal = props && props.horizontal || horizontalChildren.length > 0;
     const currentAxis = Axis.getCurrentAxis(axis, horizontal);
 
-    while (children.length > 0) {
-      const child = children.pop();
+    while (childrenLength > 0) {
+      const child = children[--childrenLength];
 
       if (child.type && isFunction(child.type.getDomain)) {
         const parentData = props.data ? Data.getData(props, axis) : undefined;
@@ -101,10 +105,17 @@ export default {
           assign({}, child.props, {data: parentData}) : child.props;
         const childDomain = child.props && child.type.getDomain(sharedProps, currentAxis);
         if (childDomain) {
-          childDomains.push(...childDomain);
+          const childDomainLength = childDomain.length;
+          for (let index = 0; index < childDomainLength; index++) {
+            childDomains[childDomainsLength++] = childDomain[index];
+          }
         }
       } else if (child.props && child.props.children) {
-        children.push(...React.Children.toArray(child.props.children));
+        const newChildren = React.Children.toArray(child.props.children);
+        const newChildrenLength = newChildren.length;
+        for (let index = 0; index < newChildrenLength; index++) {
+          children[childrenLength++] = newChildren[index];
+        }
       }
     }
 

--- a/src/helpers/wrapper.js
+++ b/src/helpers/wrapper.js
@@ -195,26 +195,29 @@ export default {
     return strings;
   },
 
-  // TODO: Convert to loops
   getStringsFromData(childComponents, axis) {
-    const stringsFromData = (children) => {
-      return children.reduce((memo, child) => {
-        if (child.props && child.props.data) {
-          return memo.concat(Helpers.getStringsFromData(child.props, axis));
-        } else if (child.type && isFunction(child.type.getData)) {
-          const data = flatten(child.type.getData(child.props));
-          const attr = axis === "x" ? "xName" : "yName";
-          return memo.concat(data.reduce((prev, datum) => {
-            return datum[attr] ? prev.concat(datum[attr]) : prev;
-          }, []));
-        } else if (child.props && child.props.children) {
-          return memo.concat(stringsFromData(React.Children.toArray(child.props.children)));
-        }
-        return memo;
-      }, []);
-    };
+    const strings = [];
+    const children = childComponents.slice(0);
 
-    return stringsFromData(childComponents);
+    while (children.length > 0) {
+      const child = children.pop();
+      if (child.props && child.props.data) {
+        strings.push(...Helpers.getStringsFromData(child.props, axis));
+      } else if (child.type && isFunction(child.type.getData)) {
+        const data = flatten(child.type.getData(child.props));
+        const attr = axis === "x" ? "xName" : "yName";
+        for (let index = 0; index < data.length; index++) {
+          const datum = data[index];
+          if (datum[attr]) {
+            strings.push(datum[attr]);
+          }
+        }
+      } else if (child.props && child.props.children) {
+        children.push(...React.Children.toArray(child.props.children));
+      }
+    }
+
+    return strings;
   },
 
   getStringsFromChildren(props, axis, childComponents) {

--- a/src/helpers/wrapper.js
+++ b/src/helpers/wrapper.js
@@ -114,25 +114,30 @@ export default {
       [0, 1] : [min, max];
   },
 
-  // TODO: Convert to loops
   getDataFromChildren(props, childComponents) {
     const getData = (childProps) => {
       const data = Data.getData(childProps);
       return Array.isArray(data) && data.length > 0 ? data : undefined;
     };
 
-    const getChildData = (children) => {
-      return children.map((child) => {
-        if (child.type && isFunction(child.type.getData)) {
-          return child.props && child.type.getData(child.props);
-        } else if (child.props && child.props.children) {
-          return flatten(getChildData(React.Children.toArray(child.props.children)));
-        }
-        return getData(child.props);
-      });
-    };
-    childComponents = childComponents || React.Children.toArray(props.children);
-    return getChildData(childComponents);
+    const children = childComponents
+      ? childComponents.slice(0)
+      : React.Children.toArray(props.children);
+    const dataArr = [];
+
+    while (children.length > 0) {
+      const child = children.pop();
+
+      if (child.type && isFunction(child.type.getData)) {
+        dataArr.push(child.props && child.type.getData(child.props));
+      } else if (child.props && child.props.children) {
+        children.push(...React.Children.toArray(child.props.children));
+      } else {
+        dataArr.push(getData(child.props));
+      }
+    }
+
+    return dataArr;
   },
 
   getStackedDomain(props, axis) {

--- a/src/helpers/wrapper.js
+++ b/src/helpers/wrapper.js
@@ -83,6 +83,7 @@ export default {
     return defaults({getTransitions, parentState}, props.animate, child.props.animate);
   },
 
+  // TODO: Convert to loops
   getDomainFromChildren(props, axis, childComponents) {
     childComponents = childComponents || React.Children.toArray(props.children);
     const horizontalChildren = childComponents.some((child) => child.props.horizontal);
@@ -110,6 +111,7 @@ export default {
       [0, 1] : [min, max];
   },
 
+  // TODO: Convert to loops
   getDataFromChildren(props, childComponents) {
     const getData = (childProps) => {
       const data = Data.getData(childProps);
@@ -178,22 +180,22 @@ export default {
   },
 
   getStringsFromCategories(childComponents, axis) {
-    const stringsFromCategories = (children) => {
-      return children.reduce((memo, child) => {
-        if (child.props && child.props.categories) {
-          return memo.concat(Data.getStringsFromCategories(child.props, axis));
-        } else if (child.props && child.props.children) {
-          return memo.concat(stringsFromCategories(
-            React.Children.toArray(child.props.children)
-          ));
-        }
-        return memo;
-      }, []);
-    };
+    const strings = [];
+    const children = childComponents.slice(0);
 
-    return stringsFromCategories(childComponents);
+    while (children.length > 0) {
+      const child = children.pop();
+      if (child.props && child.props.categories) {
+        strings.push(...Data.getStringsFromCategories(child.props, axis));
+      } else if (child.props && child.props.children) {
+        children.push(...React.Children.toArray(child.props.children));
+      }
+    }
+
+    return strings;
   },
 
+  // TODO: Convert to loops
   getStringsFromData(childComponents, axis) {
     const stringsFromData = (children) => {
       return children.reduce((memo, child) => {

--- a/src/helpers/wrapper.js
+++ b/src/helpers/wrapper.js
@@ -134,17 +134,24 @@ export default {
     const children = childComponents
       ? childComponents.slice(0)
       : React.Children.toArray(props.children);
-    const dataArr = [];
+    let childrenLength = children.length;
 
-    while (children.length > 0) {
-      const child = children.pop();
+    const dataArr = [];
+    let dataArrLength = 0;
+
+    while (childrenLength > 0) {
+      const child = children[--childrenLength];
 
       if (child.type && isFunction(child.type.getData)) {
-        dataArr.push(child.props && child.type.getData(child.props));
+        dataArr[dataArrLength++] = child.props && child.type.getData(child.props);
       } else if (child.props && child.props.children) {
-        children.push(...React.Children.toArray(child.props.children));
+        const newChildren = React.Children.toArray(child.props.children);
+        const newChildrenLength = newChildren.length;
+        for (let index = 0; index < newChildrenLength; index++) {
+          children[childrenLength++] = newChildren[index];
+        }
       } else {
-        dataArr.push(getData(child.props));
+        dataArr[dataArrLength++] = getData(child.props);
       }
     }
 


### PR DESCRIPTION
Closes #359

Converts `getStringsFromCategories`, `getStringsFromData`, `getDomainFromChildren`, and `getDataFromChildren` methods to use loops instead of recursion.

I'm not 100% on these yet but I figure I could get feedback if there are any glaring errors.

cc/ @boygirl