### PR TITLE
Feature allow sorting VictoryLine by keys other than 'x'

### DIFF
--- a/demo/components/victory-line-demo.js
+++ b/demo/components/victory-line-demo.js
@@ -319,6 +319,14 @@ export default class App extends React.Component {
               data={[]}
             />
         </VictoryChart>
+
+        <VictoryLine
+          style={{parent: parentStyle}}
+          data={range(0, 2*Math.PI, 0.01).map((t) => ({t}))}
+          sortKey={'t'}
+          x={({t}) => Math.sin(3 * t + (2*Math.PI))}
+          y={({t}) => Math.sin(2 * t)}
+        />
       </div>
     );
   }

--- a/demo/components/victory-line-demo.js
+++ b/demo/components/victory-line-demo.js
@@ -322,9 +322,9 @@ export default class App extends React.Component {
 
         <VictoryLine
           style={{parent: parentStyle}}
-          data={range(0, 2*Math.PI, 0.01).map((t) => ({t}))}
+          data={range(0, 2 * Math.PI, 0.01).map((t) => ({t}))}
           sortKey={'t'}
-          x={({t}) => Math.sin(3 * t + (2*Math.PI))}
+          x={({t}) => Math.sin(3 * t + (2 * Math.PI))}
           y={({t}) => Math.sin(2 * t)}
         />
       </div>

--- a/src/components/victory-line/helper-methods.js
+++ b/src/components/victory-line/helper-methods.js
@@ -99,8 +99,8 @@ export default {
     return defaults({}, labelStyle, {opacity, fill, padding});
   },
 
-  getDataSegments(dataset) {
-    const orderedData = sortBy(dataset, "x");
+  getDataSegments(dataset, sortKey = "x") {
+    const orderedData = sortBy(dataset, sortKey);
     const segments = [];
     let segmentStartIndex = 0;
     let segmentIndex = 0;

--- a/src/components/victory-line/victory-line.js
+++ b/src/components/victory-line/victory-line.js
@@ -266,6 +266,23 @@ export default class VictoryLine extends React.Component {
      * This value should be given as a number of pixels
      */
     width: CustomPropTypes.nonNegative,
+
+    /**
+     * The sortKey prop specifies the sort key for data points.
+     * If given as a function, it will be run on each data point, and returned value will be used.
+     * If given as an integer, it will be used as an array index for array-type data points.
+     * If given as a string, it will be used as a property key for object-type data points.
+     * If given as an array of strings, or a string containing dots or brackets,
+     * it will be used as a nested object property path (for details see Lodash docs for _.get).
+     * If `null` or `undefined`, the data value will be used as is (identity function/pass-through).
+     * @examples 0, 'x', 'x.value.nested.1.thing', 'x[2].also.nested', null, d => Math.sin(d)
+     */
+    sortKey: PropTypes.oneOfType([
+      PropTypes.func,
+      CustomPropTypes.allOfType([CustomPropTypes.integer, CustomPropTypes.nonNegative]),
+      PropTypes.string,
+      PropTypes.arrayOf(PropTypes.string)
+    ]),
     /**
      * The x prop specifies how to access the X value of each data point.
      * If given as a function, it will be run on each data point, and returned value will be used.
@@ -340,6 +357,7 @@ export default class VictoryLine extends React.Component {
     samples: 50,
     scale: "linear",
     standalone: true,
+    sortKey: "x",
     x: "x",
     y: "y",
     dataComponent: <Curve/>,
@@ -381,8 +399,8 @@ export default class VictoryLine extends React.Component {
   }
 
   renderData(props) { // eslint-disable-line max-statements
-    const { dataComponent, labelComponent, groupComponent, clipId } = props;
-    const dataSegments = LineHelpers.getDataSegments(Data.getData(props));
+    const { dataComponent, labelComponent, groupComponent, clipId, sortKey} = props;
+    const dataSegments = LineHelpers.getDataSegments(Data.getData(props), sortKey);
     const lineComponents = [];
     const lineLabelComponents = [];
     for (let index = 0, len = dataSegments.length; index < len; index++) {

--- a/test/client/spec/components/victory-line/victory-line.spec.js
+++ b/test/client/spec/components/victory-line/victory-line.spec.js
@@ -215,6 +215,34 @@ describe("components/victory-line", () => {
       const lines = wrapper.find(Curve);
       expect(lines.length).to.equal(1);
     });
+
+    it("renders data ordered by x-value, by default", () => {
+      const data = [
+        { t: 0 /*x: 10, y: 1*/},
+        { t: 1 /*x:  9, y: 1*/}
+      ];
+      const wrapper = shallow(
+        <VictoryLine data={data} x={({t}) => 10 - t} y={() => 1} />
+      );
+      const lines = wrapper.find(Curve);
+
+      expect(lines.props().data[0].t).to.equal(1);
+      expect(lines.props().data[1].t).to.equal(0);
+    });
+
+    it("renders data ordered by value of sortKey, if given", () => {
+      const data = [
+        { t: 0 /*x: 10, y: 1*/},
+        { t: 1 /*x:  9, y: 1*/}
+      ];
+      const wrapper = shallow(
+        <VictoryLine data={data} sortKey={'t'} x={({t}) => 10 - t} y={() => 1} />
+      );
+      const lines = wrapper.find(Curve);
+
+      expect(lines.props().data[0].t).to.equal(0);
+      expect(lines.props().data[1].t).to.equal(1);
+    });
   });
 
   describe("event handling", () => {


### PR DESCRIPTION
I added this because I realized that it didn't appear possible to draw a 'sideways' graph if line data are sorted so that they're monotonically increasing in X. (One _does_ end up with some very interesting-looking graphs, though!)

Anyways, this adds a prop to VictoryLine which allows specifying the sortKey, along with a small addition to the helper method which lets one pass in that sort key.

Here's an illustration of the result, with a 3:2 Lissajous curve:

**Before**
![screen shot 2016-09-05 at 4 33 08 pm](https://cloud.githubusercontent.com/assets/780461/18258278/6765e934-7387-11e6-84f4-0e20d087fce8.png)

**After**
![screen shot 2016-09-05 at 4 33 15 pm](https://cloud.githubusercontent.com/assets/780461/18258273/62114910-7387-11e6-9965-98fc8f444599.png)