### PR TITLE
Axissync merge

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -13,6 +13,7 @@ import EventsDemo from "./components/events-demo";
 import GroupDemo from "./components/group-demo";
 import VoronoiDemo from "./components/victory-voronoi-demo";
 import TooltipDemo from "./components/victory-tooltip-demo";
+import MultipleAxes from "./components/multiaxis-sync-demo";
 import { Router, Route, Link, hashHistory } from "react-router";
 
 const content = document.getElementById("content");
@@ -39,6 +40,7 @@ const App = React.createClass({
           <li><Link to="/group">Group Demo</Link></li>
           <li><Link to="/voronoi">Victory Voronoi Demo</Link></li>
           <li><Link to="/tooltip">Victory Tooltip Demo</Link></li>
+          <li><Link to="/multiaxis">MultiAxis Sync Demo</Link></li>
         </ul>
         {this.props.children}
       </div>
@@ -61,6 +63,7 @@ ReactDOM.render((
       <Route path="group" component={GroupDemo}/>
       <Route path="voronoi" component={VoronoiDemo}/>
       <Route path="tooltip" component={TooltipDemo}/>
+      <Route path="multiaxis" component={MultipleAxes}/>
     </Route>
   </Router>
 ), content);

--- a/demo/components/multiaxis-sync-demo.js
+++ b/demo/components/multiaxis-sync-demo.js
@@ -1,0 +1,109 @@
+import React from "react";
+import { merge, min, max } from "lodash";
+import { VictoryLine, VictoryAxis } from "../../src/index";
+import syncAxis from "../../src/helpers/axissync";
+
+export default class MultipleAxes extends React.Component {
+  getStyles() {
+    return {
+      parent: {
+        boxSizing: "border-box",
+        display: "block",
+        width: "100%",
+        height: "100%"
+      }
+    };
+  }
+
+  render() {
+    const styles = this.getStyles();
+    const firstAxisProps = {
+      style: {
+        axis: { stroke: "orange", strokeWidth: 2 },
+        grid: {strokeWidth: 2, stroke: "yellow"},
+        ticks: { stroke: "orange" },
+        tickLabels: { fontSize: 12 }
+      },
+      orientation: "left",
+      domain: [-200, 200],
+      label: "Low Frequency",
+      standalone: false
+    };
+    const secondAxisProps = {
+      style: {
+        axis: { stroke: "blue", strokeWidth: 2 },
+        grid: {strokeWidth: 2, stroke: "green"},
+        ticks: { stroke: "blue" },
+        tickLabels: { fontSize: 12 }
+      },
+      orientation: "right",
+      domain: [-0.8, 0.8],
+      label: "High Frequency",
+      standalone: false
+    };
+    const ticks = syncAxis([firstAxisProps, secondAxisProps]);
+    return (
+      <svg style={styles.parent} viewBox="0 0 500 300">
+        <VictoryAxis
+          style={{
+            data: {
+              strokeWidth: 2
+            },
+            labels: {
+              fontSize: 16
+            }
+          }}
+          orientation="bottom"
+          domain={[0, 20]}
+          label="Time in microseconds"
+          standalone={false}
+        />
+        <VictoryAxis
+          dependent
+          {...merge(firstAxisProps, { domain: [min(ticks[0]), max(ticks[0])] }) }
+          tickValues={ticks[0]}
+        />
+        <VictoryAxis
+          dependent
+          {...merge(secondAxisProps, { domain: [min(ticks[1]), max(ticks[1])] }) }
+          tickValues={ticks[1]}
+        />
+        <VictoryLine
+          style={{
+            data: {
+              stroke: "orange",
+              strokeWidth: 2
+            }
+          }}
+          y={(data) =>
+            200 * Math.exp(-0.05 * data.x) * Math.sin(data.x)
+          }
+          interpolation="basis"
+          domain={{
+            x: [0, 20],
+            y: [-200, 200]
+          }}
+          standalone={false}
+        />
+
+        <VictoryLine
+          style={{
+            data: {
+              stroke: "blue", strokeWidth: 1
+            }
+          }}
+          y={(data) =>
+            0.8 * Math.exp(-0.5 * data.x) * Math.sin(10 * data.x)
+          }
+          interpolation="basis"
+          samples={500}
+          domain={{
+            x: [0, 20],
+            y: [-0.8, 0.8]
+          }}
+          standalone={false}
+        />
+      </svg>
+    );
+  }
+}

--- a/demo/components/multiaxis-sync-demo.js
+++ b/demo/components/multiaxis-sync-demo.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { merge, min, max } from "lodash";
 import { VictoryLine, VictoryAxis } from "../../src/index";
-import syncAxis from "../../src/helpers/axissync";
+import axisSync from "../../src/helpers/axissync";
 
 export default class MultipleAxes extends React.Component {
   getStyles() {
@@ -41,7 +41,7 @@ export default class MultipleAxes extends React.Component {
       label: "High Frequency",
       standalone: false
     };
-    const ticks = syncAxis([firstAxisProps, secondAxisProps]);
+    const ticks = axisSync.sync([firstAxisProps, secondAxisProps]);
     return (
       <svg style={styles.parent} viewBox="0 0 500 300">
         <VictoryAxis

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "builder-victory-component": "^2.4.0",
     "d3-scale": "^1.0.0",
     "d3-voronoi": "^1.0.0",
+    "d3": "^4.2.2",
     "lodash": "^4.12.0",
     "victory-core": "^7.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -28,9 +28,9 @@
   "dependencies": {
     "builder": "~2.9.1",
     "builder-victory-component": "^2.4.0",
+    "d3-array": "^1.0.1",
     "d3-scale": "^1.0.0",
     "d3-voronoi": "^1.0.0",
-    "d3": "^4.2.2",
     "lodash": "^4.12.0",
     "victory-core": "^7.0.0"
   },

--- a/src/helpers/axissync.js
+++ b/src/helpers/axissync.js
@@ -1,0 +1,106 @@
+import { TextSize } from "victory-core";
+import Axis from "./axis";
+import VictoryAxis from "../components/victory-axis/victory-axis.js";
+import AxisHelper from "../components/victory-axis/helper-methods.js";
+import { defaults, range, groupBy, flatten, merge } from "lodash";
+import * as d3 from "d3";
+
+const defaultFontSize = 12;
+
+const fallbackProps = {
+  width: 450,
+  height: 300,
+  padding: 50
+};
+
+const getShortestString = (domain) => {
+  const domainStrs = d3.scaleLinear().domain(domain).nice().domain().map((elem) => String(elem));
+  return domainStrs.reduce((short, cur) => cur.length < short.length ? cur : short, domainStrs[0]);
+};
+
+const getSize = (isVertical, sizeObj) => isVertical ? sizeObj.height : sizeObj.width;
+
+const getLabelCount = (isVertical, props, size) =>
+  Math.max(Math.floor((getSize(isVertical, props)) / size), 2);
+
+const getTicksAndInterval = (axisProps, tickCount) => {
+  const domain = AxisHelper.getDomain(axisProps);
+  const scaleFunc = AxisHelper.getScale(axisProps);
+  const props = merge(axisProps, { tickCount });
+  return {
+    ticks: AxisHelper.getTicks(props, scaleFunc),
+    tickInterval: d3.tickStep(domain[0], domain[1], tickCount)
+  };
+};
+
+const recalcTicks = (firstTick, tickInterval, index) =>
+  firstTick instanceof Date
+    ? new Date(firstTick.getTime() + tickInterval * (index))
+    : firstTick + tickInterval * (index);
+
+const syncTicks = (axisTicksArray) => {
+  const maxLength = Math.max.apply(null, axisTicksArray.map((tickObj) => tickObj.ticks.length));
+  return axisTicksArray.map((obj) =>
+    ({
+      index: obj.index,
+      ticks: range(maxLength).map((index) => recalcTicks(obj.ticks[0], obj.tickInterval, index))
+    })
+  );
+};
+
+const getTicksForAxisWithSync = (isVertical, axisGroup) => {
+  const maxMinSize = Math.max.apply(null,
+    axisGroup.map((obj) =>
+      getSize(isVertical,
+        TextSize.approximateTextSize(
+          getShortestString(obj.props.domain),
+          defaults(obj.props.style.tickLabels, { fontSize: defaultFontSize })
+        )
+      )
+    )
+  );
+  return syncTicks(
+    axisGroup.map((axisObj) => {
+      return Object.assign(
+        getTicksAndInterval(
+          axisObj.props, getLabelCount(isVertical, axisObj.props, maxMinSize)
+        ), { index: axisObj.index }
+      );
+    })
+  );
+};
+
+const getTicksWithoutSync = (isVertical, axisGroup) =>
+  axisGroup.map((axisObj) => {
+    const minSize = getSize(isVertical,
+      TextSize.approximateTextSize(
+        getShortestString(axisObj.props.domain),
+        defaults(axisObj.props.style.tickLabels, { fontSize: defaultFontSize })
+      )
+    );
+    return merge(
+      getTicksAndInterval(
+        axisObj.props, getLabelCount(isVertical, axisObj.props, minSize)
+      ), { index: axisObj.index }
+    );
+  });
+
+const sync = (axisPropsArr) => {
+  const modifyPropsArray = axisPropsArr.map((props) =>
+    defaults(props, VictoryAxis.defaultProps, fallbackProps)
+  );
+  const groupedAxis = groupBy(
+    modifyPropsArray.map((props, index) => ({ index, props })),
+    (obj) => Axis.isVertical(obj.props)
+  );
+  const result = flatten(Object.keys(groupedAxis).map((key) => {
+    const isVertical = key === "true";
+    const axisGroup = groupedAxis[isVertical];
+    return axisGroup.length > 1
+      ? getTicksForAxisWithSync(isVertical, axisGroup)
+      : getTicksWithoutSync(isVertical, axisGroup);
+  }));
+  return result.sort((obj1, obj2) => obj1.index > obj2.index).map((obj) => obj.ticks);
+};
+
+export default sync;

--- a/src/helpers/axissync.js
+++ b/src/helpers/axissync.js
@@ -3,7 +3,8 @@ import Axis from "./axis";
 import VictoryAxis from "../components/victory-axis/victory-axis.js";
 import AxisHelper from "../components/victory-axis/helper-methods.js";
 import { defaults, range, groupBy, flatten, merge } from "lodash";
-import * as d3 from "d3";
+import { tickStep } from "d3-array";
+import { scaleLinear } from "d3-scale";
 
 const defaultFontSize = 12;
 
@@ -14,7 +15,7 @@ const fallbackProps = {
 };
 
 const getShortestString = (domain) => {
-  const domainStrs = d3.scaleLinear().domain(domain).nice().domain().map((elem) => String(elem));
+  const domainStrs = scaleLinear().domain(domain).nice().domain().map((elem) => String(elem));
   return domainStrs.reduce((short, cur) => cur.length < short.length ? cur : short, domainStrs[0]);
 };
 
@@ -29,8 +30,34 @@ const getTicksAndInterval = (axisProps, tickCount) => {
   const props = merge(axisProps, { tickCount });
   return {
     ticks: AxisHelper.getTicks(props, scaleFunc),
-    tickInterval: d3.tickStep(domain[0], domain[1], tickCount)
+    tickInterval: tickStep(domain[0], domain[1], tickCount)
   };
+};
+
+/**
+   * @param {boolean} isVertical: Is vertical axis group
+   * @param {Object[]} axisGroup: Array of axis props and axis index
+   * @returns {Object[]} array of axis ticks, interval and index.
+   * Preserves the order of the input array.
+*/
+const getMultiAxisTicksAndInterval = (isVertical, axisGroup) => {
+  const maxMinSize = Math.max.apply(null,
+    axisGroup.map((obj) =>
+      getSize(isVertical,
+        TextSize.approximateTextSize(
+          getShortestString(obj.props.domain),
+          defaults(obj.props.style.tickLabels, { fontSize: defaultFontSize })
+        )
+      )
+    )
+  );
+  return axisGroup.map((axisObj) => {
+    return Object.assign(
+      getTicksAndInterval(
+        axisObj.props, getLabelCount(isVertical, axisObj.props, maxMinSize)
+      ), { index: axisObj.index }
+    );
+  });
 };
 
 const recalcTicks = (firstTick, tickInterval, index) =>
@@ -47,45 +74,14 @@ const syncTicks = (axisTicksArray) => {
     })
   );
 };
-
-const getTicksForAxisWithSync = (isVertical, axisGroup) => {
-  const maxMinSize = Math.max.apply(null,
-    axisGroup.map((obj) =>
-      getSize(isVertical,
-        TextSize.approximateTextSize(
-          getShortestString(obj.props.domain),
-          defaults(obj.props.style.tickLabels, { fontSize: defaultFontSize })
-        )
-      )
-    )
-  );
-  return syncTicks(
-    axisGroup.map((axisObj) => {
-      return Object.assign(
-        getTicksAndInterval(
-          axisObj.props, getLabelCount(isVertical, axisObj.props, maxMinSize)
-        ), { index: axisObj.index }
-      );
-    })
-  );
-};
-
-const getTicksWithoutSync = (isVertical, axisGroup) =>
-  axisGroup.map((axisObj) => {
-    const minSize = getSize(isVertical,
-      TextSize.approximateTextSize(
-        getShortestString(axisObj.props.domain),
-        defaults(axisObj.props.style.tickLabels, { fontSize: defaultFontSize })
-      )
-    );
-    return merge(
-      getTicksAndInterval(
-        axisObj.props, getLabelCount(isVertical, axisObj.props, minSize)
-      ), { index: axisObj.index }
-    );
-  });
-
-const sync = (axisPropsArr) => {
+ /**
+   * @param {Object[]} axisPropsArr: Array of axis props
+   * @param {Function} getMultiAxisTickAndIntervalFunc: Getting ticks, intervals and indexes
+   * for sorting from object with axis props and axis index.
+   * @returns {Object[]} array of axis ticks. Preserves the order of the input array.
+*/
+const sync = (axisPropsArr, getMultiAxisTickAndIntervalFunc) => {
+  const getTicksFunc = getMultiAxisTickAndIntervalFunc || getMultiAxisTicksAndInterval;
   const modifyPropsArray = axisPropsArr.map((props) =>
     defaults(props, VictoryAxis.defaultProps, fallbackProps)
   );
@@ -95,12 +91,10 @@ const sync = (axisPropsArr) => {
   );
   const result = flatten(Object.keys(groupedAxis).map((key) => {
     const isVertical = key === "true";
-    const axisGroup = groupedAxis[isVertical];
-    return axisGroup.length > 1
-      ? getTicksForAxisWithSync(isVertical, axisGroup)
-      : getTicksWithoutSync(isVertical, axisGroup);
+    const ticks = getTicksFunc(isVertical, groupedAxis[isVertical]);
+    return syncTicks(ticks);
   }));
   return result.sort((obj1, obj2) => obj1.index > obj2.index).map((obj) => obj.ticks);
 };
 
-export default sync;
+export default {sync, getMultiAxisTicksAndInterval};

--- a/test/client/spec/helpers/axissync.spec.js
+++ b/test/client/spec/helpers/axissync.spec.js
@@ -1,0 +1,94 @@
+/* eslint no-unused-expressions: 0 */
+import syncAxis from "src/helpers/axissync";
+
+describe("helpers/axissync", () => {
+  it("return expected tick count, based on size of domain labels width", () => {
+    const res = syncAxis([
+      { domain: [124.12312222, 3523], style: {}, width: 150, orientation: "bottom" },
+      { domain: [124.12312222, 3523], style: {}, width: 150, orientation: "bottom" }]
+    );
+    expect(
+      res[0].length
+    ).to.be.eql(17);
+  });
+  it("return expected tick count, based on size of domain labels height", () => {
+    expect(
+      syncAxis([
+        {
+          domain: [1.00000000000000000000001, 3],
+          style: { tickLabels: { fontSize: 20 } }, orientation: "left", height: 200
+        },
+        {
+          domain: [1.00000000000000000000001, 3],
+          style: { tickLabels: { fontSize: 20 } }, orientation: "left", height: 200
+        }
+      ])[0].length
+    ).to.be.eql(11);
+  });
+  it("return syncronized ticks with same ticks count", () => {
+    const syncedAxises = syncAxis(
+      [
+        {
+          domain: [2, 8],
+          style: {}, orientation: "left", height: 100
+        },
+        {
+          domain: [3, 12],
+          style: {}, orientation: "left", height: 100
+        }
+      ]
+    );
+    expect(syncedAxises[0].length).to.be.eql(7);
+    expect(syncedAxises[1].length).to.be.eql(7);
+  });
+  it("return expected ticks", () => {
+    const syncedAxises = syncAxis(
+      [{
+        domain: [1, 15],
+        style: {}, orientation: "left", height: 100
+      },
+        {
+          domain: [-1000, 4000],
+          style: {}, orientation: "left", height: 100
+        }
+      ]
+    );
+    expect(syncedAxises[0]).to.be.eql([2, 4, 6, 8, 10, 12, 14]);
+    expect(syncedAxises[1]).to.be.eql([-1000, 0, 1000, 2000, 3000, 4000, 5000]);
+  });
+  it("sync expected horizontal axis", () => {
+    const syncedAxises = syncAxis(
+      [{
+        domain: [1, 15],
+        style: {}, orientation: "bottom", width: 100
+      },
+        {
+          domain: [-1000, 4000],
+          style: {}, orientation: "top", width: 100
+        },
+        {
+          domain: [-1000, 1000],
+          style: {}, orientation: "left", height: 100
+        }
+      ]
+    );
+    expect(syncedAxises[0]).to.be.eql([5, 10, 15]);
+    expect(syncedAxises[1]).to.be.eql([0, 2000, 4000]);
+    expect(syncedAxises[2]).to.be.eql([-1000, -500, 0, 500, 1000]);
+  });
+  it("sync time axis", () => {
+    const syncedAxises = syncAxis(
+      [{
+        domain: [new Date(2015, 1, 1), new Date(2016, 1, 1)],
+        style: {}, orientation: "left", height: 100, scale: "time"
+      },
+        {
+          domain: [new Date(2015, 1, 1), new Date(2017, 1, 1)],
+          style: {}, orientation: "left", height: 100, scale: "time"
+        }
+      ]
+    );
+    expect(syncedAxises[0].map((time) => time.getTime())).to.have.length(8);
+    expect(syncedAxises[1].map((time) => time.getTime())).to.to.have.length(8);
+  });
+});

--- a/test/client/spec/helpers/axissync.spec.js
+++ b/test/client/spec/helpers/axissync.spec.js
@@ -1,9 +1,9 @@
 /* eslint no-unused-expressions: 0 */
-import syncAxis from "src/helpers/axissync";
+import axisSync from "src/helpers/axissync";
 
 describe("helpers/axissync", () => {
   it("return expected tick count, based on size of domain labels width", () => {
-    const res = syncAxis([
+    const res = axisSync.sync([
       { domain: [124.12312222, 3523], style: {}, width: 150, orientation: "bottom" },
       { domain: [124.12312222, 3523], style: {}, width: 150, orientation: "bottom" }]
     );
@@ -13,7 +13,7 @@ describe("helpers/axissync", () => {
   });
   it("return expected tick count, based on size of domain labels height", () => {
     expect(
-      syncAxis([
+      axisSync.sync([
         {
           domain: [1.00000000000000000000001, 3],
           style: { tickLabels: { fontSize: 20 } }, orientation: "left", height: 200
@@ -26,7 +26,7 @@ describe("helpers/axissync", () => {
     ).to.be.eql(11);
   });
   it("return syncronized ticks with same ticks count", () => {
-    const syncedAxises = syncAxis(
+    const syncedAxises = axisSync.sync(
       [
         {
           domain: [2, 8],
@@ -42,7 +42,7 @@ describe("helpers/axissync", () => {
     expect(syncedAxises[1].length).to.be.eql(7);
   });
   it("return expected ticks", () => {
-    const syncedAxises = syncAxis(
+    const syncedAxises = axisSync.sync(
       [{
         domain: [1, 15],
         style: {}, orientation: "left", height: 100
@@ -57,7 +57,7 @@ describe("helpers/axissync", () => {
     expect(syncedAxises[1]).to.be.eql([-1000, 0, 1000, 2000, 3000, 4000, 5000]);
   });
   it("sync expected horizontal axis", () => {
-    const syncedAxises = syncAxis(
+    const syncedAxises = axisSync.sync(
       [{
         domain: [1, 15],
         style: {}, orientation: "bottom", width: 100
@@ -77,7 +77,7 @@ describe("helpers/axissync", () => {
     expect(syncedAxises[2]).to.be.eql([-1000, -500, 0, 500, 1000]);
   });
   it("sync time axis", () => {
-    const syncedAxises = syncAxis(
+    const syncedAxises = axisSync.sync(
       [{
         domain: [new Date(2015, 1, 1), new Date(2016, 1, 1)],
         style: {}, orientation: "left", height: 100, scale: "time"


### PR DESCRIPTION
Hello again! 
I worked on the issue of multi axis in Victory Chart recently and got big fail in domain/scale separating and delivering into all components. 
But with it, i wrote some code for axises synchronization. (identical number of ticks and labels in each axis, with normal tickInterval)
I moved it in special helper and suggest you use it separately or in Victory Chart, if you would support MultiAxis in the near future.
![axis-sync](https://cloud.githubusercontent.com/assets/5007467/18440395/9cfb0856-7911-11e6-9456-96faee37f1bd.png)

Alignment algorithm:
1) getTicks 
4
3
2 2
1 1 1
0 0 0
2) get max tick count :
max(..ticks)
5
3) get tick interval and add need count of ticks as maxCount - curCount
4 4 4
3 3 3 
2 2 1
1 1 1
0 0 0

