### PR TITLE
VictoryLine#renderGroup shouldn't mix array/arglist syntax in React.cloneElement call

### DIFF
--- a/src/components/victory-line/victory-line.js
+++ b/src/components/victory-line/victory-line.js
@@ -451,11 +451,12 @@ export default class VictoryLine extends React.Component {
       clipHeight: props.clipHeight || props.height
     });
 
+    const newChildren = [clipComponent].concat(children);
+
     return React.cloneElement(
       this.props.groupComponent,
       { role: "presentation", style},
-      children,
-      clipComponent
+      newChildren
     );
   }
 


### PR DESCRIPTION
I came across this bug while working on [victory-standalone](https://github.com/FormidableLabs/victory-standalone). Basically, `preact` (and `preact-compat`, its React compatibility library) aren't *quite* as conscientious about handling children as React appears to be. Go figure.