### PR TITLE
Fix labels not showing if falsey (i.e. {0})

### DIFF
--- a/src/components/victory-area/helper-methods.js
+++ b/src/components/victory-area/helper-methods.js
@@ -28,7 +28,7 @@ export default {
     };
 
     const text = Helpers.evaluateProp(label, data);
-    if (text || props.events || props.sharedEvents) {
+    if (text !== undefined || props.events || props.sharedEvents) {
       baseProps.all.labels = this.getLabelProps(dataProps, text, style);
     }
 

--- a/src/components/victory-area/victory-area.js
+++ b/src/components/victory-area/victory-area.js
@@ -403,7 +403,7 @@ export default class VictoryArea extends React.Component {
 
     if (this.baseProps.all.labels || this.hasEvents) {
       const labelProps = getComponentProps(labelComponent, "labels");
-      if (labelProps && labelProps.text) {
+      if (labelProps && labelProps.text !== undefined) {
         const areaLabel = React.cloneElement(labelComponent, labelProps);
         return React.cloneElement(groupComponent, {}, areaComponent, areaLabel);
       }

--- a/src/components/victory-bar/helper-methods.js
+++ b/src/components/victory-bar/helper-methods.js
@@ -128,7 +128,7 @@ export default {
         data: dataProps
       };
       const text = this.getLabel(props, datum, index);
-      if (text || props.events || props.sharedEvents) {
+      if (text !== undefined || props.events || props.sharedEvents) {
         childProps[eventKey].labels = this.getLabelProps(dataProps, text, style);
       }
     }

--- a/src/components/victory-bar/victory-bar.js
+++ b/src/components/victory-bar/victory-bar.js
@@ -428,7 +428,7 @@ export default class VictoryBar extends React.Component {
 
       if (this.baseProps[key].labels || this.hasEvents) {
         const labelProps = getComponentProps(index, labelComponent, "labels");
-        if (labelProps && labelProps.text) {
+        if (labelProps && labelProps.text !== undefined) {
           labelComponents[index] = React.cloneElement(labelComponent, labelProps);
         }
       }

--- a/src/components/victory-candlestick/helper-methods.js
+++ b/src/components/victory-candlestick/helper-methods.js
@@ -29,7 +29,7 @@ export default {
         data: dataProps
       };
       const text = this.getLabelText(props, datum, index);
-      if (text || props.events || props.sharedEvents) {
+      if (text !== undefined || props.events || props.sharedEvents) {
         childProps[eventKey].labels = this.getLabelProps(dataProps, text, style);
       }
     }

--- a/src/components/victory-candlestick/victory-candlestick.js
+++ b/src/components/victory-candlestick/victory-candlestick.js
@@ -473,7 +473,7 @@ export default class VictoryCandlestick extends React.Component {
 
       if (this.baseProps[key].labels || this.hasEvents) {
         const labelProps = getComponentProps(index, labelComponent, "labels");
-        if (labelProps && labelProps.text) {
+        if (labelProps && labelProps.text !== undefined) {
           labelComponents[index] = React.cloneElement(labelComponent, labelProps);
         }
       }

--- a/src/components/victory-errorbar/helper-methods.js
+++ b/src/components/victory-errorbar/helper-methods.js
@@ -28,7 +28,7 @@ export default {
         data: dataProps
       };
       const text = this.getLabelText(props, datum, index);
-      if (text || props.events || props.sharedEvents) {
+      if (text !== undefined || props.events || props.sharedEvents) {
         childProps[eventKey].labels = this.getLabelProps(dataProps, text, style);
       }
     }

--- a/src/components/victory-errorbar/victory-errorbar.js
+++ b/src/components/victory-errorbar/victory-errorbar.js
@@ -409,7 +409,7 @@ export default class VictoryErrorBar extends React.Component {
 
       if (this.baseProps[key].labels || this.hasEvents) {
         const labelProps = getComponentProps(index, labelComponent, "labels");
-        if (labelProps && labelProps.text) {
+        if (labelProps && labelProps.text !== undefined) {
           labelComponents[index] = React.cloneElement(labelComponent, labelProps);
         }
       }

--- a/src/components/victory-line/helper-methods.js
+++ b/src/components/victory-line/helper-methods.js
@@ -29,7 +29,7 @@ export default {
     };
 
     const text = Helpers.evaluateProp(label, dataset);
-    if (text || props.events || props.sharedEvents) {
+    if (text !== undefined || props.events || props.sharedEvents) {
       baseProps.all.labels = this.getLabelProps(dataProps, text, calculatedValues, style);
     }
 

--- a/src/components/victory-line/victory-line.js
+++ b/src/components/victory-line/victory-line.js
@@ -437,7 +437,7 @@ export default class VictoryLine extends React.Component {
 
       if (this.baseProps.all.labels || this.hasEvents) {
         const labelProps = getComponentProps(index, labelComponent, "labels");
-        if (labelProps && labelProps.text) {
+        if (labelProps && labelProps.text !== undefined) {
           lineLabelComponents[index] = React.cloneElement(labelComponent, labelProps);
         }
       }

--- a/src/components/victory-scatter/victory-scatter.js
+++ b/src/components/victory-scatter/victory-scatter.js
@@ -423,7 +423,7 @@ export default class VictoryScatter extends React.Component {
 
       if (this.baseProps[key].labels || this.hasEvents) {
         const labelProps = getComponentProps(index, labelComponent, "labels");
-        if (labelProps && labelProps.text) {
+        if (labelProps && labelProps.text !== undefined) {
           labelComponents[index] = React.cloneElement(labelComponent, labelProps);
         }
       }

--- a/src/components/victory-voronoi-tooltip/helper-methods.js
+++ b/src/components/victory-voronoi-tooltip/helper-methods.js
@@ -26,7 +26,7 @@ export default {
 
       childProps[eventKey] = { data: dataProps };
       const text = this.getLabelText(props, datum, index);
-      if (text || props.events || props.sharedEvents) {
+      if (text !== undefined || props.events || props.sharedEvents) {
         childProps[eventKey].labels = assign(
           {},
           this.getFlyoutProps(dataProps, text, style),

--- a/src/components/victory-voronoi-tooltip/victory-voronoi-tooltip.js
+++ b/src/components/victory-voronoi-tooltip/victory-voronoi-tooltip.js
@@ -416,7 +416,7 @@ export default class VictoryVoronoiTooltip extends React.Component {
 
       if (this.baseProps[key].labels || this.hasEvents) {
         const labelProps = getComponentProps(index, labelComponent, "labels");
-        if (labelProps && labelProps.text) {
+        if (labelProps && labelProps.text !== undefined) {
           labelComponents[index] = React.cloneElement(labelComponent, labelProps);
         }
       }

--- a/src/components/victory-voronoi/helper-methods.js
+++ b/src/components/victory-voronoi/helper-methods.js
@@ -26,7 +26,7 @@ export default {
 
       childProps[eventKey] = { data: dataProps };
       const text = this.getLabelText(props, datum, index);
-      if (text || props.events || props.sharedEvents) {
+      if (text !== undefined || props.events || props.sharedEvents) {
         childProps[eventKey].labels = this.getLabelProps(dataProps, text, style);
       }
     }

--- a/src/components/victory-voronoi/victory-voronoi.js
+++ b/src/components/victory-voronoi/victory-voronoi.js
@@ -402,7 +402,7 @@ export default class VictoryVoronoi extends React.Component {
 
       if (this.baseProps[key].labels || this.hasEvents) {
         const labelProps = getComponentProps(index, labelComponent, "labels");
-        if (labelProps && labelProps.text) {
+        if (labelProps && labelProps.text !== undefined) {
           labelComponents[index] = React.cloneElement(labelComponent, labelProps);
         }
       }


### PR DESCRIPTION
Fixes #377

Labels such as the number 0 do not show since they are falsey.  The way #356 checked for `text` failed to account for falsey values we'd want to display.  Instead of checking if `text` is truthy, this PR checks if it is defined.