### PR TITLE
Reverse initial children array in wrapper helpers

### DIFF
--- a/src/helpers/wrapper.js
+++ b/src/helpers/wrapper.js
@@ -218,7 +218,7 @@ export default {
     const strings = [];
     let stringsLength = 0;
 
-    const children = childComponents.slice(0);
+    const children = childComponents.slice(0).reverse();
     let childrenLength = children.length;
 
     while (childrenLength > 0) {
@@ -246,7 +246,7 @@ export default {
     const strings = [];
     let stringsLength = 0;
 
-    const children = childComponents.slice(0);
+    const children = childComponents.slice(0).reverse();
     let childrenLength = children.length;
 
     while (childrenLength > 0) {


### PR DESCRIPTION
This is so the children are looped over in their original order.

Similar to https://github.com/FormidableLabs/victory-chart/pull/385