### PR TITLE
Fixed typo in VictoryAxis docs

### DIFF
--- a/docs/victory-axis/ecology.md
+++ b/docs/victory-axis/ecology.md
@@ -66,7 +66,7 @@ The sensible defaults VictoryAxis provides make it easy to get started, but ever
       grid: {strokeWidth: 2},
       ticks: {stroke: "red", size: 4},
       tickLabels: {fontSize: 12},
-      axisLabel: {fontsize: 16}
+      axisLabel: {fontSize: 16}
     }}
     label="Planets"
     tickValues={[


### PR DESCRIPTION
Spent a few minutes scratching my head when I couldn't get the axis label font size to change. A quick investigation led to the discovery of a tiny typo in the documentation (a casing issue).

The bug can be seen on the live docs, try changing the 'fontsize' value under the 'Flexible and Configurable' heading: https://formidable.com/open-source/victory/docs/victory-axis/