### PR TITLE
use VictoryGroupContainer

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "d3-scale": "^1.0.0",
     "d3-voronoi": "^1.0.0",
     "lodash": "^4.12.0",
-    "victory-core": "^7.0.1"
+    "victory-core": "^8.0.0"
   },
   "devDependencies": {
     "builder-victory-component-dev": "^2.4.0",

--- a/src/components/victory-area/victory-area.js
+++ b/src/components/victory-area/victory-area.js
@@ -5,7 +5,7 @@ import Data from "../../helpers/data";
 import Domain from "../../helpers/domain";
 import {
   PropTypes as CustomPropTypes, Helpers, Events, VictoryTransition, VictoryLabel,
-  VictoryContainer, VictoryTheme, DefaultTransitions, Area, ClipPath
+  VictoryContainer, VictoryTheme, DefaultTransitions, Area, VictoryGroupContainer
 } from "victory-core";
 
 const fallbackProps = {
@@ -19,7 +19,7 @@ export default class VictoryArea extends React.Component {
   static displayName = "VictoryArea";
   static role = "area";
   static defaultTransitions = DefaultTransitions.continuousTransitions();
-
+  static continuous = true;
   static propTypes = {
     /**
      * The animate prop specifies props for VictoryAnimation to use. The animate prop should
@@ -319,16 +319,7 @@ export default class VictoryArea extends React.Component {
      * create group elements for use within container elements. This prop defaults
      * to a <g> tag on web, and a react-native-svg <G> tag on mobile
      */
-    groupComponent: PropTypes.element,
-    /**
-     * The clipPathComponent prop takes an entire component which will be used to
-     * create clipPath elements for use within container elements.
-     */
-    clipPathComponent: PropTypes.element,
-    /**
-     * Unique clipId for clipPath
-     */
-    clipId: PropTypes.number
+    groupComponent: PropTypes.element
   };
 
   static defaultProps = {
@@ -340,8 +331,7 @@ export default class VictoryArea extends React.Component {
     x: "x",
     y: "y",
     containerComponent: <VictoryContainer />,
-    groupComponent: <g/>,
-    clipPathComponent: <ClipPath/>,
+    groupComponent: <VictoryGroupContainer/>,
     theme: VictoryTheme.grayscale
   };
 
@@ -378,14 +368,14 @@ export default class VictoryArea extends React.Component {
   }
 
   renderData(props) {
-    const { dataComponent, labelComponent, groupComponent, clipId } = props;
+    const { dataComponent, labelComponent, groupComponent } = props;
     const { role } = VictoryArea;
     const getComponentProps = (component, type) => {
       const key = "all";
       if (this.hasEvents) {
         const events = this.getEvents(props, type, key);
         const componentProps = defaults(
-          {role: `${role}`, clipId},
+          {role: `${role}`},
           this.getEventState(key, type),
           this.getSharedEventState(key, type),
           component.props,
@@ -395,7 +385,7 @@ export default class VictoryArea extends React.Component {
           {}, componentProps, {events: Events.getPartialEvents(events, key, componentProps)}
         );
       }
-      return defaults({role: `${role}`, clipId}, component.props, this.baseProps[key][type]);
+      return defaults({role: `${role}`}, component.props, this.baseProps[key][type]);
     };
 
     const dataProps = getComponentProps(dataComponent, "data");
@@ -433,27 +423,15 @@ export default class VictoryArea extends React.Component {
   }
 
   renderGroup(children, props, style) {
-    const { clipPathComponent } = props;
-
-    const clipComponent = React.cloneElement(clipPathComponent, {
-      padding: props.padding,
-      clipId: props.clipId,
-      translateX: props.translateX || 0,
-      clipWidth: props.clipWidth || props.width,
-      clipHeight: props.clipHeight || props.height
-    });
-
     return React.cloneElement(
       this.props.groupComponent,
       { role: "presentation", style},
-      children,
-      clipComponent
+      children
     );
   }
 
   render() {
-    const clipId = this.props.clipId || Math.round(Math.random() * 10000);
-    const props = Helpers.modifyProps(assign({clipId}, this.props), fallbackProps, "area");
+    const props = Helpers.modifyProps(this.props, fallbackProps, "area");
     const { animate, style, standalone, theme } = props;
 
     if (animate) {

--- a/src/components/victory-axis/victory-axis.js
+++ b/src/components/victory-axis/victory-axis.js
@@ -2,7 +2,7 @@ import React, { PropTypes } from "react";
 import { assign, defaults, isFunction, partialRight } from "lodash";
 import {
   PropTypes as CustomPropTypes, Helpers, Events, VictoryTransition, VictoryLabel,
-  VictoryContainer, VictoryTheme, Line, TextSize
+  VictoryContainer, VictoryTheme, Line, TextSize, VictoryGroupContainer
 } from "victory-core";
 import AxisHelpers from "./helper-methods";
 import Axis from "../../helpers/axis";
@@ -340,7 +340,7 @@ export default class VictoryAxis extends React.Component {
     theme: VictoryTheme.grayscale,
     tickCount: 5,
     containerComponent: <VictoryContainer />,
-    groupComponent: <g/>,
+    groupComponent: <VictoryGroupContainer/>,
     fixLabelOverlap: false
   };
 

--- a/src/components/victory-bar/victory-bar.js
+++ b/src/components/victory-bar/victory-bar.js
@@ -5,7 +5,7 @@ import Data from "../../helpers/data";
 import Domain from "../../helpers/domain";
 import {
   PropTypes as CustomPropTypes, Helpers, Events, VictoryTransition, VictoryLabel,
-  VictoryContainer, VictoryTheme, Bar, ClipPath
+  VictoryContainer, VictoryTheme, Bar, VictoryGroupContainer
 } from "victory-core";
 
 const fallbackProps = {
@@ -337,16 +337,7 @@ export default class VictoryBar extends React.Component {
      * create group elements for use within container elements. This prop defaults
      * to a <g> tag on web, and a react-native-svg <G> tag on mobile
      */
-    groupComponent: PropTypes.element,
-    /**
-     * The clipPathComponent prop takes an entire component which will be used to
-     * create clipPath elements for use within container elements.
-     */
-    clipPathComponent: PropTypes.element,
-    /**
-     * Unique clipId for clipPath
-     */
-    clipId: PropTypes.number
+    groupComponent: PropTypes.element
   };
 
   static defaultProps = {
@@ -358,8 +349,7 @@ export default class VictoryBar extends React.Component {
     x: "x",
     y: "y",
     containerComponent: <VictoryContainer/>,
-    groupComponent: <g/>,
-    clipPathComponent: <ClipPath/>,
+    groupComponent: <VictoryGroupContainer/>,
     theme: VictoryTheme.grayscale
   };
 
@@ -395,7 +385,7 @@ export default class VictoryBar extends React.Component {
   }
 
   renderData(props) {
-    const { dataComponent, labelComponent, groupComponent, clipId } = props;
+    const { dataComponent, labelComponent, groupComponent } = props;
     const { role } = VictoryBar;
     const dataComponents = [];
     const labelComponents = [];
@@ -404,7 +394,7 @@ export default class VictoryBar extends React.Component {
       if (this.hasEvents) {
         const events = this.getEvents(props, type, key);
         const componentProps = defaults(
-          {index, key: `${role}-${type}-${key}`, role: `${role}-${index}`, clipId},
+          { index, key: `${role}-${type}-${key}`, role: `${role}-${index}` },
           this.getEventState(key, type),
           this.getSharedEventState(key, type),
           component.props,
@@ -415,7 +405,7 @@ export default class VictoryBar extends React.Component {
         );
       }
       return defaults(
-        {index, key: `${role}-${type}-${key}`, role: `${role}-${index}`, clipId},
+        { index, key: `${role}-${type}-${key}`, role: `${role}-${index}` },
         component.props,
         this.baseProps[key][type]
       );
@@ -460,29 +450,15 @@ export default class VictoryBar extends React.Component {
   }
 
   renderGroup(children, props, style) {
-    const { clipPathComponent, horizontal } = props;
-    const barWidth = BarHelpers.getBarWidth(props);
-    const clipPadding = horizontal ?
-      {"top": barWidth, bottom: barWidth} : {left: barWidth, right: barWidth};
-    const clipComponent = React.cloneElement(clipPathComponent, {
-      padding: props.padding,
-      clipId: props.clipId,
-      clipWidth: (props.clipWidth || props.width),
-      clipHeight: (props.clipHeight || props.height),
-      clipPadding
-    });
-
     return React.cloneElement(
       props.groupComponent,
       { role: "presentation", style: style.parent},
-      children,
-      clipComponent
+      children
     );
   }
 
   render() {
-    const clipId = this.props.clipId || Math.round(Math.random() * 10000);
-    const props = Helpers.modifyProps(assign({clipId}, this.props), fallbackProps, "bar");
+    const props = Helpers.modifyProps(this.props, fallbackProps, "bar");
     const { animate, style, standalone, theme } = props;
     if (animate) {
       const whitelist = [

--- a/src/components/victory-candlestick/victory-candlestick.js
+++ b/src/components/victory-candlestick/victory-candlestick.js
@@ -2,7 +2,7 @@ import React, { PropTypes } from "react";
 import { assign, defaults, isFunction, partialRight } from "lodash";
 import {
   PropTypes as CustomPropTypes, Helpers, Events, VictoryTransition, VictoryLabel,
-  VictoryContainer, VictoryTheme, DefaultTransitions, Candle
+  VictoryContainer, VictoryTheme, DefaultTransitions, Candle, VictoryGroupContainer
 } from "victory-core";
 import CandlestickHelpers from "./helper-methods";
 
@@ -403,7 +403,7 @@ export default class VictoryCandlestick extends React.Component {
     dataComponent: <Candle/>,
     labelComponent: <VictoryLabel/>,
     containerComponent: <VictoryContainer/>,
-    groupComponent: <g/>,
+    groupComponent: <VictoryGroupContainer/>,
     theme: VictoryTheme.grayscale
   };
 

--- a/src/components/victory-chart/victory-chart.js
+++ b/src/components/victory-chart/victory-chart.js
@@ -1,7 +1,8 @@
 import { defaults } from "lodash";
 import React, { PropTypes } from "react";
 import {
-  PropTypes as CustomPropTypes, Helpers, VictorySharedEvents, VictoryContainer, VictoryTheme
+  PropTypes as CustomPropTypes, Helpers, VictorySharedEvents, VictoryContainer,
+  VictoryTheme, VictoryGroupContainer
 } from "victory-core";
 import VictoryAxis from "../victory-axis/victory-axis";
 import ChartHelpers from "./helper-methods";
@@ -229,7 +230,7 @@ export default class VictoryChart extends React.Component {
   static defaultProps = {
     standalone: true,
     containerComponent: <VictoryContainer/>,
-    groupComponent: <g/>,
+    groupComponent: <VictoryGroupContainer/>,
     theme: VictoryTheme.grayscale,
     defaultAxes: {
       independent: <VictoryAxis/>,

--- a/src/components/victory-errorbar/victory-errorbar.js
+++ b/src/components/victory-errorbar/victory-errorbar.js
@@ -1,7 +1,7 @@
 import React, { PropTypes } from "react";
 import {
   PropTypes as CustomPropTypes, Helpers, Events, VictoryTransition, VictoryLabel,
-  VictoryContainer, VictoryTheme, DefaultTransitions, ErrorBar
+  VictoryContainer, VictoryTheme, DefaultTransitions, ErrorBar, VictoryGroupContainer
 } from "victory-core";
 import { assign, defaults, isFunction, partialRight } from "lodash";
 import Data from "../../helpers/data";
@@ -339,7 +339,7 @@ export default class VictoryErrorBar extends React.Component {
     dataComponent: <ErrorBar/>,
     labelComponent: <VictoryLabel/>,
     containerComponent: <VictoryContainer/>,
-    groupComponent: <g/>,
+    groupComponent: <VictoryGroupContainer/>,
     theme: VictoryTheme.grayscale
   };
 

--- a/src/components/victory-group/victory-group.js
+++ b/src/components/victory-group/victory-group.js
@@ -1,7 +1,7 @@
 import { assign, defaults } from "lodash";
 import React, { PropTypes } from "react";
 import { PropTypes as CustomPropTypes, Helpers, VictorySharedEvents,
-  VictoryContainer, VictoryTheme
+  VictoryContainer, VictoryTheme, VictoryGroupContainer
 } from "victory-core";
 import Scale from "../../helpers/scale";
 import Axis from "../../helpers/axis";
@@ -337,7 +337,7 @@ export default class VictoryGroup extends React.Component {
     scale: "linear",
     standalone: true,
     containerComponent: <VictoryContainer/>,
-    groupComponent: <g/>,
+    groupComponent: <VictoryGroupContainer/>,
     theme: VictoryTheme.grayscale,
     x: "x",
     y: "y"

--- a/src/components/victory-line/victory-line.js
+++ b/src/components/victory-line/victory-line.js
@@ -5,7 +5,7 @@ import Domain from "../../helpers/domain";
 import Data from "../../helpers/data";
 import {
   PropTypes as CustomPropTypes, Helpers, Events, VictoryTransition, VictoryLabel,
-  VictoryContainer, VictoryTheme, DefaultTransitions, Curve, ClipPath
+  VictoryContainer, VictoryTheme, DefaultTransitions, Curve, VictoryGroupContainer
 } from "victory-core";
 
 const fallbackProps = {
@@ -19,7 +19,7 @@ export default class VictoryLine extends React.Component {
   static displayName = "VictoryLine";
   static role = "line";
   static defaultTransitions = DefaultTransitions.continuousTransitions();
-
+  static continuous = true;
   static propTypes = {
     /**
      * The animate prop specifies props for VictoryAnimation to use. The animate prop should
@@ -345,12 +345,7 @@ export default class VictoryLine extends React.Component {
      * create group elements for use within container elements. This prop defaults
      * to a <g> tag on web, and a react-native-svg <G> tag on mobile
      */
-    groupComponent: PropTypes.element,
-    /**
-     * The clipPathComponent prop takes an entire component which will be used to
-     * create clipPath elements for use within container elements.
-     */
-    clipPathComponent: PropTypes.element
+    groupComponent: PropTypes.element
   };
 
   static defaultProps = {
@@ -363,8 +358,7 @@ export default class VictoryLine extends React.Component {
     dataComponent: <Curve/>,
     labelComponent: <VictoryLabel/>,
     containerComponent: <VictoryContainer/>,
-    groupComponent: <g/>,
-    clipPathComponent: <ClipPath/>,
+    groupComponent: <VictoryGroupContainer/>,
     theme: VictoryTheme.grayscale
   };
 
@@ -402,7 +396,7 @@ export default class VictoryLine extends React.Component {
   }
 
   renderData(props) { // eslint-disable-line max-statements
-    const { dataComponent, labelComponent, groupComponent, clipId, sortKey } = props;
+    const { dataComponent, labelComponent, groupComponent, sortKey } = props;
     const { role } = VictoryLine;
     const dataSegments = LineHelpers.getDataSegments(Data.getData(props), sortKey);
     const lineComponents = [];
@@ -413,7 +407,7 @@ export default class VictoryLine extends React.Component {
       if (this.hasEvents) {
         const events = this.getEvents(props, type, key);
         const componentProps = defaults(
-          {index, key: `${role}-${type}-${index}`, role: `${role}-${index}`, clipId},
+          {index, key: `${role}-${type}-${index}`, role: `${role}-${index}`},
           this.getEventState(key, type),
           this.getSharedEventState(key, type),
           { data },
@@ -425,7 +419,7 @@ export default class VictoryLine extends React.Component {
         );
       }
       return defaults(
-        {index, key: `${role}-${type}-${index}`, role: `${role}-${index}`, clipId, data},
+        {index, key: `${role}-${type}-${index}`, role: `${role}-${index}`, data},
         component.props,
         this.baseProps[key][type]
       );
@@ -469,26 +463,15 @@ export default class VictoryLine extends React.Component {
   }
 
   renderGroup(children, props, style) {
-    const { clipPathComponent } = props;
-    const clipComponent = React.cloneElement(clipPathComponent, {
-      padding: props.padding,
-      clipId: props.clipId,
-      translateX: props.translateX || 0,
-      clipWidth: props.clipWidth || props.width,
-      clipHeight: props.clipHeight || props.height
-    });
-
     return React.cloneElement(
       this.props.groupComponent,
       { role: "presentation", style},
-      children,
-      clipComponent
+      children
     );
   }
 
   render() {
-    const clipId = Math.round(Math.random() * 10000);
-    const props = Helpers.modifyProps(assign({clipId}, this.props), fallbackProps, "line");
+    const props = Helpers.modifyProps(this.props, fallbackProps, "line");
     const { animate, style, standalone, theme } = props;
 
     if (animate) {

--- a/src/components/victory-scatter/victory-scatter.js
+++ b/src/components/victory-scatter/victory-scatter.js
@@ -4,7 +4,7 @@ import Domain from "../../helpers/domain";
 import Data from "../../helpers/data";
 import {
   PropTypes as CustomPropTypes, Helpers, Events, VictoryTransition, VictoryLabel,
-  VictoryContainer, VictoryTheme, DefaultTransitions, Point
+  VictoryContainer, VictoryTheme, DefaultTransitions, Point, VictoryGroupContainer
 } from "victory-core";
 import ScatterHelpers from "./helper-methods";
 
@@ -353,7 +353,7 @@ export default class VictoryScatter extends React.Component {
     dataComponent: <Point/>,
     labelComponent: <VictoryLabel/>,
     containerComponent: <VictoryContainer/>,
-    groupComponent: <g/>,
+    groupComponent: <VictoryGroupContainer/>,
     theme: VictoryTheme.grayscale
   };
 

--- a/src/components/victory-stack/victory-stack.js
+++ b/src/components/victory-stack/victory-stack.js
@@ -1,7 +1,8 @@
 import { assign, defaults } from "lodash";
 import React, { PropTypes } from "react";
 import {
-  PropTypes as CustomPropTypes, Helpers, VictorySharedEvents, VictoryContainer, VictoryTheme
+  PropTypes as CustomPropTypes, Helpers, VictorySharedEvents, VictoryContainer,
+  VictoryTheme, VictoryGroupContainer
 } from "victory-core";
 import Scale from "../../helpers/scale";
 import Wrapper from "../../helpers/wrapper";
@@ -291,7 +292,7 @@ export default class VictoryStack extends React.Component {
     scale: "linear",
     standalone: true,
     containerComponent: <VictoryContainer/>,
-    groupComponent: <g/>,
+    groupComponent: <VictoryGroupContainer/>,
     theme: VictoryTheme. grayscale
   };
 

--- a/src/components/victory-voronoi-tooltip/victory-voronoi-tooltip.js
+++ b/src/components/victory-voronoi-tooltip/victory-voronoi-tooltip.js
@@ -4,7 +4,7 @@ import Domain from "../../helpers/domain";
 import Data from "../../helpers/data";
 import {
   PropTypes as CustomPropTypes, Helpers, Events, VictoryTransition, VictoryTooltip,
-  VictoryContainer, VictoryTheme, DefaultTransitions, Voronoi
+  VictoryContainer, VictoryTheme, DefaultTransitions, Voronoi, VictoryGroupContainer
 } from "victory-core";
 import TooltipHelpers from "./helper-methods";
 
@@ -332,7 +332,7 @@ export default class VictoryVoronoiTooltip extends React.Component {
     dataComponent: <Voronoi/>,
     labelComponent: <VictoryTooltip/>,
     containerComponent: <VictoryContainer/>,
-    groupComponent: <g/>,
+    groupComponent: <VictoryGroupContainer/>,
     theme: VictoryTheme.grayscale
   };
 

--- a/src/components/victory-voronoi/victory-voronoi.js
+++ b/src/components/victory-voronoi/victory-voronoi.js
@@ -4,7 +4,7 @@ import Domain from "../../helpers/domain";
 import Data from "../../helpers/data";
 import {
   PropTypes as CustomPropTypes, Helpers, Events, VictoryTransition, VictoryLabel,
-  VictoryContainer, VictoryTheme, DefaultTransitions, Voronoi
+  VictoryContainer, VictoryTheme, DefaultTransitions, Voronoi, VictoryGroupContainer
 } from "victory-core";
 import VoronoiHelpers from "./helper-methods";
 
@@ -331,7 +331,7 @@ export default class VictoryVoronoi extends React.Component {
     dataComponent: <Voronoi/>,
     labelComponent: <VictoryLabel/>,
     containerComponent: <VictoryContainer/>,
-    groupComponent: <g/>,
+    groupComponent: <VictoryGroupContainer/>,
     theme: VictoryTheme.grayscale
   };
 


### PR DESCRIPTION
*depends on https://github.com/FormidableLabs/victory-core/pull/147*

This PR uses `VictoryGroupContainer` as the default `groupComponent` and removes `clipPath` props from any components that used them