### PR TITLE
Make zoom optional in VictoryZoom closes #429

### DIFF
--- a/demo/components/victory-brush-demo.js
+++ b/demo/components/victory-brush-demo.js
@@ -77,21 +77,20 @@ export default class App extends React.Component {
       <div className="demo">
         <h1>VictoryZoom</h1>
 
-          <VictoryZoom>
-            <VictoryGroup data={this.state.transitionData}>
-              <VictoryLine style={{data: this.state.style}} />
-            </VictoryGroup>
-          </VictoryZoom>
+        <VictoryZoom>
+          <VictoryGroup data={this.state.transitionData}>
+            <VictoryLine style={{data: this.state.style}} />
+          </VictoryGroup>
+        </VictoryZoom>
 
-          <VictoryZoom>
+        <VictoryZoom>
           <VictoryChart style={{parent: parentStyle}}>
-
-          <VictoryLine
-            style={{parent: parentStyle, data: this.state.style}}
-            data={this.state.data}
-            label={"label\none"}
-            animate={{duration: 1500}}
-          />
+            <VictoryLine
+              style={{parent: parentStyle, data: this.state.style}}
+              data={this.state.data}
+              label={"label\none"}
+              animate={{duration: 1500}}
+            />
           </VictoryChart>
         </VictoryZoom>
 
@@ -99,60 +98,57 @@ export default class App extends React.Component {
           New domain
         </button>
         <VictoryZoom zoomDomain={this.state.zoomDomain}>
-        <VictoryChart style={{parent: parentStyle}}>
-
-          <VictoryLine
-            style={{parent: parentStyle, data: {stroke: "blue"}}}
-            y={(d) => Math.sin(2 * Math.PI * d.x)}
-            sample={25}
-          />
+          <VictoryChart style={{parent: parentStyle}}>
+            <VictoryLine
+              style={{parent: parentStyle, data: {stroke: "blue"}}}
+              y={(d) => Math.sin(2 * Math.PI * d.x)}
+              sample={25}
+            />
           </VictoryChart>
         </VictoryZoom>
 
         <VictoryZoom>
-        <VictoryChart style={{parent: parentStyle}}>
-
-          <VictoryLine
-            style={{
-              parent: parentStyle,
-              data: {stroke: "red", strokeWidth: 6}
-            }}
-            events={[{
-              target: "data",
-              eventHandlers: {
-                onClick: () => {
-                  return [
-                    {
-                      mutation: (props) => {
-                        return {style: merge({}, props.style, {stroke: "orange"})};
+          <VictoryChart style={{parent: parentStyle}}>
+            <VictoryLine
+              style={{
+                parent: parentStyle,
+                data: {stroke: "red", strokeWidth: 6}
+              }}
+              events={[{
+                target: "data",
+                eventHandlers: {
+                  onClick: () => {
+                    return [
+                      {
+                        mutation: (props) => {
+                          return {style: merge({}, props.style, {stroke: "orange"})};
+                        }
+                      }, {
+                        target: "labels",
+                        mutation: () => {
+                          return {text: "hey"};
+                        }
                       }
-                    }, {
-                      target: "labels",
-                      mutation: () => {
-                        return {text: "hey"};
-                      }
-                    }
-                  ];
+                    ];
+                  }
                 }
-              }
-            }]}
-            label={this.state.label}
-            data={range(0, 100)}
-            y={(d) => d * d}
-          />
+              }]}
+              label={this.state.label}
+              data={range(0, 100)}
+              y={(d) => d * d}
+            />
           </VictoryChart>
         </VictoryZoom>
-        <VictoryZoom>
-        <VictoryChart style={{parent: parentStyle}}>
 
+        <VictoryZoom>
+          <VictoryChart style={{parent: parentStyle}}>
             <VictoryArea
               style={{parent: parentStyle, data: {stroke: "#333", fill: "#888", opacity: 0.4}}}
               data={this.state.barData}
               interpolation="stepBefore"
             />
-            </VictoryChart>
-          </VictoryZoom>
-
+          </VictoryChart>
+        </VictoryZoom>
       </div>
     );
   }

--- a/test/client/spec/components/victory-zoom/victory-zoom.spec.js
+++ b/test/client/spec/components/victory-zoom/victory-zoom.spec.js
@@ -1,0 +1,29 @@
+/**
+ * Client tests
+ */
+/*eslint-disable max-nested-callbacks */
+/* eslint no-unused-expressions: 0 */
+import React from "react";
+import { shallow } from "enzyme";
+import VictoryZoom from "src/components/victory-zoom/victory-zoom";
+import VictoryChart from "src/components/victory-chart/victory-chart";
+
+describe("components/victory-zoom", () => {
+  describe("allowZoom property", () => {
+    it("should allow or disallow zooming on the chart", () => {
+      const wrapper = shallow(
+        <VictoryZoom>
+          <VictoryChart />
+        </VictoryZoom>
+      );
+      const getHandlersList = (chart) => Object.keys(chart.props().events[0].eventHandlers);
+
+      const zoomableChart = wrapper.find(VictoryChart);
+      expect(getHandlersList(zoomableChart).indexOf("onWheel") !== -1).to.equal(true);
+
+      wrapper.setProps({allowZoom: false});
+      const nonZoomableChart = wrapper.find(VictoryChart);
+      expect(getHandlersList(nonZoomableChart).indexOf("onWheel") === -1).to.equal(true);
+    });
+  });
+});


### PR DESCRIPTION
Add an allowZoom prop to VictoryZoom component (default to `true` to keep current behaviour). This is a pretty naive implementation of the wanted behaviour, I guess we could just add/remove the event listeners when `allowZoom` changes at runtime (and thus avoid a rerender), but that would imply making bigger changes, and I'm not sure it's needed.

Moreover, I fixed the indentation of the demo, I was struggling to understand where each example started and finished! But I can easily remove these changes from this commit!

If this is good for you, I'll create a PR on the docs repo.