### PR TITLE
don't animate data accessors

### DIFF
--- a/src/components/victory-area/victory-area.js
+++ b/src/components/victory-area/victory-area.js
@@ -149,10 +149,7 @@ class VictoryArea extends React.Component {
     const { animate, style, standalone, theme } = props;
 
     if (this.shouldAnimate()) {
-      const whitelist = [
-        "data", "domain", "height", "padding", "style", "width",
-        "x", "y"
-      ];
+      const whitelist = ["data", "domain", "height", "padding", "style", "width"];
       return (
         <VictoryTransition animate={animate} animationWhitelist={whitelist}>
           {React.createElement(this.constructor, props)}

--- a/src/components/victory-bar/victory-bar.js
+++ b/src/components/victory-bar/victory-bar.js
@@ -178,12 +178,9 @@ class VictoryBar extends React.Component {
     const props = Helpers.modifyProps((this.props), fallbackProps, role);
     const { animate, style, standalone, theme } = props;
     if (this.shouldAnimate()) {
-      const animationWhitelist = [
-        "data", "domain", "height", "padding", "style", "width"
-      ];
-
+      const whitelist = ["data", "domain", "height", "padding", "style", "width"];
       return (
-        <VictoryTransition animate={animate} animationWhitelist={animationWhitelist}>
+        <VictoryTransition animate={animate} animationWhitelist={whitelist}>
           {React.createElement(this.constructor, props)}
         </VictoryTransition>
       );

--- a/src/components/victory-candlestick/victory-candlestick.js
+++ b/src/components/victory-candlestick/victory-candlestick.js
@@ -202,8 +202,7 @@ class VictoryCandlestick extends React.Component {
       // make sense to tween. In the future, allow customization of animated
       // prop whitelist/blacklist?
       const whitelist = [
-        "data", "domain", "height", "padding", "samples", "size",
-        "style", "width", "x", "y"
+        "data", "domain", "height", "padding", "samples", "size", "style", "width"
       ];
       return (
         <VictoryTransition animate={animate} animationWhitelist={whitelist}>

--- a/src/components/victory-errorbar/victory-errorbar.js
+++ b/src/components/victory-errorbar/victory-errorbar.js
@@ -180,7 +180,7 @@ class VictoryErrorBar extends React.Component {
       // prop whitelist/blacklist?
       const whitelist = [
         "data", "domain", "height", "padding", "samples",
-        "style", "width", "x", "y", "errorX", "errorY", "borderWidth"
+        "style", "width", "errorX", "errorY", "borderWidth"
       ];
       return (
         <VictoryTransition animate={animate} animationWhitelist={whitelist}>

--- a/src/components/victory-line/victory-line.js
+++ b/src/components/victory-line/victory-line.js
@@ -166,10 +166,7 @@ class VictoryLine extends React.Component {
       // make sense to tween. In the future, allow customization of animated
       // prop whitelist/blacklist?
       // TODO: extract into helper
-      const whitelist = [
-        "data", "domain", "height", "padding", "samples",
-        "style", "width", "x", "y"
-      ];
+      const whitelist = ["data", "domain", "height", "padding", "samples", "style", "width"];
       return (
         <VictoryTransition animate={animate} animationWhitelist={whitelist}>
           {React.createElement(this.constructor, props)}

--- a/src/components/victory-scatter/victory-scatter.js
+++ b/src/components/victory-scatter/victory-scatter.js
@@ -165,8 +165,7 @@ class VictoryScatter extends React.Component {
 
     if (this.shouldAnimate()) {
       const whitelist = [
-        "data", "domain", "height", "maxBubbleSize", "padding", "samples", "size",
-        "style", "width", "x", "y"
+        "data", "domain", "height", "maxBubbleSize", "padding", "samples", "size", "style", "width"
       ];
       return (
         <VictoryTransition animate={animate} animationWhitelist={whitelist}>

--- a/src/components/victory-voronoi-tooltip/victory-voronoi-tooltip.js
+++ b/src/components/victory-voronoi-tooltip/victory-voronoi-tooltip.js
@@ -159,8 +159,7 @@ class VictoryVoronoiTooltip extends React.Component {
       // make sense to tween. In the future, allow customization of animated
       // prop whitelist/blacklist?
       const whitelist = [
-        "data", "domain", "height", "padding", "samples", "size",
-        "style", "width", "x", "y"
+        "data", "domain", "height", "padding", "samples", "size", "style", "width"
       ];
       return (
         <VictoryTransition animate={animate} animationWhitelist={whitelist}>

--- a/src/components/victory-voronoi/victory-voronoi.js
+++ b/src/components/victory-voronoi/victory-voronoi.js
@@ -159,8 +159,7 @@ class VictoryVoronoi extends React.Component {
       // make sense to tween. In the future, allow customization of animated
       // prop whitelist/blacklist?
       const whitelist = [
-        "data", "domain", "height", "padding", "samples", "size",
-        "style", "width", "x", "y"
+        "data", "domain", "height", "padding", "samples", "size", "style", "width"
       ];
       return (
         <VictoryTransition animate={animate} animationWhitelist={whitelist}>


### PR DESCRIPTION
fixes https://github.com/FormidableLabs/victory/issues/444

Remove `x` and `y` from the animation whitelist.