### PR TITLE
Fix issue with VictoryZoom child events

### DIFF
--- a/demo/components/victory-brush-demo.js
+++ b/demo/components/victory-brush-demo.js
@@ -98,8 +98,27 @@ export default class App extends React.Component {
           New domain
         </button>
         <VictoryZoom zoomDomain={this.state.zoomDomain}>
-          <VictoryChart style={{parent: parentStyle}}>
+          <VictoryChart
+            style={{parent: parentStyle}}
+            events={[{
+              target: "data",
+              childName: "line",
+              eventHandlers: {
+                onClick: () => {
+                  return [
+                    {
+                      mutation: (props) => {
+                        const strokeWidth = props.style.strokeWidth + 1;
+                        return {style: merge({}, props.style, {strokeWidth})};
+                      }
+                    }
+                  ];
+                }
+              }
+            }]}
+          >
             <VictoryLine
+              name="line"
               style={{parent: parentStyle, data: {stroke: "blue"}}}
               y={(d) => Math.sin(2 * Math.PI * d.x)}
               sample={25}

--- a/src/components/victory-zoom/victory-zoom.js
+++ b/src/components/victory-zoom/victory-zoom.js
@@ -176,8 +176,12 @@ class VictoryZoom extends Component {
 
   render() {
     const chart = React.Children.only(this.props.children);
+    const events = chart.props.events
+      ? (this.events || []).concat(chart.props.events)
+      : this.events;
+
     const nextProps = assign({}, chart.props, {
-      events: chart.props.events ? chart.props.events.unshift(...this.events) : this.events,
+      events,
       domain: this.state.domain,
       ref: this.getChartRef,
       modifyChildren: this.clipDataComponents


### PR DESCRIPTION
Fixes https://github.com/FormidableLabs/victory/issues/443.

When prepending zoom event handlers to shared events, we erroneously used `Array#unshift` as an expression, which returns the number of inserted elements, not the new array.

Fixed by using `Array#concat` instead.

Added chart events to one of the zoom demos to verify fix.