### PR TITLE
Feature/voronoi container

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -14,6 +14,7 @@ import GroupDemo from "./components/group-demo";
 import VoronoiDemo from "./components/victory-voronoi-demo";
 import TooltipDemo from "./components/victory-tooltip-demo";
 import ZoomContainerDemo from "./components/victory-zoom-container-demo";
+import VoronoiContainerDemo from "./components/victory-voronoi-container-demo";
 import ZoomDemo from "./components/victory-zoom-demo";
 import BrushContainerDemo from "./components/victory-brush-container-demo";
 import AnimationDemo from "./components/animation-demo";
@@ -45,10 +46,11 @@ const App = React.createClass({
           <li><Link to="/voronoi">Victory Voronoi Demo</Link></li>
           <li><Link to="/tooltip">Victory Tooltip Demo</Link></li>
           <li><Link to="/zoom-container">Victory Zoom Container Demo</Link></li>
+          <li><Link to="/voronoi-container">Victory Voronoi Container Demo</Link></li>
           <li><Link to="/zoom">Victory Zoom Demo</Link></li>
           <li><Link to="/brush-container">Victory Brush Container Demo</Link></li>
           <li><Link to="/animation">Animation Demo</Link></li>
-          <li><Link to="/selection">Selection Demo</Link></li>
+          <li><Link to="/selection">Victory Selection Container Demo</Link></li>
         </ul>
         {this.props.children}
       </div>
@@ -72,6 +74,7 @@ ReactDOM.render((
       <Route path="voronoi" component={VoronoiDemo}/>
       <Route path="tooltip" component={TooltipDemo}/>
       <Route path="zoom-container" component={ZoomContainerDemo}/>
+      <Route path="voronoi-container" component={VoronoiContainerDemo}/>
       <Route path="zoom" component={ZoomDemo}/>
       <Route path="brush-container" component={BrushContainerDemo}/>
       <Route path="animation" component={AnimationDemo}/>

--- a/demo/components/selection-demo.js
+++ b/demo/components/selection-demo.js
@@ -3,6 +3,7 @@ import {
   VictoryChart, VictoryGroup, VictoryStack, VictoryScatter, VictoryBar, VictoryLine,
   VictorySelectionContainer
 } from "../../src/index";
+import { VictoryTooltip } from "victory-core";
 
 class App extends React.Component {
 
@@ -105,6 +106,52 @@ class App extends React.Component {
                 {x: 7, y: -3}
               ]}
             />
+          </VictoryChart>
+
+          <VictoryChart style={chartStyle}
+            containerComponent={<VictorySelectionContainer/>}
+          >
+            <VictoryGroup
+              data={[
+                {x: 1, y: 5, label: "one"},
+                {x: 2, y: 4, label: "two"},
+                {x: 3, y: -2, label: "three"}
+              ]}
+            >
+              <VictoryLine name="line-1" style={{ data: {stroke: "tomato"}}}/>
+              <VictoryScatter name="scatter-1"
+                style={{ data: {fill: (d, active) => active ? "tomato" : "gray"}}}
+                labelComponent={<VictoryTooltip/>}
+              />
+            </VictoryGroup>
+
+            <VictoryGroup
+              data={[
+                {x: 1, y: -3, label: "red"},
+                {x: 2, y: 5, label: "green"},
+                {x: 3, y: 3, label: "blue"}
+              ]}
+            >
+              <VictoryLine name="line-2" style={{ data: {stroke: "blue"}}}/>
+              <VictoryScatter name="scatter-2"
+                style={{ data: {fill: (d, active) => active ? "blue" : "gray"}}}
+                labelComponent={<VictoryTooltip/>}
+              />
+            </VictoryGroup>
+
+            <VictoryGroup
+              data={[
+                {x: 1, y: 5, label: "cat"},
+                {x: 2, y: -4, label: "dog"},
+                {x: 3, y: -2, label: "bird"}
+              ]}
+            >
+              <VictoryLine name="line-3" style={{ data: {stroke: "black"}}}/>
+              <VictoryScatter name="scatter-3"
+                style={{ data: {fill: (d, active) => active ? "black" : "gray"}}}
+                labelComponent={<VictoryTooltip/>}
+              />
+            </VictoryGroup>
           </VictoryChart>
 
           <VictoryScatter

--- a/demo/components/selection-demo.js
+++ b/demo/components/selection-demo.js
@@ -113,42 +113,45 @@ class App extends React.Component {
           >
             <VictoryGroup
               data={[
-                {x: 1, y: 5, label: "one"},
-                {x: 2, y: 4, label: "two"},
-                {x: 3, y: -2, label: "three"}
+                {x: 1, y: 5},
+                {x: 2, y: 4},
+                {x: 3, y: -2}
               ]}
             >
               <VictoryLine style={{ data: {stroke: "tomato"}}}/>
               <VictoryScatter
                 style={{ data: {fill: (d, active) => active ? "tomato" : "gray"}}}
+                labels={(d) => d.y}
                 labelComponent={<VictoryTooltip/>}
               />
             </VictoryGroup>
 
             <VictoryGroup
               data={[
-                {x: 1, y: -3, label: "red"},
-                {x: 2, y: 5, label: "green"},
-                {x: 3, y: 3, label: "blue"}
+                {x: 1, y: -3},
+                {x: 2, y: 5},
+                {x: 3, y: 3}
               ]}
             >
               <VictoryLine style={{ data: {stroke: "blue"}}}/>
               <VictoryScatter
                 style={{ data: {fill: (d, active) => active ? "blue" : "gray"}}}
+                labels={(d) => d.y}
                 labelComponent={<VictoryTooltip/>}
               />
             </VictoryGroup>
 
             <VictoryGroup
               data={[
-                {x: 1, y: 5, label: "cat"},
-                {x: 2, y: -4, label: "dog"},
-                {x: 3, y: -2, label: "bird"}
+                {x: 1, y: 5},
+                {x: 2, y: -4},
+                {x: 3, y: -2}
               ]}
             >
               <VictoryLine style={{ data: {stroke: "black"}}}/>
               <VictoryScatter
                 style={{ data: {fill: (d, active) => active ? "black" : "gray"}}}
+                labels={(d) => d.y}
                 labelComponent={<VictoryTooltip/>}
               />
             </VictoryGroup>

--- a/demo/components/selection-demo.js
+++ b/demo/components/selection-demo.js
@@ -118,8 +118,8 @@ class App extends React.Component {
                 {x: 3, y: -2, label: "three"}
               ]}
             >
-              <VictoryLine name="line-1" style={{ data: {stroke: "tomato"}}}/>
-              <VictoryScatter name="scatter-1"
+              <VictoryLine style={{ data: {stroke: "tomato"}}}/>
+              <VictoryScatter
                 style={{ data: {fill: (d, active) => active ? "tomato" : "gray"}}}
                 labelComponent={<VictoryTooltip/>}
               />
@@ -132,8 +132,8 @@ class App extends React.Component {
                 {x: 3, y: 3, label: "blue"}
               ]}
             >
-              <VictoryLine name="line-2" style={{ data: {stroke: "blue"}}}/>
-              <VictoryScatter name="scatter-2"
+              <VictoryLine style={{ data: {stroke: "blue"}}}/>
+              <VictoryScatter
                 style={{ data: {fill: (d, active) => active ? "blue" : "gray"}}}
                 labelComponent={<VictoryTooltip/>}
               />
@@ -146,8 +146,8 @@ class App extends React.Component {
                 {x: 3, y: -2, label: "bird"}
               ]}
             >
-              <VictoryLine name="line-3" style={{ data: {stroke: "black"}}}/>
-              <VictoryScatter name="scatter-3"
+              <VictoryLine style={{ data: {stroke: "black"}}}/>
+              <VictoryScatter
                 style={{ data: {fill: (d, active) => active ? "black" : "gray"}}}
                 labelComponent={<VictoryTooltip/>}
               />

--- a/demo/components/victory-area-demo.js
+++ b/demo/components/victory-area-demo.js
@@ -101,6 +101,7 @@ export default class App extends React.Component {
         <VictoryChart style={style} scale={{y: "log"}}>
           <VictoryArea
             style={{data: {fill: "cyan", stroke: "cyan"}}}
+            labels={(d) => Math.round(d.y)}
             data={[{x: 1, y: 0.2}, {x: 2, y: 3}, {x: 3, y: 50}, {x: 4, y: 400}, {x: 5, y: 70}]}
           />
         </VictoryChart>

--- a/demo/components/victory-area-demo.js
+++ b/demo/components/victory-area-demo.js
@@ -226,6 +226,7 @@ export default class App extends React.Component {
                     }
                   }, {
                     target: "labels",
+                    eventKey: 0,
                     mutation: () => {
                       return {text: "hey"};
                     }

--- a/demo/components/victory-area-demo.js
+++ b/demo/components/victory-area-demo.js
@@ -157,21 +157,20 @@ export default class App extends React.Component {
         <VictoryArea
           style={{parent: style.parent, data: this.state.style}}
           data={this.state.data}
-          label={"label\none"}
           animate={{duration: 2000}}
         />
 
       <VictoryStack style={{parent: style.parent}}>
-          <VictoryArea label={"one"}
+          <VictoryArea
             data={[{x: 1, y: 2}, {x: 2, y: 3}, {x: 3, y: 5}, {x: 4, y: 4}, {x: 5, y: 7}]}
           />
-          <VictoryArea label={"two"}
+          <VictoryArea
             data={[{x: 1, y: 1}, {x: 2, y: 4}, {x: 3, y: 5}, {x: 4, y: 7}, {x: 5, y: 5}]}
           />
-          <VictoryArea label={"three"}
+          <VictoryArea
             data={[{x: 1, y: 3}, {x: 2, y: 2}, {x: 3, y: 6}, {x: 4, y: 2}, {x: 5, y: 6}]}
           />
-          <VictoryArea label={"four"}
+          <VictoryArea
             data={[{x: 1, y: 2}, {x: 2, y: 3}, {x: 3, y: 3}, {x: 4, y: 4}, {x: 5, y: 7}]}
           />
         </VictoryStack>
@@ -326,16 +325,16 @@ export default class App extends React.Component {
         </VictoryStack>
 
         <VictoryStack style={{parent: style.parent}} theme={VictoryTheme.material}>
-          <VictoryArea label={"one"}
+          <VictoryArea
             data={[{x: 1, y: 2}, {x: 2, y: 3}, {x: 3, y: 5}, {x: 4, y: 4}, {x: 5, y: 7}]}
           />
-          <VictoryArea label={"two"}
+          <VictoryArea
             data={[{x: 1, y: 1}, {x: 2, y: 4}, {x: 3, y: 5}, {x: 4, y: 7}, {x: 5, y: 5}]}
           />
-          <VictoryArea label={"three"}
+          <VictoryArea
             data={[{x: 1, y: 3}, {x: 2, y: 2}, {x: 3, y: 6}, {x: 4, y: 2}, {x: 5, y: 6}]}
           />
-          <VictoryArea label={"four"}
+          <VictoryArea
             data={[{x: 1, y: 2}, {x: 2, y: 3}, {x: 3, y: 3}, {x: 4, y: 4}, {x: 5, y: 7}]}
           />
         </VictoryStack>

--- a/demo/components/victory-line-demo.js
+++ b/demo/components/victory-line-demo.js
@@ -1,10 +1,14 @@
 /*global window:false */
-import React from "react";
+import React, { PropTypes } from "react";
 import { merge, random, range } from "lodash";
 import {VictoryLine, VictoryChart} from "../../src/index";
 import { VictoryContainer, VictoryTheme, Curve, Point } from "victory-core";
 
 class PointedLine extends React.Component {
+  static propTypes = {
+    index: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+
   renderLine(props) {
     return <Curve {...props} />;
   }

--- a/demo/components/victory-line-demo.js
+++ b/demo/components/victory-line-demo.js
@@ -136,6 +136,7 @@ export default class App extends React.Component {
                     }
                   }, {
                     target: "labels",
+                    eventKey: 99,
                     mutation: () => {
                       return {text: "hey"};
                     }

--- a/demo/components/victory-line-demo.js
+++ b/demo/components/victory-line-demo.js
@@ -5,11 +5,6 @@ import {VictoryLine, VictoryChart} from "../../src/index";
 import { VictoryContainer, VictoryTheme, Curve, Point } from "victory-core";
 
 class PointedLine extends React.Component {
-  static propTypes = {
-    ...Curve.propTypes,
-    index: React.PropTypes.number
-  };
-
   renderLine(props) {
     return <Curve {...props} />;
   }

--- a/demo/components/victory-line-demo.js
+++ b/demo/components/victory-line-demo.js
@@ -166,6 +166,7 @@ export default class App extends React.Component {
 
         <VictoryLine
           style={{parent: parentStyle}}
+          labels={(d) => Math.round(d.y)}
           data={[
             {x: new Date(1982, 1, 1), y: 125},
             {x: new Date(1987, 1, 1), y: 257},

--- a/demo/components/victory-line-demo.js
+++ b/demo/components/victory-line-demo.js
@@ -144,7 +144,6 @@ export default class App extends React.Component {
               }
             }
           }]}
-          label={this.state.label}
           data={range(0, 100)}
           y={(d) => d * d}
         />
@@ -206,7 +205,6 @@ export default class App extends React.Component {
         <VictoryLine
           style={{parent: parentStyle}}
           data={this.state.arrayData}
-          label="Hello"
           x={0}
           y={1}
           theme={VictoryTheme.grayscale}
@@ -218,7 +216,6 @@ export default class App extends React.Component {
           <VictoryLine
             style={{parent: parentStyle}}
             data={this.state.arrayData}
-            label="Hello"
             x={0}
             y={1}
           />
@@ -268,7 +265,6 @@ export default class App extends React.Component {
         <VictoryLine
           style={{parent: parentStyle}}
           data={this.state.arrayData}
-          label="Hello"
           x={0}
           domainPadding={{x: [0, 100]}}
           y={1}

--- a/demo/components/victory-tooltip-demo.js
+++ b/demo/components/victory-tooltip-demo.js
@@ -1,7 +1,7 @@
 import React from "react";
 import {
   VictoryChart, VictoryLine, VictoryBar, VictoryArea,
-  VictoryScatter, VictoryStack, VictoryGroup,
+  VictoryScatter, VictoryStack, VictoryGroup, VictoryAxis,
   VictoryCandlestick, VictoryErrorBar
 } from "../../src/index";
 import { VictoryTooltip } from "victory-core";
@@ -111,8 +111,9 @@ class App extends React.Component {
               labels={["a", "b", "c"]}
               labelComponent={<VictoryTooltip/>}
               horizontal
-              offset={20}
+              offset={35}
               colorScale={"qualitative"}
+              style={{ data: {width: 20, pointerEvents: "all"}}}
             >
               <VictoryBar
                 data={[
@@ -139,10 +140,12 @@ class App extends React.Component {
          </VictoryChart>
 
          <VictoryChart style={{parent: parentStyle}}>
+            <VictoryAxis/>
             <VictoryStack
               colorScale={"qualitative"}
               labels={["a", "b", "c"]}
               labelComponent={<VictoryTooltip/>}
+              style={{ data: {width: 30, pointerEvents: "visible"}}}
             >
               <VictoryBar
                 data={[

--- a/demo/components/victory-voronoi-container-demo.js
+++ b/demo/components/victory-voronoi-container-demo.js
@@ -142,6 +142,8 @@ class App extends React.Component {
                   data: {fill: "tomato"}
                 }}
                 size={(datum, active) => active ? 5 : 3}
+                labels={(d) => d.y}
+                labelComponent={<VictoryTooltip/>}
                 data={[
                   {x: 1, y: -5},
                   {x: 2, y: 4},
@@ -157,6 +159,8 @@ class App extends React.Component {
                   data: {fill: "blue"}
                 }}
                 size={(datum, active) => active ? 5 : 3}
+                labels={(d) => d.y}
+                labelComponent={<VictoryTooltip/>}
                 data={[
                   {x: 1, y: -3},
                   {x: 2, y: 5},
@@ -177,6 +181,8 @@ class App extends React.Component {
                   {x: 6, y: 3},
                   {x: 7, y: -3}
                 ]}
+                labels={(d) => d.y}
+                labelComponent={<VictoryTooltip/>}
                 size={(datum, active) => active ? 5 : 3}
               />
             </VictoryGroup>

--- a/demo/components/victory-voronoi-container-demo.js
+++ b/demo/components/victory-voronoi-container-demo.js
@@ -1,0 +1,248 @@
+import React from "react";
+import {
+  VictoryChart, VictoryGroup, VictoryStack, VictoryScatter, VictoryBar, VictoryLine,
+  VictoryVoronoiContainer
+} from "../../src/index";
+
+class App extends React.Component {
+
+  constructor() {
+    super();
+    this.state = {
+      points: []
+    };
+  }
+
+  handleSelection(datasets) {
+    const points = datasets.reduce((memo, dataset) => {
+      memo = memo.concat(dataset.data);
+      return memo;
+    }, []);
+    this.setState({points});
+  }
+
+  handleClearSelection() {
+    this.setState({points: []});
+  }
+
+  render() {
+    const containerStyle = {
+      display: "flex",
+      flexDirection: "row",
+      flexWrap: "wrap",
+      alignItems: "center",
+      justifyContent: "center"
+    };
+
+    const chartStyle = {parent: {border: "1px solid #ccc", margin: "2%", maxWidth: "40%"}};
+
+    return (
+      <div className="demo">
+        <div style={containerStyle}>
+          <VictoryChart style={chartStyle}
+            containerComponent={
+              <VictoryVoronoiContainer
+                onSelection={this.handleSelection.bind(this)}
+                onSelectionCleared={this.handleClearSelection.bind(this)}
+              />
+            }
+          >
+            <VictoryLine
+              style={{
+                data: {stroke: "tomato"}
+              }}
+              data={[
+                {x: 1, y: 5},
+                {x: 2, y: 4},
+                {x: 3, y: -2}
+              ]}
+            />
+            <VictoryLine
+              style={{
+                data: {stroke: "blue"}
+              }}
+              data={[
+                {x: 1, y: -3},
+                {x: 2, y: 5},
+                {x: 3, y: 3}
+              ]}
+            />
+            <VictoryLine
+              data={[
+                {x: 1, y: 5},
+                {x: 2, y: -4},
+                {x: 3, y: -2}
+              ]}
+            />
+          </VictoryChart>
+
+          <VictoryScatter
+            style={{
+              parent: chartStyle.parent,
+              data: {
+                fill: (datum, active) => active ? "tomato" : "black"
+              }
+            }}
+            containerComponent={
+              <VictoryVoronoiContainer
+                selectionStyle={{
+                  stroke: "tomato", strokeWidth: 2, fill: "tomato", fillOpacity: 0.1
+                }}
+              />
+            }
+            size={(datum, active) => active ? 5 : 3}
+            data={[
+              {x: 1, y: -5},
+              {x: 2, y: 4},
+              {x: 3, y: 2},
+              {x: 4, y: 3},
+              {x: 5, y: 1},
+              {x: 6, y: -3},
+              {x: 7, y: 3}
+            ]}
+          />
+
+          <VictoryScatter
+            style={{
+              parent: chartStyle.parent,
+              data: {
+                fill: (datum, active) => active ? "tomato" : "black"
+              }
+            }}
+            containerComponent={
+              <VictoryVoronoiContainer
+                selectionStyle={{
+                  stroke: "tomato", strokeWidth: 2, fill: "tomato", fillOpacity: 0.1
+                }}
+              />
+            }
+            size={(datum, active) => active ? 5 : 3}
+            y={(d) => d.x * d.x}
+          />
+
+          <VictoryGroup style={chartStyle}
+            containerComponent={
+              <VictoryVoronoiContainer
+                selectionStyle={{
+                  stroke: "tomato", strokeWidth: 2, fill: "tomato", fillOpacity: 0.1
+                }}
+              />
+            }
+          >
+            <VictoryScatter
+              style={{
+                data: {fill: "tomato"}
+              }}
+              size={(datum, active) => active ? 5 : 3}
+              data={[
+                {x: 1, y: -5},
+                {x: 2, y: 4},
+                {x: 3, y: 2},
+                {x: 4, y: 0},
+                {x: 5, y: 1},
+                {x: 6, y: -3},
+                {x: 7, y: 3}
+              ]}
+            />
+            <VictoryScatter
+              style={{
+                data: {fill: "blue"}
+              }}
+              size={(datum, active) => active ? 5 : 3}
+              data={[
+                {x: 1, y: -3},
+                {x: 2, y: 5},
+                {x: 3, y: 3},
+                {x: 4, y: 0},
+                {x: 5, y: -2},
+                {x: 6, y: -2},
+                {x: 7, y: 5}
+              ]}
+            />
+            <VictoryScatter
+              data={[
+                {x: 1, y: 5},
+                {x: 2, y: -4},
+                {x: 3, y: -2},
+                {x: 4, y: -3},
+                {x: 5, y: -1},
+                {x: 6, y: 3},
+                {x: 7, y: -3}
+              ]}
+              size={(datum, active) => active ? 5 : 3}
+            />
+          </VictoryGroup>
+
+          <VictoryStack style={chartStyle}
+            containerComponent={
+              <VictoryVoronoiContainer
+                selectionStyle={{
+                  stroke: "tomato", strokeWidth: 2, fill: "tomato", fillOpacity: 0.1
+                }}
+              />
+            }
+          >
+            <VictoryBar
+              style={{
+                data: {
+                  fill: "tomato",
+                  stroke: (d, active) => active ? "black" : "none",
+                  strokeWidth: 2
+                }
+              }}
+              size={(datum, active) => active ? 5 : 3}
+              data={[
+                {x: 1, y: -5},
+                {x: 2, y: 4},
+                {x: 3, y: 2},
+                {x: 4, y: 3},
+                {x: 5, y: 1},
+                {x: 6, y: -3},
+                {x: 7, y: 3}
+              ]}
+            />
+            <VictoryBar
+              style={{
+                data: {
+                  fill: "orange",
+                  stroke: (d, active) => active ? "black" : "none",
+                  strokeWidth: 2
+                }
+              }}
+              size={(datum, active) => active ? 5 : 3}
+              data={[
+                {x: 1, y: -3},
+                {x: 2, y: 5},
+                {x: 3, y: 3},
+                {x: 4, y: 0},
+                {x: 5, y: -2},
+                {x: 6, y: -2},
+                {x: 7, y: 5}
+              ]}
+            />
+            <VictoryBar
+              style={{
+                data: {
+                  fill: "gold",
+                  stroke: (d, active) => active ? "black" : "none",
+                  strokeWidth: 2
+                }
+              }}
+              data={[
+                {x: 1, y: 5},
+                {x: 2, y: -4},
+                {x: 3, y: -2},
+                {x: 4, y: -3},
+                {x: 5, y: -1},
+                {x: 6, y: 3},
+                {x: 7, y: -3}
+              ]}
+            />
+          </VictoryStack>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default App;

--- a/demo/components/victory-voronoi-container-demo.js
+++ b/demo/components/victory-voronoi-container-demo.js
@@ -52,49 +52,37 @@ class App extends React.Component {
       <div className="demo">
         <div style={containerStyle}>
           <VictoryChart style={chartStyle}
-            containerComponent={<VictoryVoronoiContainer/>}
+            containerComponent={<VictoryVoronoiContainer radius={50}/>}
           >
-            <VictoryGroup
+            <VictoryLine
               data={[
                 {x: 1, y: 5, label: "one"},
                 {x: 2, y: 4, label: "two"},
                 {x: 3, y: -2, label: "three"}
               ]}
-            >
-              <VictoryLine style={{ data: {stroke: "tomato"}}}/>
-              <VictoryScatter
-                style={{ data: {fill: (d, active) => active ? "tomato" : "none"}}}
-                labelComponent={<VictoryTooltip/>}
-              />
-            </VictoryGroup>
+              labelComponent={<VictoryTooltip/>}
+              style={{ data: { stroke: "tomato", strokeWidth: (d, active) => active ? 4 : 2}}}
+            />
 
-            <VictoryGroup
+            <VictoryLine
               data={[
                 {x: 1, y: -3, label: "red"},
                 {x: 2, y: 5, label: "green"},
                 {x: 3, y: 3, label: "blue"}
               ]}
-            >
-              <VictoryLine style={{ data: {stroke: "blue"}}}/>
-              <VictoryScatter
-                style={{ data: {fill: (d, active) => active ? "blue" : "none"}}}
-                labelComponent={<VictoryTooltip/>}
-              />
-            </VictoryGroup>
+              style={{ data: { stroke: "blue", strokeWidth: (d, active) => active ? 4 : 2}}}
+              labelComponent={<VictoryTooltip/>}
+            />
 
-            <VictoryGroup
+            <VictoryLine
               data={[
                 {x: 1, y: 5, label: "cat"},
                 {x: 2, y: -4, label: "dog"},
                 {x: 3, y: -2, label: "bird"}
               ]}
-            >
-              <VictoryLine style={{ data: {stroke: "black"}}}/>
-              <VictoryScatter
-                style={{ data: {fill: (d, active) => active ? "black" : "none"}}}
-                labelComponent={<VictoryTooltip/>}
-              />
-            </VictoryGroup>
+              style={{ data: { stroke: "black", strokeWidth: (d, active) => active ? 4 : 2}}}
+              labelComponent={<VictoryTooltip/>}
+            />
           </VictoryChart>
 
           <VictoryScatter

--- a/demo/components/victory-voronoi-container-demo.js
+++ b/demo/components/victory-voronoi-container-demo.js
@@ -53,7 +53,10 @@ class App extends React.Component {
         <div style={containerStyle}>
           <VictoryChart style={chartStyle}
             containerComponent={
-              <VictoryVoronoiContainer radius={50} labels={(d) => d.l}/>
+              <VictoryVoronoiContainer dimension="x"
+                labels={(d) => d.l}
+                labelComponent={<VictoryTooltip pointerLength={0} cornerRadius={0}/>}
+              />
             }
           >
             <VictoryLine
@@ -101,7 +104,7 @@ class App extends React.Component {
                 fill: (datum, active) => active ? "tomato" : "black"
               }
             }}
-            containerComponent={<VictoryVoronoiContainer size={20}/>}
+            containerComponent={<VictoryVoronoiContainer dimension="x"/>}
             size={(datum, active) => active ? 5 : 3}
             data={this.state.data}
             x="a"

--- a/demo/components/victory-voronoi-container-demo.js
+++ b/demo/components/victory-voronoi-container-demo.js
@@ -55,13 +55,13 @@ class App extends React.Component {
             containerComponent={
               <VictoryVoronoiContainer dimension="x"
                 labels={(d) => d.l}
-                labelComponent={<VictoryTooltip pointerLength={0} cornerRadius={0}/>}
               />
             }
           >
             <VictoryLine
               data={[
                 {x: 1, y: 5, l: "one"},
+                {x: 1.5, y: -7, l: "one point five"},
                 {x: 2, y: 4, l: "two"},
                 {x: 3, y: -2, l: "three"}
               ]}

--- a/demo/components/victory-voronoi-container-demo.js
+++ b/demo/components/victory-voronoi-container-demo.js
@@ -54,14 +54,14 @@ class App extends React.Component {
           <VictoryChart style={chartStyle}
             containerComponent={
               <VictoryVoronoiContainer dimension="x"
-                labels={(d) => d.l}
+                labels={(d) => `y: ${d.y}`}
+                labelComponent={<VictoryTooltip cornerRadius={0} flyoutStyle={{fill: "white"}}/>}
               />
             }
           >
             <VictoryLine
               data={[
                 {x: 1, y: 5, l: "one"},
-                {x: 1.5, y: -7, l: "one point five"},
                 {x: 2, y: 4, l: "two"},
                 {x: 3, y: -2, l: "three"}
               ]}

--- a/demo/components/victory-voronoi-container-demo.js
+++ b/demo/components/victory-voronoi-container-demo.js
@@ -1,8 +1,10 @@
+/*global window:false*/
 import React from "react";
 import {
   VictoryChart, VictoryGroup, VictoryStack, VictoryScatter, VictoryBar, VictoryLine,
   VictoryVoronoiContainer
 } from "../../src/index";
+import { random, range } from "lodash";
 
 import { VictoryTooltip } from "victory-core";
 class App extends React.Component {
@@ -10,20 +12,29 @@ class App extends React.Component {
   constructor() {
     super();
     this.state = {
-      points: []
+      data: this.getData()
     };
   }
 
-  handleSelection(datasets) {
-    const points = datasets.reduce((memo, dataset) => {
-      memo = memo.concat(dataset.data);
-      return memo;
-    }, []);
-    this.setState({points});
+  componentDidMount() {
+    /* eslint-disable react/no-did-mount-set-state */
+    this.setStateInterval = window.setInterval(() => {
+      this.setState({
+        data: this.getData()
+      });
+    }, 3000);
   }
 
-  handleClearSelection() {
-    this.setState({points: []});
+  componentWillUnmount() {
+    window.clearInterval(this.setStateInterval);
+  }
+
+
+  getData() {
+    const bars = random(6, 10);
+    return range(bars).map((bar) => {
+      return {a: bar + 1, b: random(2, 10)};
+    });
   }
 
   render() {
@@ -41,12 +52,7 @@ class App extends React.Component {
       <div className="demo">
         <div style={containerStyle}>
           <VictoryChart style={chartStyle}
-            containerComponent={
-              <VictoryVoronoiContainer
-                onSelection={this.handleSelection.bind(this)}
-                onSelectionCleared={this.handleClearSelection.bind(this)}
-              />
-            }
+            containerComponent={<VictoryVoronoiContainer/>}
           >
             <VictoryGroup
               data={[
@@ -92,29 +98,18 @@ class App extends React.Component {
           </VictoryChart>
 
           <VictoryScatter
+            animate={{duration: 1000}}
             style={{
               parent: chartStyle.parent,
               data: {
                 fill: (datum, active) => active ? "tomato" : "black"
               }
             }}
-            containerComponent={
-              <VictoryVoronoiContainer
-                selectionStyle={{
-                  stroke: "tomato", strokeWidth: 2, fill: "tomato", fillOpacity: 0.1
-                }}
-              />
-            }
+            containerComponent={<VictoryVoronoiContainer size={20}/>}
             size={(datum, active) => active ? 5 : 3}
-            data={[
-              {x: 1, y: -5},
-              {x: 2, y: 4},
-              {x: 3, y: 2},
-              {x: 4, y: 3},
-              {x: 5, y: 1},
-              {x: 6, y: -3},
-              {x: 7, y: 3}
-            ]}
+            data={this.state.data}
+            x="a"
+            y="b"
           />
 
           <VictoryScatter

--- a/demo/components/victory-voronoi-container-demo.js
+++ b/demo/components/victory-voronoi-container-demo.js
@@ -4,6 +4,7 @@ import {
   VictoryVoronoiContainer
 } from "../../src/index";
 
+import { VictoryTooltip } from "victory-core";
 class App extends React.Component {
 
   constructor() {
@@ -47,33 +48,47 @@ class App extends React.Component {
               />
             }
           >
-            <VictoryLine
-              style={{
-                data: {stroke: "tomato"}
-              }}
+            <VictoryGroup
               data={[
-                {x: 1, y: 5},
-                {x: 2, y: 4},
-                {x: 3, y: -2}
+                {x: 1, y: 5, label: "one"},
+                {x: 2, y: 4, label: "two"},
+                {x: 3, y: -2, label: "three"}
               ]}
-            />
-            <VictoryLine
-              style={{
-                data: {stroke: "blue"}
-              }}
+            >
+              <VictoryLine style={{ data: {stroke: "tomato"}}}/>
+              <VictoryScatter
+                style={{ data: {fill: (d, active) => active ? "tomato" : "none"}}}
+                labelComponent={<VictoryTooltip/>}
+              />
+            </VictoryGroup>
+
+            <VictoryGroup
               data={[
-                {x: 1, y: -3},
-                {x: 2, y: 5},
-                {x: 3, y: 3}
+                {x: 1, y: -3, label: "red"},
+                {x: 2, y: 5, label: "green"},
+                {x: 3, y: 3, label: "blue"}
               ]}
-            />
-            <VictoryLine
+            >
+              <VictoryLine style={{ data: {stroke: "blue"}}}/>
+              <VictoryScatter
+                style={{ data: {fill: (d, active) => active ? "blue" : "none"}}}
+                labelComponent={<VictoryTooltip/>}
+              />
+            </VictoryGroup>
+
+            <VictoryGroup
               data={[
-                {x: 1, y: 5},
-                {x: 2, y: -4},
-                {x: 3, y: -2}
+                {x: 1, y: 5, label: "cat"},
+                {x: 2, y: -4, label: "dog"},
+                {x: 3, y: -2, label: "bird"}
               ]}
-            />
+            >
+              <VictoryLine style={{ data: {stroke: "black"}}}/>
+              <VictoryScatter
+                style={{ data: {fill: (d, active) => active ? "black" : "none"}}}
+                labelComponent={<VictoryTooltip/>}
+              />
+            </VictoryGroup>
           </VictoryChart>
 
           <VictoryScatter
@@ -120,68 +135,54 @@ class App extends React.Component {
             y={(d) => d.x * d.x}
           />
 
-          <VictoryGroup style={chartStyle}
-            containerComponent={
-              <VictoryVoronoiContainer
-                selectionStyle={{
-                  stroke: "tomato", strokeWidth: 2, fill: "tomato", fillOpacity: 0.1
+          <VictoryChart style={chartStyle} containerComponent={<VictoryVoronoiContainer/>}>
+            <VictoryGroup style={chartStyle}>
+              <VictoryScatter
+                style={{
+                  data: {fill: "tomato"}
                 }}
+                size={(datum, active) => active ? 5 : 3}
+                data={[
+                  {x: 1, y: -5},
+                  {x: 2, y: 4},
+                  {x: 3, y: 2},
+                  {x: 4, y: 0},
+                  {x: 5, y: 1},
+                  {x: 6, y: -3},
+                  {x: 7, y: 3}
+                ]}
               />
-            }
-          >
-            <VictoryScatter
-              style={{
-                data: {fill: "tomato"}
-              }}
-              size={(datum, active) => active ? 5 : 3}
-              data={[
-                {x: 1, y: -5},
-                {x: 2, y: 4},
-                {x: 3, y: 2},
-                {x: 4, y: 0},
-                {x: 5, y: 1},
-                {x: 6, y: -3},
-                {x: 7, y: 3}
-              ]}
-            />
-            <VictoryScatter
-              style={{
-                data: {fill: "blue"}
-              }}
-              size={(datum, active) => active ? 5 : 3}
-              data={[
-                {x: 1, y: -3},
-                {x: 2, y: 5},
-                {x: 3, y: 3},
-                {x: 4, y: 0},
-                {x: 5, y: -2},
-                {x: 6, y: -2},
-                {x: 7, y: 5}
-              ]}
-            />
-            <VictoryScatter
-              data={[
-                {x: 1, y: 5},
-                {x: 2, y: -4},
-                {x: 3, y: -2},
-                {x: 4, y: -3},
-                {x: 5, y: -1},
-                {x: 6, y: 3},
-                {x: 7, y: -3}
-              ]}
-              size={(datum, active) => active ? 5 : 3}
-            />
-          </VictoryGroup>
+              <VictoryScatter
+                style={{
+                  data: {fill: "blue"}
+                }}
+                size={(datum, active) => active ? 5 : 3}
+                data={[
+                  {x: 1, y: -3},
+                  {x: 2, y: 5},
+                  {x: 3, y: 3},
+                  {x: 4, y: 0},
+                  {x: 5, y: -2},
+                  {x: 6, y: -2},
+                  {x: 7, y: 5}
+                ]}
+              />
+              <VictoryScatter
+                data={[
+                  {x: 1, y: 5},
+                  {x: 2, y: -4},
+                  {x: 3, y: -2},
+                  {x: 4, y: -3},
+                  {x: 5, y: -1},
+                  {x: 6, y: 3},
+                  {x: 7, y: -3}
+                ]}
+                size={(datum, active) => active ? 5 : 3}
+              />
+            </VictoryGroup>
+          </VictoryChart>
 
-          <VictoryStack style={chartStyle}
-            containerComponent={
-              <VictoryVoronoiContainer
-                selectionStyle={{
-                  stroke: "tomato", strokeWidth: 2, fill: "tomato", fillOpacity: 0.1
-                }}
-              />
-            }
-          >
+          <VictoryStack style={chartStyle} containerComponent={<VictoryVoronoiContainer/>}>
             <VictoryBar
               style={{
                 data: {

--- a/demo/components/victory-voronoi-container-demo.js
+++ b/demo/components/victory-voronoi-container-demo.js
@@ -52,36 +52,44 @@ class App extends React.Component {
       <div className="demo">
         <div style={containerStyle}>
           <VictoryChart style={chartStyle}
-            containerComponent={<VictoryVoronoiContainer radius={50}/>}
+            containerComponent={
+              <VictoryVoronoiContainer radius={50} labels={(d) => d.l}/>
+            }
           >
             <VictoryLine
               data={[
-                {x: 1, y: 5, label: "one"},
-                {x: 2, y: 4, label: "two"},
-                {x: 3, y: -2, label: "three"}
+                {x: 1, y: 5, l: "one"},
+                {x: 2, y: 4, l: "two"},
+                {x: 3, y: -2, l: "three"}
               ]}
-              labelComponent={<VictoryTooltip/>}
-              style={{ data: { stroke: "tomato", strokeWidth: (d, active) => active ? 4 : 2}}}
+              style={{
+                data: { stroke: "tomato", strokeWidth: (d, active) => active ? 4 : 2},
+                labels: {fill: "tomato"}
+              }}
             />
 
             <VictoryLine
               data={[
-                {x: 1, y: -3, label: "red"},
-                {x: 2, y: 5, label: "green"},
-                {x: 3, y: 3, label: "blue"}
+                {x: 1, y: -3, l: "red"},
+                {x: 2, y: 5, l: "green"},
+                {x: 3, y: 3, l: "blue"}
               ]}
-              style={{ data: { stroke: "blue", strokeWidth: (d, active) => active ? 4 : 2}}}
-              labelComponent={<VictoryTooltip/>}
+              style={{
+                data: { stroke: "blue", strokeWidth: (d, active) => active ? 4 : 2},
+                labels: {fill: "blue"}
+              }}
             />
 
             <VictoryLine
               data={[
-                {x: 1, y: 5, label: "cat"},
-                {x: 2, y: -4, label: "dog"},
-                {x: 3, y: -2, label: "bird"}
+                {x: 1, y: 5, l: "cat"},
+                {x: 2, y: -4, l: "dog"},
+                {x: 3, y: -2, l: "bird"}
               ]}
-              style={{ data: { stroke: "black", strokeWidth: (d, active) => active ? 4 : 2}}}
-              labelComponent={<VictoryTooltip/>}
+              style={{
+                data: { stroke: "black", strokeWidth: (d, active) => active ? 4 : 2},
+                labels: {fill: "black"}
+              }}
             />
           </VictoryChart>
 

--- a/demo/components/victory-voronoi-container-demo.js
+++ b/demo/components/victory-voronoi-container-demo.js
@@ -62,6 +62,7 @@ class App extends React.Component {
             <VictoryLine
               data={[
                 {x: 1, y: 5, l: "one"},
+                {x: 1.5, y: 5, l: "one point five"},
                 {x: 2, y: 4, l: "two"},
                 {x: 3, y: -2, l: "three"}
               ]}

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "builder-victory-component": "^3.1.0",
     "d3-voronoi": "^1.0.0",
     "lodash": "^4.12.0",
-    "victory-core": "^13.0.0"
+    "victory-core": "^14.0.0"
   },
   "devDependencies": {
     "builder-victory-component-dev": "^3.1.0",

--- a/src/components/containers/brush-helpers.js
+++ b/src/components/containers/brush-helpers.js
@@ -1,5 +1,5 @@
 import { Selection } from "victory-core";
-import { assign, throttle, isFunction, isEqual, reduce } from "lodash";
+import { assign, throttle, isFunction, isEqual } from "lodash";
 
 
 const Helpers = {
@@ -45,7 +45,7 @@ const Helpers = {
 
   getActiveHandles(point, props, domainBox) {
     const handles = this.getHandles(props, domainBox);
-    const activeHandles = reduce(["top", "bottom", "left", "right"], (memo, opt) => {
+    const activeHandles = ["top", "bottom", "left", "right"].reduce((memo, opt) => {
       memo = this.withinBounds(point, handles[opt]) ? memo.concat(opt) : memo;
       return memo;
     }, []);
@@ -60,7 +60,7 @@ const Helpers = {
       top: {y1: Math.max(y1, y2), y2: Math.min(y1, y2), x1, x2},
       bottom: {y1: Math.min(y1, y2), y2: Math.max(y1, y2), x1, x2}
     };
-    return reduce(handles, (memo, current) => {
+    return handles.reduce((memo, current) => {
       return assign(memo, mutations[current]);
     }, {});
   },

--- a/src/components/containers/selection-helpers.js
+++ b/src/components/containers/selection-helpers.js
@@ -15,7 +15,7 @@ const Helpers = {
 
     const getDataset = (children, childIndex, parent) => {
       return children.reduce((memo, child, index) => {
-        const key = childIndex ? `${childIndex}-${index}` : index;
+        const key = childIndex !== undefined ? `${childIndex}-${index}` : index;
         const childName = child.props.name || key;
         if (child.type && child.type.role === "axis") {
           return memo;
@@ -126,6 +126,7 @@ const Helpers = {
     const datasets = this.getDatasets(targetProps);
     const bounds = Selection.getBounds(targetProps);
     const selectedData = this.filterDatasets(datasets, bounds);
+    console.log(selectedData)
     const callbackMutation = selectedData && isFunction(targetProps.onSelection) ?
       targetProps.onSelection(selectedData, bounds) : {};
 
@@ -139,7 +140,7 @@ const Helpers = {
     const dataMutation = selectedData ?
       selectedData.map((d) => {
         return {
-          childName: d.childName, eventKey: d.eventKey, target: "data",
+          childName: d.childName, eventKey: d.eventKey[0], target: "data",
           mutation: () => {
             return assign({active: true}, callbackMutation);
           }

--- a/src/components/containers/selection-helpers.js
+++ b/src/components/containers/selection-helpers.js
@@ -1,45 +1,77 @@
 import { Selection, Data } from "victory-core";
-import { assign, throttle, isFunction } from "lodash";
+import { assign, throttle, isFunction, omit, defaults, keys } from "lodash";
 import React from "react";
 
 const Helpers = {
-  getDatasets(props) { // eslint-disable-line max-statements
+  getDatasets(props) {
     if (props.data) {
       return [{data: props.data}];
     }
-    const getData = (childProps) => {
-      const data = Data.getData(childProps);
-      return Array.isArray(data) && data.length > 0 ? data : undefined;
-    };
-
-    // Reverse the child array to maintain correct order when looping over
-    // children starting from the end of the array.
-    const children = React.Children.toArray(props.children).reverse();
-    let childrenLength = children.length;
-    const dataArr = [];
-    let dataArrLength = 0;
-    let childIndex = 0;
-    while (childrenLength > 0) {
-      const child = children[--childrenLength];
-      const childName = child.props.name || childIndex;
-      childIndex++;
-      if (child.type && child.type.role === "axis") {
-        childIndex++;
-      } else if (child.type && isFunction(child.type.getData)) {
-        dataArr[dataArrLength++] = {childName, data: child.type.getData(child.props)};
-      } else if (child.props && child.props.children) {
-        const newChildren = React.Children.toArray(child.props.children);
-        const newChildrenLength = newChildren.length;
-        for (let index = 0; index < newChildrenLength; index++) {
-          children[childrenLength++] = newChildren[index];
+    const getData = (children, childIndex, parent) => {
+      return children.reduce((memo, child, index) => {
+        if (child.type && child.type.role === "axis") {
+          return memo;
+        } else if (child.props && child.props.children) {
+          const nestedChildren = React.Children.toArray(child.props.children);
+          const nestedDatasets = getData(nestedChildren, index, child);
+          memo = memo.concat(nestedDatasets);
+        } else if (child.type && isFunction(child.type.getData)) {
+          child = parent ? React.cloneElement(child, parent.props) : child;
+          const childData = child.props && child.type.getData(child.props);
+          if (childData) {
+            const key = childIndex ? `${childIndex}-${index}` : index;
+            const childName = child.props.name || key;
+            memo = memo.concat([{childName, data: childData}]);
+          }
         }
-      } else {
-        dataArr[dataArrLength++] = {childName, data: getData(child.props)};
-      }
-    }
-    console.log(dataArr)
-    return dataArr;
+        return memo;
+      }, []);
+    };
+    return getData(React.Children.toArray(props.children));
   },
+
+  // getDatasets(props) { // eslint-disable-line max-statements
+  //   if (props.data) {
+  //     return [{data: props.data}];
+  //   }
+  //   const getData = (childProps) => {
+  //     const data = Data.getData(childProps);
+  //     return Array.isArray(data) && data.length > 0 ? data : undefined;
+  //   };
+
+  //   // Reverse the child array to maintain correct order when looping over
+  //   // children starting from the end of the array.
+  //   const children = React.Children.toArray(props.children).reverse();
+  //   let childrenLength = children.length;
+  //   const dataArr = [];
+  //   let dataArrLength = 0;
+  //   let childIndex = 0;
+  //   while (childrenLength > 0) {
+  //     const child = children[--childrenLength];
+  //     const childName = child.props.name || childIndex;
+  //     if (child.type && child.type.role === "axis") {
+  //       childIndex++;
+  //     } else if (child.props && child.props.children) {
+  //       const newChildren = React.Children.toArray(child.props.children).reverse();
+  //       const newChildrenLength = newChildren.length;
+  //       childIndex++;
+  //       for (let index = 0; index < newChildrenLength; index++) {
+  //         const newChild = newChildren[index];
+  //         const proxiedProps = defaults({}, newChild.props, omit(child.props, "children"));
+  //         children[childrenLength++] = React.cloneElement(newChild, proxiedProps);
+  //       }
+  //     } else if (child.type && isFunction(child.type.getData)) {
+  //       dataArr[dataArrLength++] = {childName, data: child.type.getData(child.props)};
+  //       childIndex++;
+
+  //     } else {
+  //       dataArr[dataArrLength++] = {childName, data: getData(child.props)};
+  //       childIndex++;
+
+  //     }
+  //   }
+  //   return dataArr;
+  // },
 
   filterDatasets(datasets, bounds) {
     const filtered = datasets.reduce((memo, dataset) => {
@@ -76,6 +108,7 @@ const Helpers = {
   onMouseDown(evt, targetProps) {
     evt.preventDefault();
     const { dimension, scale } = targetProps;
+    const datasets = targetProps.datasets || [];
     const {x, y} = Selection.getSVGEventCoordinates(evt);
     const x1 = dimension !== "y" ? x : Selection.getDomainCoordinates(scale).x[0];
     const y1 = dimension !== "x" ? y : Selection.getDomainCoordinates(scale).y[0];
@@ -92,7 +125,7 @@ const Helpers = {
         }
       }, {
         target: "data",
-        childName: targetProps.children ? "all" : undefined,
+        childName: targetProps.children || datasets.length ? "all" : undefined,
         eventKey: "all",
         mutation: () => null
       }
@@ -118,20 +151,27 @@ const Helpers = {
 
   onMouseUp(evt, targetProps) {
     const {x2, y2} = targetProps;
-    const parentMutation = [{
-      target: "parent",
-      mutation: () => {
-        return { select: false, x1: null, x2: null, y1: null, y2: null };
-      }
-    }];
     if (!x2 || !y2) {
-      return parentMutation;
+      return [{
+        target: "parent",
+        mutation: () => {
+          return { select: false, x1: null, x2: null, y1: null, y2: null };
+        }
+      }];
     }
-    const bounds = Selection.getBounds(targetProps);
     const datasets = this.getDatasets(targetProps);
+    const bounds = Selection.getBounds(targetProps);
     const selectedData = this.filterDatasets(datasets, bounds);
     const callbackMutation = selectedData && isFunction(targetProps.onSelection) ?
       targetProps.onSelection(selectedData, bounds) : {};
+
+    const parentMutation = [{
+      target: "parent",
+      mutation: () => {
+        return { datasets, select: false, x1: null, x2: null, y1: null, y2: null };
+      }
+    }];
+
     const dataMutation = selectedData ?
       selectedData.map((d) => {
         return {
@@ -141,6 +181,7 @@ const Helpers = {
           }
         };
       }) : [];
+
     return parentMutation.concat(dataMutation);
   }
 };

--- a/src/components/containers/selection-helpers.js
+++ b/src/components/containers/selection-helpers.js
@@ -37,6 +37,7 @@ const Helpers = {
         dataArr[dataArrLength++] = {childName, data: getData(child.props)};
       }
     }
+    console.log(dataArr)
     return dataArr;
   },
 

--- a/src/components/containers/victory-brush-container.js
+++ b/src/components/containers/victory-brush-container.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { VictoryContainer, Selection } from "victory-core";
 import BrushHelpers from "./brush-helpers";
-import { assign, isEqual, map, reduce } from "lodash";
+import { assign, isEqual } from "lodash";
 
 
 export default class VictoryBrushContainer extends VictoryContainer {
@@ -86,7 +86,7 @@ export default class VictoryBrushContainer extends VictoryContainer {
       left: dimension !== "y" && assign({y: y[1], x: x[0] - (handleWidth / 2)}, xProps),
       right: dimension !== "y" && assign({y: y[1], x: x[1] - (handleWidth / 2)}, xProps)
     };
-    const handles = reduce(["top", "bottom", "left", "right"], (memo, curr) => {
+    const handles = ["top", "bottom", "left", "right"].reduce((memo, curr) => {
       memo = handleProps[curr] ?
         memo.concat(React.cloneElement(
           handleComponent,
@@ -115,7 +115,7 @@ export default class VictoryBrushContainer extends VictoryContainer {
   // Overrides method in VictoryContainer
   getChildren(props) {
     const children = React.Children.toArray(props.children);
-    return map([...children, this.getRect(props)], (component, i) => {
+    return [...children, this.getRect(props)].map((component, i) => {
       return component ? React.cloneElement(component, {key: i}) : null;
     });
   }

--- a/src/components/containers/victory-selection-container.js
+++ b/src/components/containers/victory-selection-container.js
@@ -1,8 +1,6 @@
 import React from "react";
 import { VictoryContainer } from "victory-core";
 import SelectionHelpers from "./selection-helpers";
-import { map } from "lodash";
-
 
 export default class VictorySelectionContainer extends VictoryContainer {
   static displayName = "VictorySelectionContainer";
@@ -57,7 +55,7 @@ export default class VictorySelectionContainer extends VictoryContainer {
   // Overrides method in VictoryContainer
   getChildren(props) {
     const children = React.Children.toArray(props.children);
-    return map([...children, this.getRect(props)], (component, i) => {
+    return [...children, this.getRect(props)].map((component, i) => {
       return component ? React.cloneElement(component, {key: i}) : null;
     });
   }

--- a/src/components/containers/victory-voronoi-container.js
+++ b/src/components/containers/victory-voronoi-container.js
@@ -1,0 +1,29 @@
+import React from "react";
+import { VictoryContainer } from "victory-core";
+import VoronoiHelpers from "./voronoi-helpers";
+
+
+export default class VictoryVoronoiContainer extends VictoryContainer {
+  static displayName = "VictoryVoronoiContainer";
+  static propTypes = {
+    ...VictoryContainer.propTypes,
+    onSelection: React.PropTypes.func,
+    onSelectionCleared: React.PropTypes.func,
+    standalone: React.PropTypes.bool,
+    radius: React.PropTypes.number
+  };
+  static defaultProps = {
+    ...VictoryContainer.defaultProps,
+    standalone: true
+  };
+
+  static defaultEvents = [{
+    target: "parent",
+    eventHandlers: {
+      onMouseMove: (evt, targetProps) => {
+        evt.persist();
+        return VoronoiHelpers.onMouseMove(evt, targetProps);
+      }
+    }
+  }];
+}

--- a/src/components/containers/victory-voronoi-container.js
+++ b/src/components/containers/victory-voronoi-container.js
@@ -1,7 +1,6 @@
 import React from "react";
 import { VictoryContainer } from "victory-core";
 import VoronoiHelpers from "./voronoi-helpers";
-import { without } from "lodash";
 
 
 export default class VictoryVoronoiContainer extends VictoryContainer {
@@ -11,7 +10,8 @@ export default class VictoryVoronoiContainer extends VictoryContainer {
     onSelection: React.PropTypes.func,
     onSelectionCleared: React.PropTypes.func,
     standalone: React.PropTypes.bool,
-    radius: React.PropTypes.number
+    radius: React.PropTypes.number,
+    voronoiPadding: React.PropTypes.number
   };
   static defaultProps = {
     ...VictoryContainer.defaultProps,

--- a/src/components/containers/victory-voronoi-container.js
+++ b/src/components/containers/victory-voronoi-container.js
@@ -21,7 +21,7 @@ export default class VictoryVoronoiContainer extends VictoryContainer {
   static defaultEvents = [{
     target: "parent",
     eventHandlers: {
-      onMouseDown: (evt, targetProps) => {
+      onMouseLeave: (evt, targetProps) => {
         VoronoiHelpers.onMouseMove.cancel();
         return VoronoiHelpers.onMouseLeave(evt, targetProps);
       },
@@ -31,29 +31,4 @@ export default class VictoryVoronoiContainer extends VictoryContainer {
       }
     }
   }];
-
-  getVoronoiPath(points) {
-    return Array.isArray(points) && points.length ?
-      `M ${points.join("L")} Z` : "";
-  }
-
-  getPolygons(props) {
-    if (!props.polygons) {
-      return [];
-    }
-    return props.polygons.map((polygon) => {
-      const points = without(polygon, "data");
-      const path = this.getVoronoiPath(points);
-      return <path d={path} style={{stroke: "black", fill: "none"}}/>
-    });
-  }
-
-  // Overrides method in VictoryContainer
-  getChildren(props) {
-    const children = React.Children.toArray(props.children);
-    const components = [...children, ...this.getPolygons(props)];
-    return components.map((component, i) => {
-      return component ? React.cloneElement(component, {key: i}) : null;
-    });
-  }
 }

--- a/src/components/containers/victory-voronoi-container.js
+++ b/src/components/containers/victory-voronoi-container.js
@@ -1,6 +1,7 @@
 import React from "react";
-import { VictoryContainer } from "victory-core";
+import { VictoryContainer, VictoryTooltip, Helpers } from "victory-core";
 import VoronoiHelpers from "./voronoi-helpers";
+import { omit } from "lodash";
 
 
 export default class VictoryVoronoiContainer extends VictoryContainer {
@@ -11,11 +12,14 @@ export default class VictoryVoronoiContainer extends VictoryContainer {
     onSelectionCleared: React.PropTypes.func,
     standalone: React.PropTypes.bool,
     radius: React.PropTypes.number,
-    voronoiPadding: React.PropTypes.number
+    voronoiPadding: React.PropTypes.number,
+    labelComponent: React.PropTypes.element,
+    labels: React.PropTypes.func
   };
   static defaultProps = {
     ...VictoryContainer.defaultProps,
-    standalone: true
+    standalone: true,
+    labelComponent: <VictoryTooltip/>
   };
 
   static defaultEvents = [{
@@ -38,4 +42,50 @@ export default class VictoryVoronoiContainer extends VictoryContainer {
       onMouseMove: () => null
     }
   }];
+
+  getLabelPosition(point, scale) {
+    return {
+      x: scale.x(point._x1 !== undefined ? point._x1 : point._x),
+      y: scale.y(point._y1 !== undefined ? point._y1 : point._y)
+    };
+  }
+
+  getLabelStyle(points) {
+    return points.map((point) => {
+      const baseStyle = point.style && point.style.labels;
+      return Helpers.evaluateStyle(baseStyle, point, true);
+    });
+  }
+
+  getLabelProps(props, points) {
+    const {labels, scale} = props;
+    const labelPosition = this.getLabelPosition(points[0], scale);
+    const style = this.getLabelStyle(points);
+    return {
+      active: true,
+      style,
+      text: points.map((point) => Helpers.evaluateProp(labels, point, true)),
+      datum: omit(points[0], ["childName", "style", "continuous"]),
+      scale,
+      ...labelPosition
+    };
+  }
+
+  getTooltip(props) {
+    const {labels, activePoints, labelComponent} = props;
+    if (!labels) {
+      return null;
+    }
+    if (Array.isArray(activePoints) && activePoints.length) {
+      return React.cloneElement(labelComponent, this.getLabelProps(props, activePoints));
+    }
+  }
+
+  // Overrides method in VictoryContainer
+  getChildren(props) {
+    const children = React.Children.toArray(props.children);
+    return [...children, this.getTooltip(props)].map((component, i) => {
+      return component ? React.cloneElement(component, {key: i}) : null;
+    });
+  }
 }

--- a/src/components/containers/victory-voronoi-container.js
+++ b/src/components/containers/victory-voronoi-container.js
@@ -30,5 +30,12 @@ export default class VictoryVoronoiContainer extends VictoryContainer {
         return VoronoiHelpers.onMouseMove(evt, targetProps);
       }
     }
+  }, {
+    target: "data",
+    eventHandlers: {
+      onMouseOver: () => null,
+      onMouseOut: () => null,
+      onMouseMove: () => null
+    }
   }];
 }

--- a/src/components/containers/victory-voronoi-container.js
+++ b/src/components/containers/victory-voronoi-container.js
@@ -112,12 +112,12 @@ export default class VictoryVoronoiContainer extends VictoryContainer {
     };
   }
 
-  getLabelStyle(props, points) {
+  getStyle(props, points, type) {
     const { labelComponent, theme } = props;
     const themeStyles = theme && theme.voronoi && theme.voronoi.style ? theme.voronoi.style : {};
-    const defaultStyles = defaults({}, labelComponent.style, themeStyles.labels);
+    const defaultStyles = defaults({}, labelComponent.style, themeStyles[type]);
     return points.map((point) => {
-      const style = point.style && point.style.labels || {};
+      const style = point.style && point.style[type] || {};
       return Helpers.evaluateStyle(defaults({}, style, defaultStyles), point, true);
     });
   }
@@ -134,13 +134,14 @@ export default class VictoryVoronoiContainer extends VictoryContainer {
   getLabelProps(props, points) {
     const {labels, scale, labelComponent} = props;
     const text = points.map((point) => Helpers.evaluateProp(labels, point, true));
-    const style = this.getLabelStyle(props, points);
+    const style = this.getStyle(props, points, "labels");
     const labelPosition = this.getLabelPosition(props, points, text, style);
     return defaults(
       {
         active: true,
         renderInPortal: false,
         style,
+        flyoutStyle: this.getStyle(props, points, "flyout"),
         text,
         datum: omit(points[0], ["childName", "style", "continuous"]),
         scale,

--- a/src/components/containers/victory-voronoi-container.js
+++ b/src/components/containers/victory-voronoi-container.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { VictoryContainer } from "victory-core";
 import VoronoiHelpers from "./voronoi-helpers";
+import { without } from "lodash";
 
 
 export default class VictoryVoronoiContainer extends VictoryContainer {
@@ -20,10 +21,39 @@ export default class VictoryVoronoiContainer extends VictoryContainer {
   static defaultEvents = [{
     target: "parent",
     eventHandlers: {
+      onMouseDown: (evt, targetProps) => {
+        VoronoiHelpers.onMouseMove.cancel();
+        return VoronoiHelpers.onMouseLeave(evt, targetProps);
+      },
       onMouseMove: (evt, targetProps) => {
         evt.persist();
         return VoronoiHelpers.onMouseMove(evt, targetProps);
       }
     }
   }];
+
+  getVoronoiPath(points) {
+    return Array.isArray(points) && points.length ?
+      `M ${points.join("L")} Z` : "";
+  }
+
+  getPolygons(props) {
+    if (!props.polygons) {
+      return [];
+    }
+    return props.polygons.map((polygon) => {
+      const points = without(polygon, "data");
+      const path = this.getVoronoiPath(points);
+      return <path d={path} style={{stroke: "black", fill: "none"}}/>
+    });
+  }
+
+  // Overrides method in VictoryContainer
+  getChildren(props) {
+    const children = React.Children.toArray(props.children);
+    const components = [...children, ...this.getPolygons(props)];
+    return components.map((component, i) => {
+      return component ? React.cloneElement(component, {key: i}) : null;
+    });
+  }
 }

--- a/src/components/containers/voronoi-helpers.js
+++ b/src/components/containers/voronoi-helpers.js
@@ -102,43 +102,34 @@ const VoronoiHelpers = {
     });
   },
 
+  getParentMutation(activePoints, mousePosition) {
+    return [{
+      target: "parent",
+      eventKey: "parent",
+      mutation: () => ({ activePoints, mousePosition })
+    }];
+  },
+
   onMouseLeave(evt, targetProps) {
-    // const activePoints = targetProps.activePoints || [];
-    // const parentMutations = [{
-    //   target: "parent",
-    //   mutation: () => {
-    //     return { activePoints: []};
-    //   }
-    // }];
-    // const inactiveMutations = activePoints.length ?
-    //   activePoints.map((point) => this.getInactiveMutations(targetProps, point)) : [];
-    // return parentMutations.concat(...inactiveMutations);
+    const activePoints = targetProps.activePoints || [];
+    const inactiveMutations = activePoints.length ?
+      activePoints.map((point) => this.getInactiveMutations(targetProps, point)) : [];
+    return this.getParentMutation([]).concat(...inactiveMutations);
   },
 
   onMouseMove(evt, targetProps) {
     const activePoints = targetProps.activePoints || [];
-    const {x, y} = Selection.getSVGEventCoordinates(evt);
-    // if (!this.withinBounds(targetProps, {x, y})) {
-    //   const parentMutations = [{
-    //     target: "parent",
-    //     mutation: () => {
-    //       return { activePoints: [], mousePosition: {x, y}};
-    //     }
-    //   }];
-    //   const inactiveMutations = activePoints.length ?
-    //   activePoints.map((point) => this.getInactiveMutations(targetProps, point)) : [];
-    //   return parentMutations.concat(...inactiveMutations);
-    // }
+    const mousePosition = Selection.getSVGEventCoordinates(evt);
+    if (!this.withinBounds(targetProps, mousePosition)) {
+      const inactiveMutations = activePoints.length ?
+        activePoints.map((point) => this.getInactiveMutations(targetProps, point)) : [];
+      return this.getParentMutation([], mousePosition).concat(...inactiveMutations);
+    }
     const voronoi = this.getVoronoi(targetProps);
     const size = targetProps.dimension ? undefined : targetProps.radius;
-    const nearestVoronoi = voronoi.find(x, y, size);
+    const nearestVoronoi = voronoi.find(mousePosition.x, mousePosition.y, size);
     const points = nearestVoronoi ? nearestVoronoi.data.points : [];
-    const parentMutations = [{
-      target: "parent",
-      mutation: () => {
-        return { activePoints: points, mousePosition: {x, y}};
-      }
-    }];
+    const parentMutations = this.getParentMutation(points, mousePosition);
     if (activePoints.length && isEqual(points, activePoints)) {
       return parentMutations;
     } else {

--- a/src/components/containers/voronoi-helpers.js
+++ b/src/components/containers/voronoi-helpers.js
@@ -1,0 +1,131 @@
+import { Selection, Data } from "victory-core";
+import { assign, throttle, isFunction, groupBy, keys } from "lodash";
+import { voronoi as d3Voronoi } from "d3-voronoi";
+import React from "react";
+
+const Helpers = {
+  withinDomain(props, point) {
+    const {x1, x2, y1, y2} = this.getDomainBox(props);
+    const {x, y} = point;
+    return x >= Math.min(x1, x2) &&
+      x <= Math.max(x1, x2) &&
+      y >= Math.min(y1, y2) &&
+      y <= Math.max(y1, y2);
+  },
+
+  getDomainBox(props) {
+    const { scale, domain } = props;
+    const fullCoordinates = Selection.getDomainCoordinates(scale, domain);
+    return {
+      x1: Math.min(...fullCoordinates.x),
+      x2: Math.max(...fullCoordinates.x),
+      y1: Math.min(...fullCoordinates.y),
+      y2: Math.max(...fullCoordinates.y)
+    };
+  },
+
+  // returns an array of data objects with eventKey and childName added
+  getDatasets(props) { // eslint-disable-line max-statements
+    const addMeta = (data, name) => {
+      return data.map((datum, index) => {
+        return assign({childName: name, eventKey: index}, datum);
+      });
+    };
+
+    if (props.data) {
+      return addMeta(props.data);
+    }
+    const getData = (childProps) => {
+      const data = Data.getData(childProps);
+      return Array.isArray(data) && data.length > 0 ? data : undefined;
+    };
+
+    // Reverse the child array to maintain correct order when looping over
+    // children starting from the end of the array.
+    const children = React.Children.toArray(props.children).reverse();
+    let childrenLength = children.length;
+    const dataArr = [];
+    let childIndex = 0;
+    while (childrenLength > 0) {
+      const child = children[--childrenLength];
+      const childName = child.props.name || childIndex;
+      childIndex++;
+      if (child.type && child.type.role === "axis") {
+        childIndex++;
+      } else if (child.type && isFunction(child.type.getData)) {
+        dataArr.push(...addMeta(child.type.getData(child.props), childName));
+      } else if (child.props && child.props.children) {
+        const newChildren = React.Children.toArray(child.props.children);
+        const newChildrenLength = newChildren.length;
+        for (let index = 0; index < newChildrenLength; index++) {
+          children[childrenLength++] = newChildren[index];
+        }
+      } else {
+        dataArr.push(...addMeta(getData(child.props), childName));
+      }
+    }
+    return dataArr;
+  },
+
+  // returns an array of objects with point and data where point is an x, y coordinate, and data is
+  // an array of points belonging to that coordinate
+  mergeDatasets(props, datasets) {
+    const {scale} = props;
+    const points = groupBy(datasets, (datum) => {
+      const x = scale.x(datum._x);
+      const y = scale.y(datum._y);
+      return `${x},${y}`;
+    });
+    return keys(points).map((key) => {
+      const point = key.split(",");
+      return {
+        x: +point[0],
+        y: +point[1],
+        data: points[key]
+      };
+    });
+  },
+
+  // filterDatasets(datasets, bounds) {
+  //   const filtered = datasets.reduce((memo, dataset) => {
+  //     const selectedData = this.getSelectedData(dataset.data, bounds);
+  //     memo = selectedData ?
+  //       memo.concat({
+  //         childName: dataset.childName, eventKey: selectedData.eventKey, data: selectedData.data
+  //       }) :
+  //       memo;
+  //     return memo;
+  //   }, []);
+  //   return filtered.length ? filtered : null;
+  // },
+
+  // getSelectedData(dataset, bounds) {
+  //   const {x, y} = bounds;
+  //   const withinBounds = (d) => {
+  //     return d._x >= x[0] && d._x <= x[1] && d._y >= y[0] && d._y <= y[1];
+  //   };
+  //   const eventKey = [];
+  //   const data = [];
+  //   let count = 0;
+  //   for (let index = 0, len = dataset.length; index < len; index++) {
+  //     const datum = dataset[index];
+  //     if (withinBounds(datum)) {
+  //       data[count] = datum;
+  //       eventKey[count] = datum.eventKey === undefined ? index : datum.eventKey;
+  //       count++;
+  //     }
+  //   }
+  //   return count > 0 ? {eventKey, data} : null;
+  // },
+
+  onMouseMove(evt, targetProps) {
+    const datasets = this.getDatasets(targetProps);
+    const voronoiDataset = this.mergeDatasets(targetProps, datasets);
+    console.log(voronoiDataset);
+    const {x, y} = Selection.getSVGEventCoordinates(evt);
+  }
+};
+
+export default {
+  onMouseMove: throttle(Helpers.onMouseMove.bind(Helpers), 16, {leading: true})
+};

--- a/src/components/containers/voronoi-helpers.js
+++ b/src/components/containers/voronoi-helpers.js
@@ -86,6 +86,15 @@ const Helpers = {
     });
   },
 
+  getVoronoiFunction(props, dataset) {
+    const {x1, y1, x2, y2} = this.getDomainBox(props);
+    const voronoiFunction = d3Voronoi()
+      .x((d) => d.x)
+      .y((d) => d.y)
+      .extent([[x1, y1], [x2, y2]]);
+    return voronoiFunction(dataset);
+  },
+
   // filterDatasets(datasets, bounds) {
   //   const filtered = datasets.reduce((memo, dataset) => {
   //     const selectedData = this.getSelectedData(dataset.data, bounds);
@@ -121,8 +130,10 @@ const Helpers = {
   onMouseMove(evt, targetProps) {
     const datasets = this.getDatasets(targetProps);
     const voronoiDataset = this.mergeDatasets(targetProps, datasets);
-    console.log(voronoiDataset);
+    const voronoi = this.getVoronoiFunction(targetProps, voronoiDataset);
     const {x, y} = Selection.getSVGEventCoordinates(evt);
+    const nearestPoint = voronoi.find(x, y, targetProps.size);
+    console.log(nearestPoint);
   }
 };
 

--- a/src/components/containers/voronoi-helpers.js
+++ b/src/components/containers/voronoi-helpers.js
@@ -113,7 +113,7 @@ const VoronoiHelpers = {
         return memo;
       }, []);
     }
-    const voronoi = targetProps.voronoi || this.getVoronoi(targetProps); // TODO: animation
+    const voronoi = this.getVoronoi(targetProps); // TODO: animation
     const nearestVoronoi = voronoi.find(x, y, targetProps.size);
     const points = nearestVoronoi ? nearestVoronoi.data.points : [];
     const parentMutations = [{

--- a/src/components/containers/zoom-helpers.js
+++ b/src/components/containers/zoom-helpers.js
@@ -1,5 +1,5 @@
 import { Selection, Collection } from "victory-core";
-import { throttle, isFunction, map } from "lodash";
+import { throttle, isFunction } from "lodash";
 
 const Helpers = {
 
@@ -35,8 +35,8 @@ const Helpers = {
    * @return {[Number, Number]}                The translated domain
    */
   pan(currentDomain, originalDomain, delta) {
-    const [fromCurrent, toCurrent] = map(currentDomain, (val) => +val);
-    const [fromOriginal, toOriginal] = map(originalDomain, (val) => +val);
+    const [fromCurrent, toCurrent] = currentDomain.map((val) => +val);
+    const [fromOriginal, toOriginal] = originalDomain.map((val) => +val);
     const lowerBound = fromCurrent + delta;
     const upperBound = toCurrent + delta;
     let newDomain;
@@ -52,7 +52,7 @@ const Helpers = {
       newDomain = currentDomain;
     }
     return Collection.containsDates(currentDomain) || Collection.containsDates(originalDomain) ?
-      map(newDomain, (val) => new Date(val)) : newDomain;
+      newDomain.map((val) => new Date(val)) : newDomain;
   },
 
   getDomainScale(domain, scale) {

--- a/src/components/victory-area/helper-methods.js
+++ b/src/components/victory-area/helper-methods.js
@@ -7,10 +7,12 @@ export default {
     props = Helpers.modifyProps(props, fallbackProps, "area");
     const calculatedValues = this.getCalculatedValues(props);
     const {scale, style, data, domain} = calculatedValues;
-    const {standalone, interpolation, events, sharedEvents, width, height, groupComponent} = props;
+    const {
+      standalone, interpolation, events, sharedEvents, width, height, groupComponent, theme
+    } = props;
 
     const initialChildProps = {
-      parent: { style: style.parent, width, height, scale, data, domain, standalone },
+      parent: { style: style.parent, width, height, scale, data, domain, standalone, theme },
       all: {
         data: { scale, data, interpolation, groupComponent, style: style.data }
       }

--- a/src/components/victory-area/victory-area.js
+++ b/src/components/victory-area/victory-area.js
@@ -41,7 +41,11 @@ class VictoryArea extends React.Component {
     ]),
     events: PropTypes.arrayOf(PropTypes.shape({
       target: PropTypes.oneOf(["data", "labels", "parent"]),
-      eventKey: PropTypes.oneOf(["all"]),
+      eventKey: PropTypes.oneOfType([
+        PropTypes.array,
+        CustomPropTypes.allOfType([CustomPropTypes.integer, CustomPropTypes.nonNegative]),
+        PropTypes.string
+      ]),
       eventHandlers: PropTypes.object
     })),
     groupComponent: PropTypes.element,
@@ -50,7 +54,7 @@ class VictoryArea extends React.Component {
       "basis", "bundle", "cardinal", "catmullRom", "linear", "monotoneX",
       "monotoneY", "natural", "radial", "step", "stepAfter", "stepBefore"
     ]),
-    label: PropTypes.string,
+    labels: PropTypes.oneOfType([ PropTypes.func, PropTypes.array ]),
     labelComponent: PropTypes.element,
     name: PropTypes.string,
     padding: PropTypes.oneOfType([
@@ -114,15 +118,16 @@ class VictoryArea extends React.Component {
 
   renderData(props) {
     const { dataComponent, labelComponent, groupComponent } = props;
+    const labelComponents = this.dataKeys.reduce((memo, key) => {
+      const labelProps = this.getComponentProps(labelComponent, "labels", key);
+      if (labelProps && labelProps.text !== undefined && labelProps.text !== null) {
+        memo = memo.concat(React.cloneElement(labelComponent, labelProps));
+      }
+      return memo;
+    }, []);
     const dataProps = this.getComponentProps(dataComponent, "data", "all");
-    const areaComponent = React.cloneElement(dataComponent, dataProps);
-
-    const labelProps = this.getComponentProps(labelComponent, "labels", "all");
-    if (labelProps && labelProps.text !== undefined && labelProps.text !== null) {
-      const areaLabel = React.cloneElement(labelComponent, labelProps);
-      return React.cloneElement(groupComponent, {}, areaComponent, areaLabel);
-    }
-    return React.cloneElement(groupComponent, {}, areaComponent);
+    const children = [React.cloneElement(dataComponent, dataProps), ...labelComponents];
+    return React.cloneElement(groupComponent, {}, children);
   }
 
   renderContainer(props, children) {

--- a/src/components/victory-area/victory-area.js
+++ b/src/components/victory-area/victory-area.js
@@ -54,6 +54,10 @@ class VictoryArea extends React.Component {
       "basis", "bundle", "cardinal", "catmullRom", "linear", "monotoneX",
       "monotoneY", "natural", "radial", "step", "stepAfter", "stepBefore"
     ]),
+    Label: CustomPropTypes.deprecated(
+      PropTypes.string,
+      "Use `labels` instead for individual data labels"
+    ),
     labels: PropTypes.oneOfType([ PropTypes.func, PropTypes.array ]),
     labelComponent: PropTypes.element,
     name: PropTypes.string,

--- a/src/components/victory-area/victory-area.js
+++ b/src/components/victory-area/victory-area.js
@@ -1,4 +1,4 @@
-import { partialRight } from "lodash";
+import { partialRight, without } from "lodash";
 import React, { PropTypes } from "react";
 import AreaHelpers from "./helper-methods";
 import {
@@ -118,7 +118,8 @@ class VictoryArea extends React.Component {
 
   renderData(props) {
     const { dataComponent, labelComponent, groupComponent } = props;
-    const labelComponents = this.dataKeys.reduce((memo, key) => {
+    const dataKeys = without(this.dataKeys, "all");
+    const labelComponents = dataKeys.reduce((memo, key) => {
       const labelProps = this.getComponentProps(labelComponent, "labels", key);
       if (labelProps && labelProps.text !== undefined && labelProps.text !== null) {
         memo = memo.concat(React.cloneElement(labelComponent, labelProps));

--- a/src/components/victory-axis/helper-methods.js
+++ b/src/components/victory-axis/helper-methods.js
@@ -189,7 +189,7 @@ export default {
     const {
       style, orientation, isVertical, scale, ticks, tickFormat, stringTicks, anchors, domain
     } = calculatedValues;
-
+    const { width, height, standalone, theme, tickValues } = props;
     const {
       globalTransform, gridOffset, gridEdge
     } = this.getLayoutProps(props, calculatedValues);
@@ -197,12 +197,11 @@ export default {
     const axisProps = this.getAxisProps(props, calculatedValues, globalTransform);
     const axisLabelProps = this.getAxisLabelProps(props, calculatedValues, globalTransform);
     const initialChildProps = { parent: {
-      style: style.parent, ticks, scale, width: props.width,
-      height: props.height, domain, standalone: props.standalone
+      style: style.parent, ticks, scale, width, height, domain, standalone, theme
     }};
 
     return ticks.reduce((childProps, indexedTick, index) => {
-      const tick = stringTicks ? props.tickValues[indexedTick - 1] : indexedTick;
+      const tick = stringTicks ? tickValues[indexedTick - 1] : indexedTick;
 
       const styles = this.getEvaluatedStyles(style, tick, index);
       const tickLayout = {
@@ -279,15 +278,16 @@ export default {
   },
 
   getTicks(props, scale) {
+    const { tickValues, tickCount, crossAxis } = props;
     if (props.tickValues) {
       if (Helpers.stringTicks(props)) {
         return range(1, props.tickValues.length + 1);
       }
-      return props.tickValues.length ? props.tickValues : scale.domain();
+      return tickValues.length ? tickValues : scale.domain();
     } else if (scale.ticks && isFunction(scale.ticks)) {
-      const scaleTicks = scale.ticks(props.tickCount);
+      const scaleTicks = scale.ticks(tickCount);
       const ticks = Array.isArray(scaleTicks) && scaleTicks.length ? scaleTicks : scale.domain();
-      if (props.crossAxis) {
+      if (crossAxis) {
         const filteredTicks = includes(ticks, 0) ? without(ticks, 0) : ticks;
         return filteredTicks.length ? filteredTicks : ticks;
       }

--- a/src/components/victory-bar/helper-methods.js
+++ b/src/components/victory-bar/helper-methods.js
@@ -96,9 +96,9 @@ export default {
   getBaseProps(props, fallbackProps) {
     props = Helpers.modifyProps(props, fallbackProps, "bar");
     const {style, data, scale, domain } = this.getCalculatedValues(props);
-    const { horizontal, width, height, padding, standalone } = props;
+    const { horizontal, width, height, padding, standalone, theme } = props;
     const initialChildProps = {parent: {
-      domain, scale, width, height, data, standalone, style: style.parent
+      domain, scale, width, height, data, standalone, theme, style: style.parent
     }};
 
     return data.reduce((childProps, datum, index) => {

--- a/src/components/victory-candlestick/helper-methods.js
+++ b/src/components/victory-candlestick/helper-methods.js
@@ -6,9 +6,9 @@ export default {
     props = Helpers.modifyProps(props, fallbackProps, "candlestick");
     const calculatedValues = this.getCalculatedValues(props);
     const { data, style, scale, domain } = calculatedValues;
-    const { groupComponent, width, height, padding, standalone } = props;
+    const { groupComponent, width, height, padding, standalone, theme } = props;
     const initialChildProps = {parent: {
-      domain, scale, width, height, data, standalone, style: style.parent
+      domain, scale, width, height, data, standalone, theme, style: style.parent
     }};
 
     return data.reduce((childProps, datum, index) => {

--- a/src/components/victory-chart/victory-chart.js
+++ b/src/components/victory-chart/victory-chart.js
@@ -262,10 +262,10 @@ export default class VictoryChart extends React.Component {
   }
 
   getContainerProps(props, calculatedProps) {
-    const { width, height, standalone } = props;
+    const { width, height, standalone, theme } = props;
     const { domain, scale, style } = calculatedProps;
     return {
-      domain, scale, width, height, standalone, style: style.parent
+      domain, scale, width, height, standalone, theme, style: style.parent
     };
   }
 

--- a/src/components/victory-errorbar/helper-methods.js
+++ b/src/components/victory-errorbar/helper-methods.js
@@ -5,9 +5,9 @@ export default {
   getBaseProps(props, fallbackProps) {
     props = Helpers.modifyProps(props, fallbackProps, "errorbar");
     const { data, style, scale, domain } = this.getCalculatedValues(props, fallbackProps);
-    const { groupComponent, height, width, borderWidth, standalone } = props;
+    const { groupComponent, height, width, borderWidth, standalone, theme } = props;
     const initialChildProps = { parent: {
-      domain, style: style.parent, scale, data, height, width, standalone
+      domain, style: style.parent, scale, data, height, width, standalone, theme
     }};
 
     return data.reduce((childProps, datum, index) => {

--- a/src/components/victory-group/victory-group.js
+++ b/src/components/victory-group/victory-group.js
@@ -281,10 +281,10 @@ export default class VictoryGroup extends React.Component {
   }
 
   getContainerProps(props, calculatedProps) {
-    const { width, height, standalone } = props;
+    const { width, height, standalone, theme} = props;
     const { domain, scale, style } = calculatedProps;
     return {
-      domain, scale, width, height, standalone, style: style.parent
+      domain, scale, width, height, standalone, theme, style: style.parent
     };
   }
 

--- a/src/components/victory-line/helper-methods.js
+++ b/src/components/victory-line/helper-methods.js
@@ -1,4 +1,4 @@
-import { sortBy, defaults, last } from "lodash";
+import { sortBy, defaults } from "lodash";
 import { Helpers, Log, Data, Domain, Scale } from "victory-core";
 
 export default {
@@ -6,10 +6,10 @@ export default {
     props = Helpers.modifyProps(props, fallbackProps, "line");
     const calculatedValues = this.getCalculatedValues(props);
     const { scale, data, domain, style } = calculatedValues;
-    const {interpolation, width, height, events, sharedEvents, standalone} = props;
+    const {interpolation, width, height, events, sharedEvents, standalone, groupComponent} = props;
     const initialChildProps = {
       parent: { style: style.parent, scale, data, height, width, domain, standalone },
-      all: { data: { scale, data, interpolation, style: style.data } }
+      all: { data: { scale, data, interpolation, groupComponent, style: style.data } }
     };
     return data.reduce((childProps, datum, index) => {
       const text = this.getLabelText(props, datum, index);

--- a/src/components/victory-line/helper-methods.js
+++ b/src/components/victory-line/helper-methods.js
@@ -27,7 +27,7 @@ export default {
     const sortKey = props.sortKey || "x";
     let data = sortBy(Data.getData(props), sortKey);
 
-    if (dataset.length < 2) {
+    if (data.length < 2) {
       Log.warn("VictoryLine needs at least two data points to render properly.");
       data = [];
     }

--- a/src/components/victory-line/helper-methods.js
+++ b/src/components/victory-line/helper-methods.js
@@ -6,10 +6,12 @@ export default {
     props = Helpers.modifyProps(props, fallbackProps, "line");
     const calculatedValues = this.getCalculatedValues(props);
     const { scale, data, domain, style } = calculatedValues;
-    const {interpolation, width, height, events, sharedEvents, standalone, groupComponent} = props;
+    const {
+      interpolation, width, height, events, sharedEvents, standalone, groupComponent, theme
+    } = props;
     const initialChildProps = {
       parent: { style: style.parent, scale, data, height, width, domain, standalone },
-      all: { data: { scale, data, interpolation, groupComponent, style: style.data } }
+      all: { data: { scale, data, interpolation, groupComponent, theme, style: style.data } }
     };
     return data.reduce((childProps, datum, index) => {
       const text = this.getLabelText(props, datum, index);

--- a/src/components/victory-line/victory-line.js
+++ b/src/components/victory-line/victory-line.js
@@ -46,7 +46,11 @@ class VictoryLine extends React.Component {
     ]),
     events: PropTypes.arrayOf(PropTypes.shape({
       target: PropTypes.oneOf(["data", "labels", "parent"]),
-      eventKey: PropTypes.oneOf(["all"]),
+      eventKey: PropTypes.oneOfType([
+        PropTypes.array,
+        CustomPropTypes.allOfType([CustomPropTypes.integer, CustomPropTypes.nonNegative]),
+        PropTypes.string
+      ]),
       eventHandlers: PropTypes.object
     })),
     groupComponent: PropTypes.element,
@@ -122,13 +126,13 @@ class VictoryLine extends React.Component {
 
   renderData(props) {
     const { dataComponent, labelComponent, groupComponent } = props;
-    const labelComponents = [];
-    for (let index = 0, len = this.dataKeys.length; index < len; index++) {
-      const labelProps = this.getComponentProps(labelComponent, "labels", index);
+    const labelComponents = this.dataKeys.reduce((memo, key) => {
+      const labelProps = this.getComponentProps(labelComponent, "labels", key);
       if (labelProps && labelProps.text !== undefined && labelProps.text !== null) {
-        labelComponents[index] = React.cloneElement(labelComponent, labelProps);
+        memo = memo.concat(React.cloneElement(labelComponent, labelProps));
       }
-    }
+      return memo;
+    }, []);
     const dataProps = this.getComponentProps(dataComponent, "data", "all");
     const children = [React.cloneElement(dataComponent, dataProps), ...labelComponents];
     return React.cloneElement(groupComponent, {}, children);

--- a/src/components/victory-line/victory-line.js
+++ b/src/components/victory-line/victory-line.js
@@ -59,6 +59,10 @@ class VictoryLine extends React.Component {
       "basis", "bundle", "cardinal", "catmullRom", "linear", "monotoneX",
       "monotoneY", "natural", "radial", "step", "stepAfter", "stepBefore"
     ]),
+    Label: CustomPropTypes.deprecated(
+      PropTypes.string,
+      "Use `labels` instead for individual data labels"
+    ),
     labels: PropTypes.oneOfType([ PropTypes.func, PropTypes.array ]),
     labelComponent: PropTypes.element,
     name: PropTypes.string,

--- a/src/components/victory-line/victory-line.js
+++ b/src/components/victory-line/victory-line.js
@@ -1,4 +1,4 @@
-import { partialRight } from "lodash";
+import { partialRight, without } from "lodash";
 import React, { PropTypes } from "react";
 import LineHelpers from "./helper-methods";
 import {
@@ -126,7 +126,8 @@ class VictoryLine extends React.Component {
 
   renderData(props) {
     const { dataComponent, labelComponent, groupComponent } = props;
-    const labelComponents = this.dataKeys.reduce((memo, key) => {
+    const dataKeys = without(this.dataKeys, "all");
+    const labelComponents = dataKeys.reduce((memo, key) => {
       const labelProps = this.getComponentProps(labelComponent, "labels", key);
       if (labelProps && labelProps.text !== undefined && labelProps.text !== null) {
         memo = memo.concat(React.cloneElement(labelComponent, labelProps));

--- a/src/components/victory-line/victory-line.js
+++ b/src/components/victory-line/victory-line.js
@@ -55,7 +55,7 @@ class VictoryLine extends React.Component {
       "basis", "bundle", "cardinal", "catmullRom", "linear", "monotoneX",
       "monotoneY", "natural", "radial", "step", "stepAfter", "stepBefore"
     ]),
-    label: PropTypes.string,
+    labels: PropTypes.oneOfType([ PropTypes.func, PropTypes.array ]),
     labelComponent: PropTypes.element,
     name: PropTypes.string,
     padding: PropTypes.oneOfType([
@@ -122,18 +122,16 @@ class VictoryLine extends React.Component {
 
   renderData(props) {
     const { dataComponent, labelComponent, groupComponent } = props;
-    const dataComponents = [];
     const labelComponents = [];
     for (let index = 0, len = this.dataKeys.length; index < len; index++) {
-      const dataProps = this.getComponentProps(dataComponent, "data", index);
-      dataComponents[index] = React.cloneElement(dataComponent, dataProps);
-
       const labelProps = this.getComponentProps(labelComponent, "labels", index);
       if (labelProps && labelProps.text !== undefined && labelProps.text !== null) {
         labelComponents[index] = React.cloneElement(labelComponent, labelProps);
       }
     }
-    return React.cloneElement(groupComponent, {}, ...dataComponents, ...labelComponents);
+    const dataProps = this.getComponentProps(dataComponent, "data", "all");
+    const children = [React.cloneElement(dataComponent, dataProps), ...labelComponents];
+    return React.cloneElement(groupComponent, {}, children);
   }
 
   shouldAnimate() {

--- a/src/components/victory-scatter/helper-methods.js
+++ b/src/components/victory-scatter/helper-methods.js
@@ -34,10 +34,11 @@ export default {
   getLabelProps(dataProps, text, calculatedStyle) {
     const { x, y, index, scale, datum, data } = dataProps;
     const labelStyle = this.getLabelStyle(calculatedStyle.labels, dataProps) || {};
+    const sign = (datum._y1 || datum._y) < 0 ? -1 : 1;
     return {
       style: labelStyle,
       x,
-      y: y - (labelStyle.padding || 0),
+      y: y - sign * (labelStyle.padding || 0),
       text,
       index,
       scale,

--- a/src/components/victory-scatter/helper-methods.js
+++ b/src/components/victory-scatter/helper-methods.js
@@ -5,10 +5,10 @@ export default {
   getBaseProps(props, fallbackProps) {
     props = Helpers.modifyProps(props, fallbackProps, "scatter");
     const calculatedValues = this.getCalculatedValues(props);
+    const { height, width, standalone, theme } = props;
     const { data, style, scale, domain } = calculatedValues;
     const initialChildProps = { parent: {
-      style: style.parent, scale, domain, data, height: props.height,
-      width: props.width, standalone: props.standalone
+      style: style.parent, scale, domain, data, height, width, standalone, theme
     }};
 
     return data.reduce((childProps, datum, index) => {

--- a/src/components/victory-stack/victory-stack.js
+++ b/src/components/victory-stack/victory-stack.js
@@ -240,10 +240,10 @@ export default class VictoryStack extends React.Component {
   }
 
   getContainerProps(props, calculatedProps) {
-    const { width, height, standalone } = props;
+    const { width, height, standalone, theme } = props;
     const { domain, scale, style } = calculatedProps;
     return {
-      domain, scale, width, height, standalone, style: style.parent
+      domain, scale, width, height, standalone, theme, style: style.parent
     };
   }
 

--- a/src/components/victory-voronoi-tooltip/helper-methods.js
+++ b/src/components/victory-voronoi-tooltip/helper-methods.js
@@ -6,9 +6,9 @@ export default {
   getBaseProps(props, fallbackProps) {
     props = Helpers.modifyProps(props, fallbackProps, "voronoi");
     const { data, style, scale, polygons, domain } = this.getCalculatedValues(props);
+    const { width, height, standalone, theme, events, sharedEvents } = props;
     const initialChildProps = { parent: {
-      style: style.parent, scale, domain, data, standalone: props.standalone,
-      height: props.height, width: props.width
+      style: style.parent, scale, domain, data, standalone, height, width, theme
     }};
 
     return data.reduce((childProps, datum, index) => {
@@ -24,7 +24,7 @@ export default {
 
       childProps[eventKey] = { data: dataProps };
       const text = this.getLabelText(props, datum, index);
-      if (text !== undefined && text !== null || props.events || props.sharedEvents) {
+      if (text !== undefined && text !== null || events || sharedEvents) {
         childProps[eventKey].labels = assign(
           {},
           this.getFlyoutProps(dataProps, text, style),

--- a/src/components/victory-voronoi-tooltip/victory-voronoi-tooltip.js
+++ b/src/components/victory-voronoi-tooltip/victory-voronoi-tooltip.js
@@ -2,7 +2,7 @@ import React, { PropTypes } from "react";
 import { partialRight } from "lodash";
 import {
   PropTypes as CustomPropTypes, Helpers, VictoryTransition, VictoryTooltip, addEvents,
-  VictoryContainer, VictoryTheme, DefaultTransitions, Voronoi, Data, Domain
+  VictoryContainer, VictoryTheme, DefaultTransitions, Voronoi, Data, Domain, Log
 } from "victory-core";
 import TooltipHelpers from "./helper-methods";
 
@@ -120,6 +120,12 @@ class VictoryVoronoiTooltip extends React.Component {
   static expectedComponents = [
     "dataComponent", "labelComponent", "groupComponent", "containerComponent"
   ];
+
+  componentDidMount() {
+    Log.warn(
+      "`VictoryVoronoiTooltip` will be deprecated in victory@0.20.0, use `VictoryVoronoiContainer`"
+    );
+  }
 
   renderData(props) {
     const { dataComponent, labelComponent, groupComponent } = props;

--- a/src/components/victory-voronoi/helper-methods.js
+++ b/src/components/victory-voronoi/helper-methods.js
@@ -6,9 +6,9 @@ export default {
   getBaseProps(props, fallbackProps) {
     props = Helpers.modifyProps(props, fallbackProps, "voronoi");
     const { data, style, scale, polygons, domain } = this.getCalculatedValues(props);
+    const { width, height, standalone, theme, events, sharedEvents } = props;
     const initialChildProps = { parent: {
-      style: style.parent, scale, domain, data, standalone: props.standalone,
-      height: props.height, width: props.width
+      style: style.parent, scale, domain, data, standalone, height, width, theme
     }};
 
     return data.reduce((childProps, datum, index) => {
@@ -24,7 +24,7 @@ export default {
 
       childProps[eventKey] = { data: dataProps };
       const text = this.getLabelText(props, datum, index);
-      if (text !== undefined && text !== null || props.events || props.sharedEvents) {
+      if (text !== undefined && text !== null || events || sharedEvents) {
         childProps[eventKey].labels = this.getLabelProps(dataProps, text, style);
       }
 

--- a/src/components/victory-voronoi/victory-voronoi.js
+++ b/src/components/victory-voronoi/victory-voronoi.js
@@ -2,7 +2,7 @@ import React, { PropTypes } from "react";
 import { partialRight } from "lodash";
 import {
   PropTypes as CustomPropTypes, Helpers, VictoryTransition, VictoryLabel, addEvents,
-  VictoryContainer, VictoryTheme, DefaultTransitions, Voronoi, Data, Domain
+  VictoryContainer, VictoryTheme, DefaultTransitions, Voronoi, Data, Domain, Log
 } from "victory-core";
 import VoronoiHelpers from "./helper-methods";
 
@@ -117,6 +117,12 @@ class VictoryVoronoi extends React.Component {
   static expectedComponents = [
     "dataComponent", "labelComponent", "groupComponent", "containerComponent"
   ];
+
+  componentDidMount() {
+    Log.warn(
+      "`VictoryVoronoi` will be deprecated in victory@0.20.0, use `VictoryVoronoiContainer` instead"
+    );
+  }
 
   renderData(props) {
     const { dataComponent, labelComponent, groupComponent } = props;

--- a/src/index.js
+++ b/src/index.js
@@ -18,10 +18,14 @@ export {
   default as VictoryCandlestick
 } from "./components/victory-candlestick/victory-candlestick";
 export { default as VictoryBrushContainer } from "./components/containers/victory-brush-container";
+export {
+  default as VictoryVoronoiContainer
+} from "./components/containers/victory-voronoi-container";
 export { default as VictoryZoomContainer } from "./components/containers/victory-zoom-container";
 export { default as VictoryZoom } from "./components/victory-zoom/victory-zoom";
 export { default as BrushHelpers } from "./components/containers/brush-helpers";
 export { default as SelectionHelpers } from "./components/containers/selection-helpers";
+export { default as VoronoiHelpers } from "./components/containers/voronoi-helpers";
 export { default as ZoomHelpers } from "./components/containers/zoom-helpers";
 
 

--- a/test/client/spec/components/victory-line/victory-line.spec.js
+++ b/test/client/spec/components/victory-line/victory-line.spec.js
@@ -105,10 +105,10 @@ describe("components/victory-line", () => {
         {x: 6, y: 4},
         {x: 7, y: 6}
       ];
-      const wrapper = shallow(
+      const wrapper = mount(
         <VictoryLine data={data}/>
       );
-      const lines = wrapper.find(Curve);
+      const lines = wrapper.find("path");
       expect(lines.length).to.equal(2);
     });
 
@@ -122,10 +122,10 @@ describe("components/victory-line", () => {
         {x: 6, y: 4},
         {x: 7, y: 6}
       ];
-      const wrapper = shallow(
+      const wrapper = mount(
         <VictoryLine data={data}/>
       );
-      const lines = wrapper.find(Curve);
+      const lines = wrapper.find("path");
       expect(lines.length).to.equal(2);
     });
 
@@ -139,10 +139,10 @@ describe("components/victory-line", () => {
         {x: 6, y: 4},
         {x: 7, y: 6}
       ];
-      const wrapper = shallow(
+      const wrapper = mount(
         <VictoryLine data={data}/>
       );
-      const lines = wrapper.find(Curve);
+      const lines = wrapper.find("path");
       expect(lines.length).to.equal(2);
     });
 
@@ -156,10 +156,10 @@ describe("components/victory-line", () => {
         {x: 6, y: 4},
         {x: 7, y: null}
       ];
-      const wrapper = shallow(
+      const wrapper = mount(
         <VictoryLine data={data}/>
       );
-      const lines = wrapper.find(Curve);
+      const lines = wrapper.find("path");
       expect(lines.length).to.equal(2);
     });
 
@@ -174,10 +174,10 @@ describe("components/victory-line", () => {
         {x: 7, y: 5},
         {x: 8, y: 3}
       ];
-      const wrapper = shallow(
+      const wrapper = mount(
         <VictoryLine data={data}/>
       );
-      const lines = wrapper.find(Curve);
+      const lines = wrapper.find("path");
       expect(lines.length).to.equal(3);
     });
   });
@@ -188,10 +188,10 @@ describe("components/victory-line", () => {
         [1, 2],
         [3, 4]
       ];
-      const wrapper = shallow(
+      const wrapper = mount(
         <VictoryLine data={data} x={0} y={1} />
       );
-      const lines = wrapper.find(Curve);
+      const lines = wrapper.find("path");
       expect(lines.length).to.equal(1);
     });
 

--- a/test/client/spec/components/victory-line/victory-line.spec.js
+++ b/test/client/spec/components/victory-line/victory-line.spec.js
@@ -44,10 +44,10 @@ describe("components/victory-line", () => {
       const log = console;
       const warningStub = sinon.stub(log, "warn");
       const data = [{x: 1, y: 1}];
-      const wrapper = shallow(
+      const wrapper = mount(
         <VictoryLine data={data}/>
       );
-      const lines = wrapper.find(Curve);
+      const lines = wrapper.find("path");
       expect(lines.length).to.equal(0);
       expect(warningStub).to.have.been.called;
       log.warn.restore();


### PR DESCRIPTION
**depends on https://github.com/FormidableLabs/victory-core/pull/196**

This PR Adds `VictoryVoronoiContainer` for hover events (tooltips). `VictoryVoronoiContainer` has several benefits over `VictoryVoronoi` and `VictoryVoronoiTooltip`
  - Supports multi-dataset voronoi
  - Much better performance (voronoi polygons are not actually rendered, so the number of nodes rendered is dramatically lower)
  - Supports multi-data tooltips
  - Supports rectangular selections with a dimension prop _i.e._ `dimension="x"` creates vertical hover areas for every unique x value in all child data

This PR also deprecates `label` in favor of `labels` in `VictoryLine` and `VictoryArea`, allowing individual data labels for these components like in other Victory components. This will be a breaking change for anyone using the `label` prop in VictoryLine or VictoryArea. Series labels will need to be configured manually

This PR also changes how null values are handled in VictoryArea, and groups all line and area segments (i.e. split by null values) into the same eventKey, so that they operate as a single line for the purposes of events.