### PR TITLE
Chore/remove for loops

### DIFF
--- a/src/components/containers/victory-zoom-container.js
+++ b/src/components/containers/victory-zoom-container.js
@@ -98,7 +98,7 @@ export default class VictoryZoomContainer extends VictoryContainer {
   modifyChildren(props) {
     const childComponents = React.Children.toArray(props.children);
 
-    return childComponents.map((child, index) => {
+    return childComponents.map((child) => {
       const {zoomDomain, cachedZoomDomain, currentDomain} = props;
       const domain = isEqual(zoomDomain, cachedZoomDomain) ?
         currentDomain || zoomDomain : zoomDomain;

--- a/src/components/containers/victory-zoom-container.js
+++ b/src/components/containers/victory-zoom-container.js
@@ -97,17 +97,16 @@ export default class VictoryZoomContainer extends VictoryContainer {
 
   modifyChildren(props) {
     const childComponents = React.Children.toArray(props.children);
-    const newChildren = [];
-    for (let index = 0, len = childComponents.length; index < len; index++) {
-      const child = childComponents[index];
+
+    return childComponents.map((child, index) => {
       const {zoomDomain, cachedZoomDomain, currentDomain} = props;
       const domain = isEqual(zoomDomain, cachedZoomDomain) ?
         currentDomain || zoomDomain : zoomDomain;
-      newChildren[index] = React.cloneElement(
+
+      return React.cloneElement(
         child, defaults({domain}, child.props)
       );
-    }
-    return newChildren;
+    });
   }
 
   // Overrides method in VictoryContainer

--- a/src/components/victory-axis/helper-methods.js
+++ b/src/components/victory-axis/helper-methods.js
@@ -196,28 +196,30 @@ export default {
 
     const axisProps = this.getAxisProps(props, calculatedValues, globalTransform);
     const axisLabelProps = this.getAxisLabelProps(props, calculatedValues, globalTransform);
-    const childProps = { parent: {
+    const initialChildProps = { parent: {
       style: style.parent, ticks, scale, width: props.width,
       height: props.height, domain, standalone: props.standalone
     }};
-    for (let index = 0, len = ticks.length; index < len; index++) {
-      const tick = stringTicks ? props.tickValues[(ticks[index]) - 1] : ticks[index];
+
+    return ticks.reduce((childProps, indexedTick, index) => {
+      const tick = stringTicks ? props.tickValues[indexedTick - 1] : indexedTick;
 
       const styles = this.getEvaluatedStyles(style, tick, index);
       const tickLayout = {
         position: this.getTickPosition(styles, orientation, isVertical),
-        transform: this.getTickTransform(scale(ticks[index]), globalTransform, isVertical)
+        transform: this.getTickTransform(scale(indexedTick), globalTransform, isVertical)
       };
 
       const gridLayout = {
         edge: gridEdge,
         transform: {
           x: isVertical ?
-            -gridOffset.x + globalTransform.x : scale(ticks[index]) + globalTransform.x,
+            -gridOffset.x + globalTransform.x : scale(indexedTick) + globalTransform.x,
           y: isVertical ?
-            scale(ticks[index]) + globalTransform.y : gridOffset.y + globalTransform.y
+            scale(indexedTick) + globalTransform.y : gridOffset.y + globalTransform.y
         }
       };
+
       childProps[index] = {
         axis: axisProps,
         axisLabel: axisLabelProps,
@@ -227,8 +229,9 @@ export default {
         ),
         grid: this.getGridProps(gridLayout, styles.gridStyle, tick)
       };
-    }
-    return childProps;
+
+      return childProps;
+    }, initialChildProps);
   },
 
   getCalculatedValues(props) {

--- a/src/components/victory-axis/victory-axis.js
+++ b/src/components/victory-axis/victory-axis.js
@@ -132,20 +132,19 @@ class VictoryAxis extends React.Component {
 
   renderGridAndTicks(props) {
     const { tickComponent, tickLabelComponent, gridComponent } = props;
-    const gridAndTickComponents = [];
-    for (let index = 0, len = this.dataKeys.length; index < len; index++) {
-      const key = this.dataKeys[index];
+
+    return this.dataKeys.map((key, index) => {
       const tickProps = this.getComponentProps(tickComponent, "ticks", index);
       const TickComponent = React.cloneElement(tickComponent, tickProps);
       const gridProps = this.getComponentProps(gridComponent, "grid", index);
       const GridComponent = React.cloneElement(gridComponent, gridProps);
       const tickLabelProps = this.getComponentProps(tickLabelComponent, "tickLabels", index);
       const TickLabel = React.cloneElement(tickLabelComponent, tickLabelProps);
-      gridAndTickComponents[index] = React.cloneElement(
+
+      return React.cloneElement(
         props.groupComponent, {key: `tick-group-${key}`}, GridComponent, TickComponent, TickLabel
       );
-    }
-    return gridAndTickComponents;
+    });
   }
 
   fixLabelOverlap(gridAndTicks, props) {

--- a/src/components/victory-bar/helper-methods.js
+++ b/src/components/victory-bar/helper-methods.js
@@ -97,11 +97,11 @@ export default {
     props = Helpers.modifyProps(props, fallbackProps, "bar");
     const {style, data, scale, domain } = this.getCalculatedValues(props);
     const { horizontal, width, height, padding, standalone } = props;
-    const childProps = {parent: {
+    const initialChildProps = {parent: {
       domain, scale, width, height, data, standalone, style: style.parent
     }};
-    for (let index = 0, len = data.length; index < len; index++) {
-      const datum = data[index];
+
+    return data.reduce((childProps, datum, index) => {
       const eventKey = datum.eventKey || index;
       const position = this.getBarPosition(props, datum, scale);
       const dataProps = assign(
@@ -125,8 +125,9 @@ export default {
       if (text !== undefined && text !== null || props.events || props.sharedEvents) {
         childProps[eventKey].labels = this.getLabelProps(dataProps, text, style);
       }
-    }
-    return childProps;
+
+      return childProps;
+    }, initialChildProps);
   },
 
   getLabelProps(dataProps, text, calculatedStyle) {

--- a/src/components/victory-bar/victory-bar.js
+++ b/src/components/victory-bar/victory-bar.js
@@ -1,6 +1,6 @@
 import React, { PropTypes } from "react";
 import BarHelpers from "./helper-methods";
-import { partialRight } from "lodash";
+import { compact, partialRight } from "lodash";
 import {
   PropTypes as CustomPropTypes, Helpers, VictoryTransition, VictoryLabel, VictoryContainer,
   VictoryTheme, Bar, addEvents, Data, Domain
@@ -141,17 +141,19 @@ class VictoryBar extends React.Component {
 
   renderData(props) {
     const { dataComponent, labelComponent, groupComponent } = props;
-    const dataComponents = [];
-    const labelComponents = [];
-    for (let index = 0, len = this.dataKeys.length; index < len; index++) {
-      const dataProps = this.getComponentProps(dataComponent, "data", index);
-      dataComponents[index] = React.cloneElement(dataComponent, dataProps);
 
+    const dataComponents = this.dataKeys.map((_dataKey, index) => {
+      const dataProps = this.getComponentProps(dataComponent, "data", index);
+      return React.cloneElement(dataComponent, dataProps);
+    });
+
+    const labelComponents = compact(this.dataKeys.map((_dataKey, index) => {
       const labelProps = this.getComponentProps(labelComponent, "labels", index);
-      if (labelProps && labelProps.text !== undefined && labelProps.text !== null) {
-        labelComponents[index] = React.cloneElement(labelComponent, labelProps);
+      if (labelProps.text !== undefined && labelProps.text !== null) {
+        return React.cloneElement(labelComponent, labelProps);
       }
-    }
+    }));
+
     return labelComponents.length > 0 ?
       React.cloneElement(groupComponent, {}, ...dataComponents, ...labelComponents) :
       dataComponents;

--- a/src/components/victory-bar/victory-bar.js
+++ b/src/components/victory-bar/victory-bar.js
@@ -1,6 +1,6 @@
 import React, { PropTypes } from "react";
 import BarHelpers from "./helper-methods";
-import { compact, partialRight } from "lodash";
+import { partialRight } from "lodash";
 import {
   PropTypes as CustomPropTypes, Helpers, VictoryTransition, VictoryLabel, VictoryContainer,
   VictoryTheme, Bar, addEvents, Data, Domain
@@ -147,12 +147,12 @@ class VictoryBar extends React.Component {
       return React.cloneElement(dataComponent, dataProps);
     });
 
-    const labelComponents = compact(this.dataKeys.map((_dataKey, index) => {
+    const labelComponents = this.dataKeys.map((_dataKey, index) => {
       const labelProps = this.getComponentProps(labelComponent, "labels", index);
       if (labelProps.text !== undefined && labelProps.text !== null) {
         return React.cloneElement(labelComponent, labelProps);
       }
-    }));
+    }).filter(Boolean);
 
     return labelComponents.length > 0 ?
       React.cloneElement(groupComponent, {}, ...dataComponents, ...labelComponents) :

--- a/src/components/victory-candlestick/helper-methods.js
+++ b/src/components/victory-candlestick/helper-methods.js
@@ -7,11 +7,11 @@ export default {
     const calculatedValues = this.getCalculatedValues(props);
     const { data, style, scale, domain } = calculatedValues;
     const { groupComponent, width, height, padding, standalone } = props;
-    const childProps = {parent: {
+    const initialChildProps = {parent: {
       domain, scale, width, height, data, standalone, style: style.parent
     }};
-    for (let index = 0, len = data.length; index < len; index++) {
-      const datum = data[index];
+
+    return data.reduce((childProps, datum, index) => {
       const eventKey = datum.eventKey || index;
       const x = scale.x(datum._x1 !== undefined ? datum._x1 : datum._x);
       const y1 = scale.y(datum._high);
@@ -31,8 +31,9 @@ export default {
       if (text !== undefined && text !== null || props.events || props.sharedEvents) {
         childProps[eventKey].labels = this.getLabelProps(dataProps, text, style);
       }
-    }
-    return childProps;
+
+      return childProps;
+    }, initialChildProps);
   },
 
   getLabelProps(dataProps, text, calculatedStyle) {

--- a/src/components/victory-candlestick/victory-candlestick.js
+++ b/src/components/victory-candlestick/victory-candlestick.js
@@ -1,5 +1,5 @@
 import React, { PropTypes } from "react";
-import { compact, partialRight } from "lodash";
+import { partialRight } from "lodash";
 import {
   PropTypes as CustomPropTypes, Helpers, VictoryTransition, VictoryLabel, addEvents,
   VictoryContainer, VictoryTheme, DefaultTransitions, Candle
@@ -165,12 +165,12 @@ class VictoryCandlestick extends React.Component {
       return React.cloneElement(dataComponent, dataProps);
     });
 
-    const labelComponents = compact(this.dataKeys.map((_dataKey, index) => {
+    const labelComponents = this.dataKeys.map((_dataKey, index) => {
       const labelProps = this.getComponentProps(labelComponent, "labels", index);
       if (labelProps.text !== undefined && labelProps.text !== null) {
         return React.cloneElement(labelComponent, labelProps);
       }
-    }));
+    }).filter(Boolean);
 
     return labelComponents.length > 0 ?
       React.cloneElement(groupComponent, {}, ...dataComponents, ...labelComponents) :

--- a/src/components/victory-candlestick/victory-candlestick.js
+++ b/src/components/victory-candlestick/victory-candlestick.js
@@ -1,5 +1,5 @@
 import React, { PropTypes } from "react";
-import { partialRight } from "lodash";
+import { compact, partialRight } from "lodash";
 import {
   PropTypes as CustomPropTypes, Helpers, VictoryTransition, VictoryLabel, addEvents,
   VictoryContainer, VictoryTheme, DefaultTransitions, Candle
@@ -159,18 +159,19 @@ class VictoryCandlestick extends React.Component {
 
   renderData(props) {
     const { dataComponent, labelComponent, groupComponent} = props;
-    const dataComponents = [];
-    const labelComponents = [];
 
-    for (let index = 0, len = this.dataKeys.length; index < len; index++) {
+    const dataComponents = this.dataKeys.map((_dataKey, index) => {
       const dataProps = this.getComponentProps(dataComponent, "data", index);
-      dataComponents[index] = React.cloneElement(dataComponent, dataProps);
+      return React.cloneElement(dataComponent, dataProps);
+    });
 
+    const labelComponents = compact(this.dataKeys.map((_dataKey, index) => {
       const labelProps = this.getComponentProps(labelComponent, "labels", index);
-      if (labelProps && labelProps.text !== undefined && labelProps.text !== null) {
-        labelComponents[index] = React.cloneElement(labelComponent, labelProps);
+      if (labelProps.text !== undefined && labelProps.text !== null) {
+        return React.cloneElement(labelComponent, labelProps);
       }
-    }
+    }));
+
     return labelComponents.length > 0 ?
       React.cloneElement(groupComponent, {}, ...dataComponents, ...labelComponents) :
       dataComponents;

--- a/src/components/victory-chart/victory-chart.js
+++ b/src/components/victory-chart/victory-chart.js
@@ -233,9 +233,8 @@ export default class VictoryChart extends React.Component {
   getNewChildren(props, childComponents, calculatedProps) {
     const baseStyle = calculatedProps.style.parent;
     const getAnimationProps = Wrapper.getAnimationProps.bind(this);
-    const newChildren = [];
-    for (let index = 0, len = childComponents.length; index < len; index++) {
-      const child = childComponents[index];
+
+    return childComponents.map((child, index) => {
       const style = defaults({}, child.props.style, {parent: baseStyle});
       const childProps = this.getChildProps(child, props, calculatedProps);
       const newProps = defaults({
@@ -252,9 +251,9 @@ export default class VictoryChart extends React.Component {
         standalone: false,
         style
       }, childProps);
-      newChildren[index] = React.cloneElement(child, newProps);
-    }
-    return newChildren;
+
+      return React.cloneElement(child, newProps);
+    });
   }
 
   renderContainer(containerComponent, props) {

--- a/src/components/victory-errorbar/helper-methods.js
+++ b/src/components/victory-errorbar/helper-methods.js
@@ -6,11 +6,11 @@ export default {
     props = Helpers.modifyProps(props, fallbackProps, "errorbar");
     const { data, style, scale, domain } = this.getCalculatedValues(props, fallbackProps);
     const { groupComponent, height, width, borderWidth, standalone } = props;
-    const childProps = { parent: {
+    const initialChildProps = { parent: {
       domain, style: style.parent, scale, data, height, width, standalone
     }};
-    for (let index = 0, len = data.length; index < len; index++) {
-      const datum = data[index];
+
+    return data.reduce((childProps, datum, index) => {
       const eventKey = datum.eventKey || index;
       const x = scale.x(datum._x1 !== undefined ? datum._x1 : datum._x);
       const y = scale.y(datum._y1 !== undefined ? datum._y1 : datum._y);
@@ -29,8 +29,9 @@ export default {
       if (text !== undefined && text !== null || props.events || props.sharedEvents) {
         childProps[eventKey].labels = this.getLabelProps(dataProps, text, style);
       }
-    }
-    return childProps;
+
+      return childProps;
+    }, initialChildProps);
   },
 
   getLabelProps(dataProps, text, calculatedStyle) {

--- a/src/components/victory-errorbar/victory-errorbar.js
+++ b/src/components/victory-errorbar/victory-errorbar.js
@@ -3,7 +3,7 @@ import {
   PropTypes as CustomPropTypes, Helpers, VictoryTransition, VictoryLabel, addEvents,
   VictoryContainer, VictoryTheme, DefaultTransitions, ErrorBar, Data
 } from "victory-core";
-import { partialRight } from "lodash";
+import { compact, partialRight } from "lodash";
 import ErrorBarHelpers from "./helper-methods";
 
 const fallbackProps = {
@@ -142,17 +142,19 @@ class VictoryErrorBar extends React.Component {
 
   renderData(props) {
     const { dataComponent, labelComponent, groupComponent } = props;
-    const dataComponents = [];
-    const labelComponents = [];
-    for (let index = 0, len = this.dataKeys.length; index < len; index++) {
-      const dataProps = this.getComponentProps(dataComponent, "data", index);
-      dataComponents[index] = React.cloneElement(dataComponent, dataProps);
 
+    const dataComponents = this.dataKeys.map((_dataKey, index) => {
+      const dataProps = this.getComponentProps(dataComponent, "data", index);
+      return React.cloneElement(dataComponent, dataProps);
+    });
+
+    const labelComponents = compact(this.dataKeys.map((_dataKey, index) => {
       const labelProps = this.getComponentProps(labelComponent, "labels", index);
-      if (labelProps && labelProps.text !== undefined && labelProps.text !== null) {
-        labelComponents[index] = React.cloneElement(labelComponent, labelProps);
+      if (labelProps.text !== undefined && labelProps.text !== null) {
+        return React.cloneElement(labelComponent, labelProps);
       }
-    }
+    }));
+
     return labelComponents.length > 0 ?
       React.cloneElement(groupComponent, {}, ...dataComponents, ...labelComponents) :
       dataComponents;

--- a/src/components/victory-errorbar/victory-errorbar.js
+++ b/src/components/victory-errorbar/victory-errorbar.js
@@ -3,7 +3,7 @@ import {
   PropTypes as CustomPropTypes, Helpers, VictoryTransition, VictoryLabel, addEvents,
   VictoryContainer, VictoryTheme, DefaultTransitions, ErrorBar, Data
 } from "victory-core";
-import { compact, partialRight } from "lodash";
+import { partialRight } from "lodash";
 import ErrorBarHelpers from "./helper-methods";
 
 const fallbackProps = {
@@ -148,12 +148,12 @@ class VictoryErrorBar extends React.Component {
       return React.cloneElement(dataComponent, dataProps);
     });
 
-    const labelComponents = compact(this.dataKeys.map((_dataKey, index) => {
+    const labelComponents = this.dataKeys.map((_dataKey, index) => {
       const labelProps = this.getComponentProps(labelComponent, "labels", index);
       if (labelProps.text !== undefined && labelProps.text !== null) {
         return React.cloneElement(labelComponent, labelProps);
       }
-    }));
+    }).filter(Boolean);
 
     return labelComponents.length > 0 ?
       React.cloneElement(groupComponent, {}, ...dataComponents, ...labelComponents) :

--- a/src/components/victory-group/victory-group.js
+++ b/src/components/victory-group/victory-group.js
@@ -251,9 +251,8 @@ export default class VictoryGroup extends React.Component {
     const { offset, theme, labelComponent } = props;
     const childProps = this.getChildProps(props, calculatedProps);
     const getAnimationProps = Wrapper.getAnimationProps.bind(this);
-    const newChildren = [];
-    for (let index = 0, len = childComponents.length; index < len; index++) {
-      const child = childComponents[index];
+
+    return childComponents.map((child, index) => {
       const role = child.type && child.type.role;
       const xOffset = this.getXO(props, calculatedProps, index);
       const style = role === "voronoi" || role === "tooltip" ?
@@ -264,7 +263,7 @@ export default class VictoryGroup extends React.Component {
         {x: (offset * childComponents.length) / 2};
       const domainPadding = child.props.domainPadding ||
         props.domainPadding || defaultDomainPadding;
-      newChildren[index] = React.cloneElement(child, assign({
+      return React.cloneElement(child, assign({
         domainPadding, labels, style, theme, horizontal,
         data: this.getDataWithOffset(props, datasets[index], xOffset),
         animate: getAnimationProps(props, child, index),
@@ -273,8 +272,7 @@ export default class VictoryGroup extends React.Component {
         labelComponent: labelComponent || child.props.labelComponent,
         xOffset: role === "stack" ? xOffset : undefined
       }, childProps));
-    }
-    return newChildren;
+    });
   }
 
   renderContainer(containerComponent, props) {

--- a/src/components/victory-line/helper-methods.js
+++ b/src/components/victory-line/helper-methods.js
@@ -11,24 +11,26 @@ export default {
     const { scale, dataset, dataSegments, domain } = calculatedValues;
     const style = Helpers.getStyles(props.style, defaultStyles, "auto", "100%");
     const {interpolation, label, width, height, events, sharedEvents, standalone} = props;
-    const childProps = { parent: {
+    const initialChildProps = { parent: {
       style: style.parent, scale, data: dataset, height, width, domain, standalone
     }};
-    for (let index = 0, len = dataSegments.length; index < len; index++) {
+
+    return dataSegments.reduce((childProps, dataSegment, index) => {
       const dataProps = {
         scale,
         interpolation,
         style: style.data,
-        data: dataSegments[index]
+        data: dataSegment
       };
       const text = index === dataSegments.length - 1 ? label : undefined;
       const addLabels = (text !== undefined && text !== null) || events || sharedEvents;
       const labelProps = addLabels ?
         this.getLabelProps(dataProps, text, calculatedValues, style) : undefined;
-      childProps[index] = { data: dataProps, labels: labelProps };
-    }
 
-    return childProps;
+      childProps[index] = { data: dataProps, labels: labelProps };
+
+      return childProps;
+    }, initialChildProps);
   },
 
   getLabelProps(dataProps, text, calculatedValues, style) { // eslint-disable-line max-params

--- a/src/components/victory-line/victory-line.js
+++ b/src/components/victory-line/victory-line.js
@@ -1,4 +1,4 @@
-import { partialRight } from "lodash";
+import { compact, partialRight } from "lodash";
 import React, { PropTypes } from "react";
 import LineHelpers from "./helper-methods";
 import {
@@ -122,17 +122,19 @@ class VictoryLine extends React.Component {
 
   renderData(props) {
     const { dataComponent, labelComponent, groupComponent } = props;
-    const dataComponents = [];
-    const labelComponents = [];
-    for (let index = 0, len = this.dataKeys.length; index < len; index++) {
-      const dataProps = this.getComponentProps(dataComponent, "data", index);
-      dataComponents[index] = React.cloneElement(dataComponent, dataProps);
 
+    const dataComponents = this.dataKeys.map((_dataKey, index) => {
+      const dataProps = this.getComponentProps(dataComponent, "data", index);
+      return React.cloneElement(dataComponent, dataProps);
+    });
+
+    const labelComponents = compact(this.dataKeys.map((_dataKey, index) => {
       const labelProps = this.getComponentProps(labelComponent, "labels", index);
-      if (labelProps && labelProps.text !== undefined && labelProps.text !== null) {
-        labelComponents[index] = React.cloneElement(labelComponent, labelProps);
+      if (labelProps.text !== undefined && labelProps.text !== null) {
+        return React.cloneElement(labelComponent, labelProps);
       }
-    }
+    }));
+
     return React.cloneElement(groupComponent, {}, ...dataComponents, ...labelComponents);
   }
 

--- a/src/components/victory-line/victory-line.js
+++ b/src/components/victory-line/victory-line.js
@@ -1,4 +1,4 @@
-import { compact, partialRight } from "lodash";
+import { partialRight } from "lodash";
 import React, { PropTypes } from "react";
 import LineHelpers from "./helper-methods";
 import {
@@ -128,12 +128,12 @@ class VictoryLine extends React.Component {
       return React.cloneElement(dataComponent, dataProps);
     });
 
-    const labelComponents = compact(this.dataKeys.map((_dataKey, index) => {
+    const labelComponents = this.dataKeys.map((_dataKey, index) => {
       const labelProps = this.getComponentProps(labelComponent, "labels", index);
       if (labelProps.text !== undefined && labelProps.text !== null) {
         return React.cloneElement(labelComponent, labelProps);
       }
-    }));
+    }).filter(Boolean);
 
     return React.cloneElement(groupComponent, {}, ...dataComponents, ...labelComponents);
   }

--- a/src/components/victory-scatter/helper-methods.js
+++ b/src/components/victory-scatter/helper-methods.js
@@ -6,12 +6,12 @@ export default {
     props = Helpers.modifyProps(props, fallbackProps, "scatter");
     const calculatedValues = this.getCalculatedValues(props);
     const { data, style, scale, domain } = calculatedValues;
-    const childProps = { parent: {
+    const initialChildProps = { parent: {
       style: style.parent, scale, domain, data, height: props.height,
       width: props.width, standalone: props.standalone
     }};
-    for (let index = 0, len = data.length; index < len; index++) {
-      const datum = data[index];
+
+    return data.reduce((childProps, datum, index) => {
       const eventKey = datum.eventKey;
       const x = scale.x(datum._x1 !== undefined ? datum._x1 : datum._x);
       const y = scale.y(datum._y1 !== undefined ? datum._y1 : datum._y);
@@ -27,8 +27,9 @@ export default {
       if (text !== undefined && text !== null || props.events || props.sharedEvents) {
         childProps[eventKey].labels = this.getLabelProps(dataProps, text, style);
       }
-    }
-    return childProps;
+
+      return childProps;
+    }, initialChildProps);
   },
 
   getLabelProps(dataProps, text, calculatedStyle) {

--- a/src/components/victory-scatter/victory-scatter.js
+++ b/src/components/victory-scatter/victory-scatter.js
@@ -1,5 +1,5 @@
 import React, { PropTypes } from "react";
-import { partialRight } from "lodash";
+import { compact, partialRight } from "lodash";
 import {
   PropTypes as CustomPropTypes, Helpers, VictoryTransition, VictoryLabel, addEvents,
   VictoryContainer, VictoryTheme, DefaultTransitions, Point, Data, Domain
@@ -129,17 +129,19 @@ class VictoryScatter extends React.Component {
 
   renderData(props) {
     const { dataComponent, labelComponent, groupComponent } = props;
-    const dataComponents = [];
-    const labelComponents = [];
-    for (let index = 0, len = this.dataKeys.length; index < len; index++) {
-      const dataProps = this.getComponentProps(dataComponent, "data", index);
-      dataComponents[index] = React.cloneElement(dataComponent, dataProps);
 
+    const dataComponents = this.dataKeys.map((_dataKey, index) => {
+      const dataProps = this.getComponentProps(dataComponent, "data", index);
+      return React.cloneElement(dataComponent, dataProps);
+    });
+
+    const labelComponents = compact(this.dataKeys.map((_dataKey, index) => {
       const labelProps = this.getComponentProps(labelComponent, "labels", index);
-      if (labelProps && labelProps.text !== undefined && labelProps.text !== null) {
-        labelComponents[index] = React.cloneElement(labelComponent, labelProps);
+      if (labelProps.text !== undefined && labelProps.text !== null) {
+        return React.cloneElement(labelComponent, labelProps);
       }
-    }
+    }));
+
     return labelComponents.length > 0 ?
       React.cloneElement(groupComponent, {}, ...dataComponents, ...labelComponents) :
       dataComponents;

--- a/src/components/victory-scatter/victory-scatter.js
+++ b/src/components/victory-scatter/victory-scatter.js
@@ -1,5 +1,5 @@
 import React, { PropTypes } from "react";
-import { compact, partialRight } from "lodash";
+import { partialRight } from "lodash";
 import {
   PropTypes as CustomPropTypes, Helpers, VictoryTransition, VictoryLabel, addEvents,
   VictoryContainer, VictoryTheme, DefaultTransitions, Point, Data, Domain
@@ -135,12 +135,12 @@ class VictoryScatter extends React.Component {
       return React.cloneElement(dataComponent, dataProps);
     });
 
-    const labelComponents = compact(this.dataKeys.map((_dataKey, index) => {
+    const labelComponents = this.dataKeys.map((_dataKey, index) => {
       const labelProps = this.getComponentProps(labelComponent, "labels", index);
       if (labelProps.text !== undefined && labelProps.text !== null) {
         return React.cloneElement(labelComponent, labelProps);
       }
-    }));
+    }).filter(Boolean);
 
     return labelComponents.length > 0 ?
       React.cloneElement(groupComponent, {}, ...dataComponents, ...labelComponents) :

--- a/src/components/victory-stack/victory-stack.js
+++ b/src/components/victory-stack/victory-stack.js
@@ -215,7 +215,7 @@ export default class VictoryStack extends React.Component {
     const childProps = this.getChildProps(props, calculatedProps);
     const getAnimationProps = Wrapper.getAnimationProps.bind(this);
 
-    const newChildren = childComponents.map((child, index) => {
+    return childComponents.map((child, index) => {
       const data = this.addLayoutData(props, calculatedProps, datasets, index);
       const style = Wrapper.getChildStyle(child, index, calculatedProps);
       const labels = props.labels ? this.getLabels(props, datasets, index) : child.props.labels;

--- a/src/components/victory-stack/victory-stack.js
+++ b/src/components/victory-stack/victory-stack.js
@@ -214,13 +214,13 @@ export default class VictoryStack extends React.Component {
     const { datasets } = calculatedProps;
     const childProps = this.getChildProps(props, calculatedProps);
     const getAnimationProps = Wrapper.getAnimationProps.bind(this);
-    const newChildren = [];
-    for (let index = 0, len = childComponents.length; index < len; index++) {
-      const child = childComponents[index];
+
+    const newChildren = childComponents.map((child, index) => {
       const data = this.addLayoutData(props, calculatedProps, datasets, index);
       const style = Wrapper.getChildStyle(child, index, calculatedProps);
       const labels = props.labels ? this.getLabels(props, datasets, index) : child.props.labels;
-      newChildren[index] = React.cloneElement(child, assign({
+
+      return React.cloneElement(child, assign({
         animate: getAnimationProps(props, child, index),
         key: index,
         labels,
@@ -231,8 +231,7 @@ export default class VictoryStack extends React.Component {
         colorScale: this.getColorScale(props, child),
         data
       }, childProps));
-    }
-    return newChildren;
+    });
   }
 
   renderContainer(containerComponent, props) {

--- a/src/components/victory-voronoi-tooltip/helper-methods.js
+++ b/src/components/victory-voronoi-tooltip/helper-methods.js
@@ -6,12 +6,12 @@ export default {
   getBaseProps(props, fallbackProps) {
     props = Helpers.modifyProps(props, fallbackProps, "voronoi");
     const { data, style, scale, polygons, domain } = this.getCalculatedValues(props);
-    const childProps = { parent: {
+    const initialChildProps = { parent: {
       style: style.parent, scale, domain, data, standalone: props.standalone,
       height: props.height, width: props.width
     }};
-    for (let index = 0, len = data.length; index < len; index++) {
-      const datum = data[index];
+
+    return data.reduce((childProps, datum, index) => {
       const polygon = without(polygons[index], "data");
       const eventKey = datum.eventKey;
       const x = scale.x(datum._x1 !== undefined ? datum._x1 : datum._x);
@@ -30,8 +30,9 @@ export default {
           this.getFlyoutProps(dataProps, text, style),
         );
       }
-    }
-    return childProps;
+
+      return childProps;
+    }, initialChildProps);
   },
 
   getFlyoutProps(dataProps, text, style) {

--- a/src/components/victory-voronoi-tooltip/victory-voronoi-tooltip.js
+++ b/src/components/victory-voronoi-tooltip/victory-voronoi-tooltip.js
@@ -1,5 +1,5 @@
 import React, { PropTypes } from "react";
-import { compact, partialRight } from "lodash";
+import { partialRight } from "lodash";
 import {
   PropTypes as CustomPropTypes, Helpers, VictoryTransition, VictoryTooltip, addEvents,
   VictoryContainer, VictoryTheme, DefaultTransitions, Voronoi, Data, Domain
@@ -129,12 +129,12 @@ class VictoryVoronoiTooltip extends React.Component {
       return React.cloneElement(dataComponent, dataProps);
     });
 
-    const labelComponents = compact(this.dataKeys.map((_dataKey, index) => {
+    const labelComponents = this.dataKeys.map((_dataKey, index) => {
       const labelProps = this.getComponentProps(labelComponent, "labels", index);
       if (labelProps.text !== undefined && labelProps.text !== null) {
         return React.cloneElement(labelComponent, labelProps);
       }
-    }));
+    }).filter(Boolean);
 
     return labelComponents.length > 0 ?
       React.cloneElement(groupComponent, {}, ...dataComponents, ...labelComponents) :

--- a/src/components/victory-voronoi-tooltip/victory-voronoi-tooltip.js
+++ b/src/components/victory-voronoi-tooltip/victory-voronoi-tooltip.js
@@ -1,5 +1,5 @@
 import React, { PropTypes } from "react";
-import { compact, get, partialRight } from "lodash";
+import { compact, partialRight } from "lodash";
 import {
   PropTypes as CustomPropTypes, Helpers, VictoryTransition, VictoryTooltip, addEvents,
   VictoryContainer, VictoryTheme, DefaultTransitions, Voronoi, Data, Domain

--- a/src/components/victory-voronoi-tooltip/victory-voronoi-tooltip.js
+++ b/src/components/victory-voronoi-tooltip/victory-voronoi-tooltip.js
@@ -1,5 +1,5 @@
 import React, { PropTypes } from "react";
-import { partialRight } from "lodash";
+import { compact, get, partialRight } from "lodash";
 import {
   PropTypes as CustomPropTypes, Helpers, VictoryTransition, VictoryTooltip, addEvents,
   VictoryContainer, VictoryTheme, DefaultTransitions, Voronoi, Data, Domain
@@ -123,17 +123,19 @@ class VictoryVoronoiTooltip extends React.Component {
 
   renderData(props) {
     const { dataComponent, labelComponent, groupComponent } = props;
-    const dataComponents = [];
-    const labelComponents = [];
-    for (let index = 0, len = this.dataKeys.length; index < len; index++) {
-      const dataProps = this.getComponentProps(dataComponent, "data", index);
-      dataComponents[index] = React.cloneElement(dataComponent, dataProps);
 
+    const dataComponents = this.dataKeys.map((_dataKey, index) => {
+      const dataProps = this.getComponentProps(dataComponent, "data", index);
+      return React.cloneElement(dataComponent, dataProps);
+    });
+
+    const labelComponents = compact(this.dataKeys.map((_dataKey, index) => {
       const labelProps = this.getComponentProps(labelComponent, "labels", index);
-      if (labelProps && labelProps.text !== undefined && labelProps.text !== null) {
-        labelComponents[index] = React.cloneElement(labelComponent, labelProps);
+      if (labelProps.text !== undefined && labelProps.text !== null) {
+        return React.cloneElement(labelComponent, labelProps);
       }
-    }
+    }));
+
     return labelComponents.length > 0 ?
       React.cloneElement(groupComponent, {}, ...dataComponents, ...labelComponents) :
       dataComponents;

--- a/src/components/victory-voronoi/helper-methods.js
+++ b/src/components/victory-voronoi/helper-methods.js
@@ -6,12 +6,12 @@ export default {
   getBaseProps(props, fallbackProps) {
     props = Helpers.modifyProps(props, fallbackProps, "voronoi");
     const { data, style, scale, polygons, domain } = this.getCalculatedValues(props);
-    const childProps = { parent: {
+    const initialChildProps = { parent: {
       style: style.parent, scale, domain, data, standalone: props.standalone,
       height: props.height, width: props.width
     }};
-    for (let index = 0, len = data.length; index < len; index++) {
-      const datum = data[index];
+
+    return data.reduce((childProps, datum, index) => {
       const polygon = without(polygons[index], "data");
       const eventKey = datum.eventKey;
       const x = scale.x(datum._x1 !== undefined ? datum._x1 : datum._x);
@@ -27,8 +27,9 @@ export default {
       if (text !== undefined && text !== null || props.events || props.sharedEvents) {
         childProps[eventKey].labels = this.getLabelProps(dataProps, text, style);
       }
-    }
-    return childProps;
+
+      return childProps;
+    }, initialChildProps);
   },
 
   getLabelProps(dataProps, text, calculatedStyle) {

--- a/src/components/victory-voronoi/victory-voronoi.js
+++ b/src/components/victory-voronoi/victory-voronoi.js
@@ -1,5 +1,5 @@
 import React, { PropTypes } from "react";
-import { partialRight } from "lodash";
+import { compact, get, partialRight } from "lodash";
 import {
   PropTypes as CustomPropTypes, Helpers, VictoryTransition, VictoryLabel, addEvents,
   VictoryContainer, VictoryTheme, DefaultTransitions, Voronoi, Data, Domain
@@ -120,17 +120,19 @@ class VictoryVoronoi extends React.Component {
 
   renderData(props) {
     const { dataComponent, labelComponent, groupComponent } = props;
-    const dataComponents = [];
-    const labelComponents = [];
-    for (let index = 0, len = this.dataKeys.length; index < len; index++) {
-      const dataProps = this.getComponentProps(dataComponent, "data", index);
-      dataComponents[index] = React.cloneElement(dataComponent, dataProps);
 
+    const dataComponents = this.dataKeys.map((_dataKey, index) => {
+      const dataProps = this.getComponentProps(dataComponent, "data", index);
+      return React.cloneElement(dataComponent, dataProps);
+    });
+
+    const labelComponents = compact(this.dataKeys.map((_dataKey, index) => {
       const labelProps = this.getComponentProps(labelComponent, "labels", index);
-      if (labelProps && labelProps.text !== undefined && labelProps.text !== null) {
-        labelComponents[index] = React.cloneElement(labelComponent, labelProps);
+      if (labelProps.text !== undefined && labelProps.text !== null) {
+        return React.cloneElement(labelComponent, labelProps);
       }
-    }
+    }));
+
     return labelComponents.length > 0 ?
       React.cloneElement(groupComponent, {}, ...dataComponents, ...labelComponents) :
       dataComponents;

--- a/src/components/victory-voronoi/victory-voronoi.js
+++ b/src/components/victory-voronoi/victory-voronoi.js
@@ -1,5 +1,5 @@
 import React, { PropTypes } from "react";
-import { compact, get, partialRight } from "lodash";
+import { compact, partialRight } from "lodash";
 import {
   PropTypes as CustomPropTypes, Helpers, VictoryTransition, VictoryLabel, addEvents,
   VictoryContainer, VictoryTheme, DefaultTransitions, Voronoi, Data, Domain

--- a/src/components/victory-voronoi/victory-voronoi.js
+++ b/src/components/victory-voronoi/victory-voronoi.js
@@ -1,5 +1,5 @@
 import React, { PropTypes } from "react";
-import { compact, partialRight } from "lodash";
+import { partialRight } from "lodash";
 import {
   PropTypes as CustomPropTypes, Helpers, VictoryTransition, VictoryLabel, addEvents,
   VictoryContainer, VictoryTheme, DefaultTransitions, Voronoi, Data, Domain
@@ -126,12 +126,12 @@ class VictoryVoronoi extends React.Component {
       return React.cloneElement(dataComponent, dataProps);
     });
 
-    const labelComponents = compact(this.dataKeys.map((_dataKey, index) => {
+    const labelComponents = this.dataKeys.map((_dataKey, index) => {
       const labelProps = this.getComponentProps(labelComponent, "labels", index);
       if (labelProps.text !== undefined && labelProps.text !== null) {
         return React.cloneElement(labelComponent, labelProps);
       }
-    }));
+    }).filter(Boolean);
 
     return labelComponents.length > 0 ?
       React.cloneElement(groupComponent, {}, ...dataComponents, ...labelComponents) :


### PR DESCRIPTION
Removes `for` loops that could be substituted for simple `map/reduce` functions. A few still remain due to being complicated algorithms. If appropriate, we can refactor those later, but they're not as straightforward. 