### PR TITLE
avoid double calculating data

### DIFF
--- a/src/components/victory-line/helper-methods.js
+++ b/src/components/victory-line/helper-methods.js
@@ -55,7 +55,7 @@ export default {
   getCalculatedValues(props) {
     let dataset = Data.getData(props);
 
-    if (Data.getData(props).length < 2) {
+    if (dataset.length < 2) {
       Log.warn("VictoryLine needs at least two data points to render properly.");
       dataset = [];
     }

--- a/test/client/spec/components/victory-line/victory-line.spec.js
+++ b/test/client/spec/components/victory-line/victory-line.spec.js
@@ -2,6 +2,7 @@
  * Client tests
  */
 /* global sinon */
+/* global console */
 /*eslint-disable max-nested-callbacks */
 /* eslint no-unused-expressions: 0 */
 
@@ -40,7 +41,8 @@ describe("components/victory-line", () => {
 
   describe("rendering with data", () => {
     it("renders no line segments for single data points", () => {
-      const warningStub = sinon.stub(console, "warn");
+      const log = console;
+      const warningStub = sinon.stub(log, "warn");
       const data = [{x: 1, y: 1}];
       const wrapper = shallow(
         <VictoryLine data={data}/>
@@ -48,7 +50,7 @@ describe("components/victory-line", () => {
       const lines = wrapper.find(Curve);
       expect(lines.length).to.equal(0);
       expect(warningStub).to.have.been.called;
-      console.warn.restore();
+      log.warn.restore();
     });
 
     it("renders one dataComponent for the line", () => {

--- a/test/client/spec/components/victory-line/victory-line.spec.js
+++ b/test/client/spec/components/victory-line/victory-line.spec.js
@@ -39,6 +39,18 @@ describe("components/victory-line", () => {
   });
 
   describe("rendering with data", () => {
+    it("renders no line segments for single data points", () => {
+      const warningStub = sinon.stub(console, "warn");
+      const data = [{x: 1, y: 1}];
+      const wrapper = shallow(
+        <VictoryLine data={data}/>
+      );
+      const lines = wrapper.find(Curve);
+      expect(lines.length).to.equal(0);
+      expect(warningStub).to.have.been.called;
+      console.warn.restore();
+    });
+
     it("renders one dataComponent for the line", () => {
       const data = [
         {x: 1, y: 1},
@@ -339,6 +351,5 @@ describe("components/victory-line", () => {
         expect(roleValue).to.equal("presentation");
       });
     });
-
   });
 });


### PR DESCRIPTION
Speaking of performance improvements, this ~~should help a bit~~ definitely makes a big difference. 

`master`
```
                     <VictoryLine> data
- identity fn                                   363 ops/sec
- 10 pts                                        645 ops/sec
- 50 pts                                        380 ops/sec
- 100 pts                                       245 ops/sec
```

`chore/remove-excess-data-processing`
```
                     <VictoryLine> data
- identity fn                                   425 ops/sec
- 10 pts                                        691 ops/sec
- 50 pts                                        441 ops/sec
- 100 pts                                       302 ops/sec
```

That double processing was costing us quite a lot. 