### PR TITLE
x y zoom

### DIFF
--- a/demo/components/victory-brush-container-demo.js
+++ b/demo/components/victory-brush-container-demo.js
@@ -153,7 +153,7 @@ class App extends React.Component {
             domain={{x: [0, 10], y: [-5, 5]}}
             containerComponent={
               <VictoryBrushContainer
-                selectedDomain={{x: [0, 10], y: [-5, 5]}}
+                selectedDomain={{x: [0, 10]}}
               />
             }
             size={(datum, active) => active ? 5 : 3}
@@ -293,6 +293,27 @@ class App extends React.Component {
               ]}
             />
           </VictoryStack>
+
+          <VictoryLine style={chartStyle}
+            containerComponent={
+              <VictoryBrushContainer
+                selectedDomain={{y: [-3, 3]}}
+                selectionComponent={<rect style={{fill: "teal"}}/>}
+              />
+            }
+            style={{
+              data: {stroke: "teal"}
+            }}
+            data={[
+              {x: 1, y: -3},
+              {x: 2, y: 5},
+              {x: 3, y: -3},
+              {x: 4, y: 0},
+              {x: 5, y: -5},
+              {x: 6, y: 2},
+              {x: 7, y: 0}
+            ]}
+          />
         </div>
       </div>
     );

--- a/demo/components/victory-brush-container-demo.js
+++ b/demo/components/victory-brush-container-demo.js
@@ -99,7 +99,7 @@ class App extends React.Component {
 
           <VictoryChart style={chartStyle}
             containerComponent={
-              <VictoryBrushContainer/>
+              <VictoryBrushContainer dimension={null}/>
             }
           >
             <VictoryLine

--- a/demo/components/victory-zoom-container-demo.js
+++ b/demo/components/victory-zoom-container-demo.js
@@ -68,7 +68,7 @@ export default class App extends React.Component {
         transitionData: this.getTransitionData(),
         style: this.getStyles()
       });
-    }, 30000);
+    }, 3000);
   }
 
   componentWillUnmount() {

--- a/demo/components/victory-zoom-container-demo.js
+++ b/demo/components/victory-zoom-container-demo.js
@@ -111,10 +111,8 @@ export default class App extends React.Component {
             />
             <VictoryLine
               style={{
-                data: {stroke: "red", strokeWidth: 5},
-                labels: {fontSize: 12}
+                data: {stroke: "red", strokeWidth: 5}
               }}
-              label={this.state.label}
               data={[
                 {x: new Date(1982, 1, 1), y: 125},
                 {x: new Date(1987, 1, 1), y: 257},
@@ -196,7 +194,6 @@ export default class App extends React.Component {
                   }
                 }
               }]}
-              label={this.state.label}
               data={range(0, 100)}
               y={(d) => d * d}
             />

--- a/demo/components/victory-zoom-container-demo.js
+++ b/demo/components/victory-zoom-container-demo.js
@@ -127,7 +127,7 @@ export default class App extends React.Component {
 
           <VictoryChart style={{parent: parentStyle}}
             animate={{duration: 1500}}
-            containerComponent={<VictoryZoomContainer/>}
+            containerComponent={<VictoryZoomContainer zoomDomain={{x: [0, 50]}}/>}
           >
             <VictoryLine
               style={{parent: parentStyle, data: this.state.style}}

--- a/demo/components/victory-zoom-container-demo.js
+++ b/demo/components/victory-zoom-container-demo.js
@@ -127,7 +127,9 @@ export default class App extends React.Component {
 
           <VictoryChart style={{parent: parentStyle}}
             animate={{duration: 1500}}
-            containerComponent={<VictoryZoomContainer zoomDomain={{x: [0, 50]}}/>}
+            containerComponent={
+              <VictoryZoomContainer zoomDomain={{x: [0, 50]}} minimumZoom={{x: 5}}/>
+            }
           >
             <VictoryLine
               style={{parent: parentStyle, data: this.state.style}}

--- a/demo/components/victory-zoom-container-demo.js
+++ b/demo/components/victory-zoom-container-demo.js
@@ -68,7 +68,7 @@ export default class App extends React.Component {
         transitionData: this.getTransitionData(),
         style: this.getStyles()
       });
-    }, 3000);
+    }, 30000);
   }
 
   componentWillUnmount() {
@@ -99,7 +99,6 @@ export default class App extends React.Component {
             containerComponent={
               <VictoryZoomContainer
                 zoomDomain={{x: [new Date(1993, 1, 1), new Date(2005, 1, 1)]}}
-                allowZoom={false}
               />
             }
             scale={{

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "builder-victory-component": "^3.1.0",
     "d3-voronoi": "^1.0.0",
     "lodash": "^4.12.0",
-    "victory-core": "^14.0.0"
+    "victory-core": "^14.0.1"
   },
   "devDependencies": {
     "builder-victory-component-dev": "^3.1.0",

--- a/src/components/containers/victory-brush-container.js
+++ b/src/components/containers/victory-brush-container.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { VictoryContainer, Selection } from "victory-core";
 import BrushHelpers from "./brush-helpers";
-import { assign, isEqual } from "lodash";
+import { assign, defaults, isEqual } from "lodash";
 
 
 export default class VictoryBrushContainer extends VictoryContainer {
@@ -31,7 +31,6 @@ export default class VictoryBrushContainer extends VictoryContainer {
       stroke: "transparent",
       fill: "transparent"
     },
-    dimension: "x",
     handleWidth: 8,
     selectionComponent: <rect/>,
     handleComponent: <rect/>
@@ -62,6 +61,7 @@ export default class VictoryBrushContainer extends VictoryContainer {
   getSelectBox(props, coordinates) {
     const {x, y} = coordinates;
     const {selectionStyle, selectionComponent} = props;
+    const selectionComponentStyle = selectionComponent.props && selectionComponent.props.style;
     return x[0] !== x[1] && y[0] !== y[1] ?
       React.cloneElement(selectionComponent, {
         width: Math.abs(x[1] - x[0]) || 1,
@@ -69,7 +69,7 @@ export default class VictoryBrushContainer extends VictoryContainer {
         x: Math.min(x[0], x[1]),
         y: Math.min(y[0], y[1]),
         cursor: "move",
-        style: selectionStyle
+        style: defaults({}, selectionComponentStyle, selectionStyle)
       }) : null;
   }
 
@@ -78,8 +78,10 @@ export default class VictoryBrushContainer extends VictoryContainer {
     const {x, y} = coordinates;
     const width = Math.abs(x[1] - x[0]) || 1;
     const height = Math.abs(y[1] - y[0]) || 1;
-    const yProps = { style: handleStyle, width, height: handleWidth, cursor: "ns-resize"};
-    const xProps = { style: handleStyle, width: handleWidth, height, cursor: "ew-resize"};
+    const handleComponentStyle = handleComponent.props && handleComponent.props.style || {};
+    const style = defaults({}, handleComponentStyle, handleStyle);
+    const yProps = { style, width, height: handleWidth, cursor: "ns-resize"};
+    const xProps = { style, width: handleWidth, height, cursor: "ew-resize"};
     const handleProps = {
       top: dimension !== "x" && assign({x: x[0], y: y[1] - (handleWidth / 2)}, yProps),
       bottom: dimension !== "x" && assign({x: x[0], y: y[0] - (handleWidth / 2)}, yProps),
@@ -98,9 +100,11 @@ export default class VictoryBrushContainer extends VictoryContainer {
   }
 
   getRect(props) {
-    const {selectedDomain, currentDomain, cachedSelectedDomain, scale} = props;
+    const {currentDomain, cachedSelectedDomain, scale} = props;
+    const selectedDomain = BrushHelpers.getDomain(props.selectedDomain, props);
+    const propsDomain = BrushHelpers.getDomain(props.domain, props);
     const domain = isEqual(selectedDomain, cachedSelectedDomain) ?
-      currentDomain || selectedDomain || props.domain : selectedDomain || props.domain;
+      currentDomain || selectedDomain || propsDomain : selectedDomain || propsDomain;
     const coordinates = Selection.getDomainCoordinates(scale, domain);
     const selectBox = this.getSelectBox(props, coordinates);
     return selectBox ?

--- a/src/components/containers/victory-brush-container.js
+++ b/src/components/containers/victory-brush-container.js
@@ -101,10 +101,9 @@ export default class VictoryBrushContainer extends VictoryContainer {
 
   getRect(props) {
     const {currentDomain, cachedSelectedDomain, scale} = props;
-    const selectedDomain = BrushHelpers.getDomain(props.selectedDomain, props);
-    const propsDomain = BrushHelpers.getDomain(props.domain, props);
+    const selectedDomain = defaults({}, props.selectedDomain, props.domain);
     const domain = isEqual(selectedDomain, cachedSelectedDomain) ?
-      currentDomain || selectedDomain || propsDomain : selectedDomain || propsDomain;
+      defaults({}, currentDomain, selectedDomain) : selectedDomain;
     const coordinates = Selection.getDomainCoordinates(scale, domain);
     const selectBox = this.getSelectBox(props, coordinates);
     return selectBox ?

--- a/src/components/containers/victory-voronoi-container.js
+++ b/src/components/containers/victory-voronoi-container.js
@@ -141,7 +141,7 @@ export default class VictoryVoronoiContainer extends VictoryContainer {
         active: true,
         renderInPortal: false,
         style,
-        flyoutStyle: this.getStyle(props, points, "flyout"),
+        flyoutStyle: this.getStyle(props, points, "flyout")[0],
         text,
         datum: omit(points[0], ["childName", "style", "continuous"]),
         scale,

--- a/src/components/containers/victory-zoom-container.js
+++ b/src/components/containers/victory-zoom-container.js
@@ -11,6 +11,10 @@ export default class VictoryZoomContainer extends VictoryContainer {
       x: CustomPropTypes.domain,
       y: CustomPropTypes.domain
     }),
+    minimumDomain: PropTypes.shape({
+      x: CustomPropTypes.domain,
+      y: CustomPropTypes.domain
+    }),
     onDomainChange: PropTypes.func,
     clipContainerComponent: PropTypes.element.isRequired,
     allowZoom: PropTypes.bool,
@@ -103,11 +107,12 @@ export default class VictoryZoomContainer extends VictoryContainer {
     const childComponents = React.Children.toArray(props.children);
 
     return childComponents.map((child) => {
-      const {cachedZoomDomain, currentDomain} = props;
+      const {currentDomain} = props;
+      const originalDomain = defaults({}, props.original, props.domain);
       const zoomDomain = defaults({}, props.zoomDomain, props.domain);
+      const cachedZoomDomain = defaults({}, props.cachedZoomDomain, props.domain);
       const domain = isEqual(zoomDomain, cachedZoomDomain) ?
-        defaults({}, currentDomain, zoomDomain) : zoomDomain;
-
+        defaults({}, currentDomain, originalDomain) : zoomDomain;
       return React.cloneElement(
         child, defaults({domain}, child.props)
       );

--- a/src/components/containers/victory-zoom-container.js
+++ b/src/components/containers/victory-zoom-container.js
@@ -103,9 +103,10 @@ export default class VictoryZoomContainer extends VictoryContainer {
     const childComponents = React.Children.toArray(props.children);
 
     return childComponents.map((child) => {
-      const {zoomDomain, cachedZoomDomain, currentDomain} = props;
+      const {cachedZoomDomain, currentDomain} = props;
+      const zoomDomain = defaults({}, props.zoomDomain, props.domain);
       const domain = isEqual(zoomDomain, cachedZoomDomain) ?
-        currentDomain || zoomDomain : zoomDomain;
+        defaults({}, currentDomain, zoomDomain) : zoomDomain;
 
       return React.cloneElement(
         child, defaults({domain}, child.props)

--- a/src/components/containers/victory-zoom-container.js
+++ b/src/components/containers/victory-zoom-container.js
@@ -14,7 +14,7 @@ export default class VictoryZoomContainer extends VictoryContainer {
     onDomainChange: PropTypes.func,
     clipContainerComponent: PropTypes.element.isRequired,
     allowZoom: PropTypes.bool,
-    dimension: PropTypes.oneOf(["x", "y", null])
+    dimension: PropTypes.oneOf(["x", "y"])
   };
   static defaultProps = {
     ...VictoryContainer.defaultProps,

--- a/src/components/containers/victory-zoom-container.js
+++ b/src/components/containers/victory-zoom-container.js
@@ -13,7 +13,8 @@ export default class VictoryZoomContainer extends VictoryContainer {
     }),
     onDomainChange: PropTypes.func,
     clipContainerComponent: PropTypes.element.isRequired,
-    allowZoom: PropTypes.bool
+    allowZoom: PropTypes.bool,
+    dimension: PropTypes.oneOf(["x", "y", null])
   };
   static defaultProps = {
     ...VictoryContainer.defaultProps,
@@ -55,9 +56,11 @@ export default class VictoryZoomContainer extends VictoryContainer {
   }];
 
   clipDataComponents(children, props) { //eslint-disable-line max-statements
-    const { scale, height, clipContainerComponent } = props;
+    const { scale, clipContainerComponent } = props;
     const rangeX = scale.x.range();
+    const rangeY = scale.y.range();
     const plottableWidth = Math.abs(rangeX[0] - rangeX[1]);
+    const plottableHeight = Math.abs(rangeY[0] - rangeY[1]);
     const childComponents = [];
     let group = [];
     let groupNumber = 0;
@@ -66,8 +69,9 @@ export default class VictoryZoomContainer extends VictoryContainer {
       return React.cloneElement(clipContainerComponent, {
         key: `ZoomClipContainer-${index}`,
         clipWidth: plottableWidth,
-        clipHeight: height,
-        translateX: rangeX[0],
+        clipHeight: plottableHeight,
+        translateX: Math.min(...rangeX),
+        translateY: Math.min(...rangeY),
         children: arr
       });
     };

--- a/src/components/containers/victory-zoom-container.js
+++ b/src/components/containers/victory-zoom-container.js
@@ -11,9 +11,9 @@ export default class VictoryZoomContainer extends VictoryContainer {
       x: CustomPropTypes.domain,
       y: CustomPropTypes.domain
     }),
-    minimumDomain: PropTypes.shape({
-      x: CustomPropTypes.domain,
-      y: CustomPropTypes.domain
+    minimumZoom: PropTypes.shape({
+      x: PropTypes.number,
+      y: PropTypes.number
     }),
     onDomainChange: PropTypes.func,
     clipContainerComponent: PropTypes.element.isRequired,

--- a/src/components/containers/zoom-helpers.js
+++ b/src/components/containers/zoom-helpers.js
@@ -108,10 +108,11 @@ const Helpers = {
 
   onMouseDown(evt, targetProps) {
     evt.preventDefault();
-    const originalDomain = this.getOriginalDomain(targetProps);
-    const zoomDomain = defaults({}, targetProps.zoomDomain, originalDomain);
-    const currentDomain = targetProps.currentDomain ?
-      defaults({}, targetProps.currentDomain, zoomDomain) : zoomDomain;
+    const {domain, zoomDomain} = targetProps;
+    const originalDomain = defaults({}, targetProps.originalDomain, domain);
+    const currentDomain = defaults(
+      {}, targetProps.currentDomain || zoomDomain || originalDomain, domain
+    );
     const {x, y} = Selection.getSVGEventCoordinates(evt);
     return [{
       target: "parent",
@@ -145,12 +146,12 @@ const Helpers = {
 
   onMouseMove(evt, targetProps, eventKey, ctx) { // eslint-disable-line max-params
     if (targetProps.panning) {
-      const { scale, startX, startY, onDomainChange, dimension } = targetProps;
+      const { scale, startX, startY, onDomainChange, dimension, domain, zoomDomain } = targetProps;
       const {x, y} = Selection.getSVGEventCoordinates(evt);
-      const originalDomain = this.getOriginalDomain(targetProps);
-      const zoomDomain = defaults({}, targetProps.zoomDomain, originalDomain);
-      const lastDomain = targetProps.currentDomain ?
-        defaults({}, targetProps.currentDomain, zoomDomain) : zoomDomain;
+      const originalDomain = defaults({}, targetProps.originalDomain, domain);
+      const lastDomain = defaults(
+        {}, targetProps.currentDomain || zoomDomain || originalDomain, domain
+      );
       const dx = (startX - x) / this.getDomainScale(lastDomain, scale, "x");
       const dy = (y - startY) / this.getDomainScale(lastDomain, scale, "y");
       const currentDomain = {
@@ -178,11 +179,11 @@ const Helpers = {
     if (!targetProps.allowZoom) {
       return {};
     }
-    const { onDomainChange, dimension } = targetProps;
-    const originalDomain = this.getOriginalDomain(targetProps);
-    const zoomDomain = defaults({}, targetProps.zoomDomain, originalDomain);
-    const lastDomain = targetProps.currentDomain ?
-      defaults({}, targetProps.currentDomain, zoomDomain) : zoomDomain;
+    const { onDomainChange, dimension, domain, zoomDomain } = targetProps;
+    const originalDomain = defaults({}, targetProps.originalDomain, domain);
+    const lastDomain = defaults(
+      {}, targetProps.currentDomain || zoomDomain || originalDomain, domain
+    );
     const {x, y} = lastDomain;
     const currentDomain = {
       x: dimension === "y" ? lastDomain.x : this.scale(x, evt, targetProps, "x"),

--- a/src/components/victory-axis/victory-axis.js
+++ b/src/components/victory-axis/victory-axis.js
@@ -75,7 +75,10 @@ class VictoryAxis extends React.Component {
         left: PropTypes.number, right: PropTypes.number
       })
     ]),
-    scale: CustomPropTypes.scale,
+    scale: PropTypes.oneOfType([
+      CustomPropTypes.scale,
+      PropTypes.shape({ x: CustomPropTypes.scale, y: CustomPropTypes.scale })
+    ]),
     sharedEvents: PropTypes.shape({ events: PropTypes.array, getEventState: PropTypes.func }),
     standalone: PropTypes.bool,
     style: PropTypes.shape({

--- a/src/helpers/wrapper.js
+++ b/src/helpers/wrapper.js
@@ -311,6 +311,9 @@ export default {
   },
 
   getY0(datum, index, calculatedProps) {
+    if (datum.y0) {
+      return datum.y0;
+    }
     const { datasets } = calculatedProps;
     const y = datum._y;
     const previousDataSets = datasets.slice(0, index);


### PR DESCRIPTION

**Breaking Changes**
- `VictoryZoomContainer` now zooms both x and y dimensions, use the prop `dimension="x"` to return to the old behavior
- `VictoryZoomContainer` now centers zoom behavior on the mouse position rather than the center of the chart
- `VictoryZoomContainer` has a minimum zoom level of the extent of the domain / 1000. Set a custom minimum with the `minimumZoom` prop, which takes an object with numeric values for x and/ or y.
- `VictoryBrushContainer` no longer has `dimension="x"` as the default value.

---
closes https://github.com/FormidableLabs/victory/issues/428
closes https://github.com/FormidableLabs/victory/issues/491
closes https://github.com/FormidableLabs/victory/issues/499
closes https://github.com/FormidableLabs/victory/issues/495