### PR TITLE
Bump d3-voronoi version to above 1.1.0 in order to ensure .find method exists

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "builder": "^3.1.0",
     "builder-victory-component": "^3.1.0",
-    "d3-voronoi": "^1.0.0",
+    "d3-voronoi": "^1.1.2",
     "lodash": "^4.12.0",
     "victory-core": "^14.0.3"
   },


### PR DESCRIPTION
`find` was introduced in version 1.1.0 (see https://github.com/d3/d3-voronoi/releases)