### PR TITLE
check for VictoryLabel by role

### DIFF
--- a/src/components/victory-axis/victory-axis.js
+++ b/src/components/victory-axis/victory-axis.js
@@ -153,7 +153,7 @@ class VictoryAxis extends React.Component {
   fixLabelOverlap(gridAndTicks, props) {
     const isVertical = Helpers.isVertical(props);
     const size = isVertical ? props.height : props.width;
-    const isVictoryLabel = (child) => child.type.name === "VictoryLabel";
+    const isVictoryLabel = (child) => child.type && child.type.role === "label";
     const labels = gridAndTicks.map((gridAndTick) => gridAndTick.props.children)
      .reduce((accumulator, childArr) => accumulator.concat(childArr))
      .filter(isVictoryLabel)


### PR DESCRIPTION
depends on https://github.com/FormidableLabs/victory-core/pull/222

Check for `VictoryLabel` by static role like other Victory components so that the check will still work in uglified code