### PR TITLE
Exclude null and undefined in multi-line labels

### DIFF
--- a/src/components/containers/victory-voronoi-container.js
+++ b/src/components/containers/victory-voronoi-container.js
@@ -142,6 +142,9 @@ export default class VictoryVoronoiContainer extends VictoryContainer {
     const {labels, scale, labelComponent} = props;
     const text = points.reduce((memo, point) => {
       const t = Helpers.evaluateProp(labels, point, true);
+      if (t === null || t === undefined) {
+        return memo;
+      }
       memo = memo.concat(`${t}`.split("\n"));
       return memo;
     }, []);


### PR DESCRIPTION
If a label is null or undefined it should not be included in a multi-line label. This change ensures it is not.