### PR TITLE
Fixing theme propagation

### DIFF
--- a/src/components/victory-area/victory-area.js
+++ b/src/components/victory-area/victory-area.js
@@ -10,7 +10,8 @@ const fallbackProps = {
   width: 450,
   height: 300,
   padding: 50,
-  interpolation: "linear"
+  interpolation: "linear",
+  theme: VictoryTheme.grayscale
 };
 
 const animationWhitelist = ["data", "domain", "height", "padding", "style", "width"];
@@ -110,8 +111,7 @@ class VictoryArea extends React.Component {
     samples: 50,
     standalone: true,
     containerComponent: <VictoryContainer />,
-    groupComponent: <VictoryClipContainer/>,
-    theme: VictoryTheme.grayscale
+    groupComponent: <VictoryClipContainer/>
   };
 
   static displayName = "VictoryArea";

--- a/src/components/victory-axis/victory-axis.js
+++ b/src/components/victory-axis/victory-axis.js
@@ -10,7 +10,8 @@ import Axis from "../../helpers/axis";
 const fallbackProps = {
   width: 450,
   height: 300,
-  padding: 50
+  padding: 50,
+  theme: VictoryTheme.grayscale
 };
 
 const animationWhitelist = [
@@ -104,7 +105,6 @@ class VictoryAxis extends React.Component {
     gridComponent: <Line type={"grid"}/>,
     scale: "linear",
     standalone: true,
-    theme: VictoryTheme.grayscale,
     tickCount: 5,
     containerComponent: <VictoryContainer />,
     groupComponent: <g role="presentation"/>,

--- a/src/components/victory-bar/victory-bar.js
+++ b/src/components/victory-bar/victory-bar.js
@@ -9,7 +9,8 @@ import {
 const fallbackProps = {
   width: 450,
   height: 300,
-  padding: 50
+  padding: 50,
+  theme: VictoryTheme.grayscale
 };
 
 const defaultData = [
@@ -134,8 +135,7 @@ class VictoryBar extends React.Component {
     scale: "linear",
     standalone: true,
     containerComponent: <VictoryContainer/>,
-    groupComponent: <g role="presentation"/>,
-    theme: VictoryTheme.grayscale
+    groupComponent: <g role="presentation"/>
   };
 
   static getDomain = Domain.getDomainWithZero.bind(Domain);

--- a/src/components/victory-candlestick/victory-candlestick.js
+++ b/src/components/victory-candlestick/victory-candlestick.js
@@ -13,7 +13,8 @@ const fallbackProps = {
   candleColors: {
     positive: "#ffffff",
     negative: "#252525"
-  }
+  },
+  theme: VictoryTheme.grayscale
 };
 
 const defaultData = [
@@ -151,8 +152,7 @@ class VictoryCandlestick extends React.Component {
     dataComponent: <Candle/>,
     labelComponent: <VictoryLabel/>,
     containerComponent: <VictoryContainer/>,
-    groupComponent: <g role="presentation"/>,
-    theme: VictoryTheme.grayscale
+    groupComponent: <g role="presentation"/>
   };
 
   static getDomain = CandlestickHelpers.getDomain.bind(CandlestickHelpers);

--- a/src/components/victory-chart/victory-chart.js
+++ b/src/components/victory-chart/victory-chart.js
@@ -13,7 +13,7 @@ const fallbackProps = {
   width: 450,
   height: 300,
   padding: 50,
-  theme: VictoryTheme.grayscale,
+  theme: VictoryTheme.grayscale
 };
 
 export default class VictoryChart extends React.Component {

--- a/src/components/victory-chart/victory-chart.js
+++ b/src/components/victory-chart/victory-chart.js
@@ -12,7 +12,8 @@ import Wrapper from "../../helpers/wrapper";
 const fallbackProps = {
   width: 450,
   height: 300,
-  padding: 50
+  padding: 50,
+  theme: VictoryTheme.grayscale,
 };
 
 export default class VictoryChart extends React.Component {
@@ -87,7 +88,6 @@ export default class VictoryChart extends React.Component {
     standalone: true,
     containerComponent: <VictoryContainer/>,
     groupComponent: <g/>,
-    theme: VictoryTheme.grayscale,
     defaultAxes: {
       independent: <VictoryAxis/>,
       dependent: <VictoryAxis dependentAxis/>

--- a/src/components/victory-errorbar/victory-errorbar.js
+++ b/src/components/victory-errorbar/victory-errorbar.js
@@ -9,7 +9,8 @@ import ErrorBarHelpers from "./helper-methods";
 const fallbackProps = {
   width: 450,
   height: 300,
-  padding: 50
+  padding: 50,
+  theme: VictoryTheme.grayscale
 };
 
 const defaultData = [
@@ -134,8 +135,7 @@ class VictoryErrorBar extends React.Component {
     dataComponent: <ErrorBar/>,
     labelComponent: <VictoryLabel/>,
     containerComponent: <VictoryContainer/>,
-    groupComponent: <g role="presentation"/>,
-    theme: VictoryTheme.grayscale
+    groupComponent: <g role="presentation"/>
   };
 
   static getDomain = ErrorBarHelpers.getDomain.bind(ErrorBarHelpers);

--- a/src/components/victory-group/victory-group.js
+++ b/src/components/victory-group/victory-group.js
@@ -9,7 +9,8 @@ const fallbackProps = {
   width: 450,
   height: 300,
   padding: 50,
-  offset: 0
+  offset: 0,
+  theme: VictoryTheme.grayscale
 };
 
 export default class VictoryGroup extends React.Component {
@@ -117,8 +118,7 @@ export default class VictoryGroup extends React.Component {
     scale: "linear",
     standalone: true,
     containerComponent: <VictoryContainer/>,
-    groupComponent: <g/>,
-    theme: VictoryTheme.grayscale
+    groupComponent: <g/>
   };
 
   static getDomain = Wrapper.getDomain.bind(Wrapper);

--- a/src/components/victory-line/victory-line.js
+++ b/src/components/victory-line/victory-line.js
@@ -11,7 +11,8 @@ const fallbackProps = {
   width: 450,
   height: 300,
   padding: 50,
-  interpolation: "linear"
+  interpolation: "linear",
+  theme: VictoryTheme.grayscale
 };
 
 const animationWhitelist = ["data", "domain", "height", "padding", "samples", "style", "width"];
@@ -116,8 +117,7 @@ class VictoryLine extends React.Component {
     dataComponent: <Curve/>,
     labelComponent: <VictoryLabel/>,
     containerComponent: <VictoryContainer/>,
-    groupComponent: <VictoryClipContainer/>,
-    theme: VictoryTheme.grayscale
+    groupComponent: <VictoryClipContainer/>
   };
 
   static getDomain = Domain.getDomain.bind(Domain);

--- a/src/components/victory-scatter/victory-scatter.js
+++ b/src/components/victory-scatter/victory-scatter.js
@@ -11,7 +11,8 @@ const fallbackProps = {
   height: 300,
   padding: 50,
   size: 3,
-  symbol: "circle"
+  symbol: "circle",
+  theme: VictoryTheme.grayscale
 };
 
 const animationWhitelist = [
@@ -121,8 +122,7 @@ class VictoryScatter extends React.Component {
     dataComponent: <Point/>,
     labelComponent: <VictoryLabel/>,
     containerComponent: <VictoryContainer/>,
-    groupComponent: <g/>,
-    theme: VictoryTheme.grayscale
+    groupComponent: <g/>
   };
 
   static getDomain = Domain.getDomain.bind(Domain);

--- a/src/components/victory-voronoi-tooltip/victory-voronoi-tooltip.js
+++ b/src/components/victory-voronoi-tooltip/victory-voronoi-tooltip.js
@@ -9,7 +9,8 @@ import TooltipHelpers from "./helper-methods";
 const fallbackProps = {
   width: 450,
   height: 300,
-  padding: 50
+  padding: 50,
+  theme: VictoryTheme.grayscale
 };
 
 const animationWhitelist = [
@@ -115,8 +116,7 @@ class VictoryVoronoiTooltip extends React.Component {
     dataComponent: <Voronoi/>,
     labelComponent: <VictoryTooltip/>,
     containerComponent: <VictoryContainer/>,
-    groupComponent: <g role="presentation"/>,
-    theme: VictoryTheme.grayscale
+    groupComponent: <g role="presentation"/>
   };
 
   static getDomain = Domain.getDomain.bind(Domain);

--- a/src/components/victory-voronoi/helper-methods.js
+++ b/src/components/victory-voronoi/helper-methods.js
@@ -25,14 +25,14 @@ export default {
       childProps[eventKey] = { data: dataProps };
       const text = this.getLabelText(props, datum, index);
       if (text !== undefined && text !== null || events || sharedEvents) {
-        childProps[eventKey].labels = this.getLabelProps(dataProps, text, style);
+        childProps[eventKey].labels = this.getLabelProps(dataProps, text, style, theme);
       }
 
       return childProps;
     }, initialChildProps);
   },
 
-  getLabelProps(dataProps, text, calculatedStyle) {
+  getLabelProps(dataProps, text, calculatedStyle, theme) {
     const { x, y, index, scale, datum, data } = dataProps;
     const labelStyle = this.getLabelStyle(calculatedStyle.labels, dataProps) || {};
     return {
@@ -46,7 +46,8 @@ export default {
       data,
       textAnchor: labelStyle.textAnchor,
       verticalAnchor: labelStyle.verticalAnchor || "end",
-      angle: labelStyle.angle
+      angle: labelStyle.angle,
+      theme
     };
   },
 

--- a/src/components/victory-voronoi/helper-methods.js
+++ b/src/components/victory-voronoi/helper-methods.js
@@ -17,7 +17,7 @@ export default {
       const x = scale.x(datum._x1 !== undefined ? datum._x1 : datum._x);
       const y = scale.y(datum._y1 !== undefined ? datum._y1 : datum._y);
       const dataProps = {
-        x, y, datum, data, index, scale, polygon,
+        x, y, datum, data, index, scale, polygon, theme,
         size: props.size,
         style: this.getDataStyles(datum, style.data)
       };
@@ -25,15 +25,15 @@ export default {
       childProps[eventKey] = { data: dataProps };
       const text = this.getLabelText(props, datum, index);
       if (text !== undefined && text !== null || events || sharedEvents) {
-        childProps[eventKey].labels = this.getLabelProps(dataProps, text, style, theme);
+        childProps[eventKey].labels = this.getLabelProps(dataProps, text, style);
       }
 
       return childProps;
     }, initialChildProps);
   },
 
-  getLabelProps(dataProps, text, calculatedStyle, theme) {
-    const { x, y, index, scale, datum, data } = dataProps;
+  getLabelProps(dataProps, text, calculatedStyle) {
+    const { x, y, index, scale, datum, data, theme } = dataProps;
     const labelStyle = this.getLabelStyle(calculatedStyle.labels, dataProps) || {};
     return {
       style: labelStyle,

--- a/src/components/victory-voronoi/victory-voronoi.js
+++ b/src/components/victory-voronoi/victory-voronoi.js
@@ -9,7 +9,8 @@ import VoronoiHelpers from "./helper-methods";
 const fallbackProps = {
   width: 450,
   height: 300,
-  padding: 50
+  padding: 50,
+  theme: VictoryTheme.grayscale
 };
 
 const animationWhitelist = [
@@ -112,8 +113,7 @@ class VictoryVoronoi extends React.Component {
     dataComponent: <Voronoi/>,
     labelComponent: <VictoryLabel/>,
     containerComponent: <VictoryContainer/>,
-    groupComponent: <g role="presentation"/>,
-    theme: VictoryTheme.grayscale
+    groupComponent: <g role="presentation"/>
   };
 
   static getDomain = Domain.getDomain.bind(Domain);


### PR DESCRIPTION
Digging into [victory/issues/540](https://github.com/FormidableLabs/victory/issues/540) and I'm putting up this CR to see if I'm heading in the right direction. The problem appears to be that when a component has a theme value set in defaultProps, the parent component detects that the same as if the component were rendered with a theme. Essentially a parent component doesn't see a difference between these two.

``` javascript
<VictoryVoronoiContainer /> and <VictoryVoronoiContainer theme={VictoryTheme.grayscale} />
```

To fix this  I'm moving the theme from defaultProps to fallbackProps. This should ensure that `component.props.theme` is always undefined if the component was not rendered with an explicit theme prop.

Let me know if I'm heading in the right direction and I'll implement the fix in more components. A quick grep shows the following components will likely need to be updated. Even though they may not all be passed as rendered components, I'm thinking we should probably update them all.

- VictoryArea
- VictoryAxis
- VictoryBar
- VictoryCandlestick
- VictoryChart
- VictoryErrorbar
- VictoryGroup
- VictoryLine
- VictoryScatter
- VictoryVoronoi