### PR TITLE
pass theme to voronoi container's label component

### DIFF
--- a/demo/components/victory-voronoi-container-demo.js
+++ b/demo/components/victory-voronoi-container-demo.js
@@ -6,7 +6,7 @@ import {
 } from "../../src/index";
 import { random, range } from "lodash";
 
-import { VictoryTooltip } from "victory-core";
+import { VictoryTooltip, VictoryTheme } from "victory-core";
 class App extends React.Component {
 
   constructor() {
@@ -52,13 +52,13 @@ class App extends React.Component {
       <div className="demo">
         <div style={containerStyle}>
           <VictoryChart style={chartStyle}
+            theme={VictoryTheme.material}
             domainPadding={{y: 2}}
             containerComponent={
               <VictoryVoronoiContainer dimension="x"
                 labels={(d) => `y:${d.y}`}
                 labelComponent={
                   <VictoryTooltip
-                    cornerRadius={0}
                     flyoutStyle={{fill: "white"}}
                     style={{fontSize: 10}}
                   />

--- a/src/components/containers/victory-voronoi-container.js
+++ b/src/components/containers/victory-voronoi-container.js
@@ -138,7 +138,7 @@ export const voronoiContainerMixin = (base) => class VictoryVoronoiContainer ext
   }
 
   getLabelProps(props, points) {
-    const {labels, scale, labelComponent} = props;
+    const {labels, scale, labelComponent, theme} = props;
     const text = points.reduce((memo, point) => {
       const t = Helpers.evaluateProp(labels, point, true);
       if (t === null || t === undefined) {
@@ -151,13 +151,11 @@ export const voronoiContainerMixin = (base) => class VictoryVoronoiContainer ext
     const labelPosition = this.getLabelPosition(props, points, text, style);
     return defaults(
       {
+        theme, style, text, scale,
         active: true,
         renderInPortal: false,
-        style,
         flyoutStyle: this.getStyle(props, points, "flyout")[0],
-        text,
         datum: omit(points[0], ["childName", "style", "continuous"]),
-        scale,
         ...labelPosition
       },
       labelComponent.props,


### PR DESCRIPTION
cc/ @GreenGremlin
works with https://github.com/FormidableLabs/victory-core/pull/229 as a alternative to https://github.com/FormidableLabs/victory-chart/pull/455