### PR TITLE
Update to React 15.5.

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -1,6 +1,7 @@
 /*global document:false window */
 import React from "react";
 import ReactDOM from "react-dom";
+import PropTypes from "prop-types";
 import AreaDemo from "./components/victory-area-demo";
 import AxisDemo from "./components/victory-axis-demo";
 import BarDemo from "./components/victory-bar-demo";
@@ -24,22 +25,18 @@ import { startCase } from "lodash";
 
 const content = document.getElementById("content");
 
-const App = React.createClass({
-  propTypes: {
-    children: React.PropTypes.element
-  },
-
+class App extends React.Component {
   componentWillUpdate() {
     this.setTitle();
-  },
+  }
 
   componentWillMount() {
     this.setTitle();
-  },
+  }
 
   setTitle() {
     document.title = startCase(window.location.hash.match(/\/(.*)\?/)[1] || "Victory Chart Demos");
-  },
+  }
 
   render() {
     return (
@@ -69,7 +66,11 @@ const App = React.createClass({
       </div>
     );
   }
-});
+}
+
+App.propTypes = {
+  children: PropTypes.element
+};
 
 ReactDOM.render((
   <Router history={hashHistory}>

--- a/demo/components/victory-bar-demo.js
+++ b/demo/components/victory-bar-demo.js
@@ -1,5 +1,6 @@
 /*global window:false*/
 import React from "react";
+import PropTypes from "prop-types";
 import {VictoryBar, VictoryChart, VictoryGroup, VictoryStack } from "../../src/index";
 import { VictorySharedEvents } from "victory-core";
 import { assign, random, range, merge } from "lodash";
@@ -7,9 +8,9 @@ import { VictoryContainer, VictoryTheme } from "victory-core";
 
 class Wrapper extends React.Component {
   static propTypes = {
-    children: React.PropTypes.oneOfType([
-      React.PropTypes.arrayOf(React.PropTypes.node),
-      React.PropTypes.node
+    children: PropTypes.oneOfType([
+      PropTypes.arrayOf(PropTypes.node),
+      PropTypes.node
     ])
   };
 
@@ -529,9 +530,9 @@ export default class App extends React.Component {
 
 class ChartWrap extends React.Component {
   static propTypes = {
-    width: React.PropTypes.number,
-    height: React.PropTypes.number,
-    children: React.PropTypes.any
+    width: PropTypes.number,
+    height: PropTypes.number,
+    children: PropTypes.any
   };
   static defaultProps = {
     width: 350,

--- a/demo/components/victory-candlestick-demo.js
+++ b/demo/components/victory-candlestick-demo.js
@@ -1,5 +1,6 @@
 /*global window:false */
 import React from "react";
+import PropTypes from "prop-types";
 import { random, range, merge } from "lodash";
 import {VictoryCandlestick, VictoryChart, VictoryAxis} from "../../src/index";
 import { VictoryTheme } from "victory-core";
@@ -189,7 +190,7 @@ export default class App extends React.Component {
 }
 
 App.propTypes = {
-  data: React.PropTypes.arrayOf(React.PropTypes.object)
+  data: PropTypes.arrayOf(PropTypes.object)
 };
 
 App.defaultProps = {

--- a/demo/components/victory-chart-demo.js
+++ b/demo/components/victory-chart-demo.js
@@ -1,5 +1,6 @@
 /*global window:false */
 import React from "react";
+import PropTypes from "prop-types";
 import { merge, random, range, omit } from "lodash";
 import {
   VictoryChart, VictoryLine, VictoryAxis, VictoryBar, VictoryArea,
@@ -13,9 +14,9 @@ const UPDATE_INTERVAL = 3000;
 
 class Wrapper extends React.Component {
   static propTypes = {
-    children: React.PropTypes.oneOfType([
-      React.PropTypes.arrayOf(React.PropTypes.node),
-      React.PropTypes.node
+    children: PropTypes.oneOfType([
+      PropTypes.arrayOf(PropTypes.node),
+      PropTypes.node
     ])
   };
 

--- a/demo/components/victory-errorbar-demo.js
+++ b/demo/components/victory-errorbar-demo.js
@@ -1,5 +1,6 @@
 /*global window:false */
 import React from "react";
+import PropTypes from "prop-types";
 import { merge, random, range } from "lodash";
 import { VictoryErrorBar, VictoryScatter, VictoryLine, VictoryChart } from "../../src/index";
 import { VictoryContainer, VictoryTheme, ErrorBar } from "victory-core";
@@ -165,7 +166,7 @@ export default class App extends React.Component {
 }
 
 App.propTypes = {
-  data: React.PropTypes.arrayOf(React.PropTypes.object)
+  data: PropTypes.arrayOf(PropTypes.object)
 };
 
 App.defaultProps = {

--- a/demo/components/victory-line-demo.js
+++ b/demo/components/victory-line-demo.js
@@ -1,5 +1,6 @@
 /*global window:false */
-import React, { PropTypes } from "react";
+import React from "react";
+import PropTypes from "prop-types";
 import { merge, random, range } from "lodash";
 import {VictoryLine, VictoryChart} from "../../src/index";
 import { VictoryContainer, VictoryTheme, Curve, Point } from "victory-core";

--- a/demo/components/victory-scatter-demo.js
+++ b/demo/components/victory-scatter-demo.js
@@ -1,5 +1,6 @@
 /*global window:false */
 import React from "react";
+import PropTypes from "prop-types";
 import { merge, random, range } from "lodash";
 import {VictoryScatter, VictoryChart} from "../../src/index";
 import {VictoryLabel} from "victory-core";
@@ -43,9 +44,9 @@ const symbolStyle = {
 
 class CatPoint extends React.Component {
   static propTypes = {
-    x: React.PropTypes.number,
-    y: React.PropTypes.number,
-    symbol: React.PropTypes.string
+    x: PropTypes.number,
+    y: PropTypes.number,
+    symbol: PropTypes.string
   };
 
   render() {
@@ -250,7 +251,7 @@ export default class App extends React.Component {
 }
 
 App.propTypes = {
-  data: React.PropTypes.arrayOf(React.PropTypes.object)
+  data: PropTypes.arrayOf(PropTypes.object)
 };
 
 App.defaultProps = {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "builder-victory-component": "^3.1.0",
     "d3-voronoi": "^1.1.2",
     "lodash": "^4.12.0",
-    "victory-core": "^14.1.1"
+    "victory-core": "^14.1.1",
+    "prop-types": "~15.5.8"
   },
   "devDependencies": {
     "builder-victory-component-dev": "^3.1.0",
@@ -40,10 +41,11 @@
     "d3-shape": "^1.0.0",
     "enzyme": "^2.3.0",
     "mocha": "^2.2.5",
-    "react": "~15.1.0",
-    "react-addons-test-utils": "~15.1.0",
-    "react-dom": "~15.1.0",
+    "react": "~15.5.4",
+    "react-addons-test-utils": "~15.5.1",
+    "react-dom": "~15.5.4",
     "react-router": "^2.4.0",
+    "react-test-renderer": "~15.5.4",
     "sinon": "^1.17.2",
     "sinon-chai": "^2.8.0"
   },

--- a/src/components/containers/victory-brush-container.js
+++ b/src/components/containers/victory-brush-container.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React from "react";
 import { VictoryContainer, Selection } from "victory-core";
 import BrushHelpers from "./brush-helpers";
@@ -7,17 +8,17 @@ export const brushContainerMixin = (base) => class VictoryBrushContainer extends
   static displayName = "VictoryBrushContainer";
   static propTypes = {
     ...VictoryContainer.propTypes,
-    selectionStyle: React.PropTypes.object,
-    handleStyle: React.PropTypes.object,
-    dimension: React.PropTypes.oneOf(["x", "y"]),
-    selectedDomain: React.PropTypes.shape({
-      x: React.PropTypes.array,
-      y: React.PropTypes.array
+    selectionStyle: PropTypes.object,
+    handleStyle: PropTypes.object,
+    dimension: PropTypes.oneOf(["x", "y"]),
+    selectedDomain: PropTypes.shape({
+      x: PropTypes.array,
+      y: PropTypes.array
     }),
-    onDomainChange: React.PropTypes.func,
-    handleWidth: React.PropTypes.number,
-    selectionComponent: React.PropTypes.element,
-    handleComponent: React.PropTypes.element
+    onDomainChange: PropTypes.func,
+    handleWidth: PropTypes.number,
+    selectionComponent: PropTypes.element,
+    handleComponent: PropTypes.element
   };
   static defaultProps = {
     ...VictoryContainer.defaultProps,

--- a/src/components/containers/victory-selection-container.js
+++ b/src/components/containers/victory-selection-container.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React from "react";
 import { VictoryContainer } from "victory-core";
 import SelectionHelpers from "./selection-helpers";
@@ -6,12 +7,12 @@ export const selectionContainerMixin = (base) => class VictorySelectionContainer
   static displayName = "VictorySelectionContainer";
   static propTypes = {
     ...VictoryContainer.propTypes,
-    selectionStyle: React.PropTypes.object,
-    onSelection: React.PropTypes.func,
-    onSelectionCleared: React.PropTypes.func,
-    dimension: React.PropTypes.oneOf(["x", "y"]),
-    standalone: React.PropTypes.bool,
-    selectionComponent: React.PropTypes.element
+    selectionStyle: PropTypes.object,
+    onSelection: PropTypes.func,
+    onSelectionCleared: PropTypes.func,
+    dimension: PropTypes.oneOf(["x", "y"]),
+    standalone: PropTypes.bool,
+    selectionComponent: PropTypes.element
   };
   static defaultProps = {
     ...VictoryContainer.defaultProps,

--- a/src/components/containers/victory-voronoi-container.js
+++ b/src/components/containers/victory-voronoi-container.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React from "react";
 import { VictoryContainer, VictoryTooltip, Helpers, TextSize } from "victory-core";
 import VoronoiHelpers from "./voronoi-helpers";
@@ -7,14 +8,14 @@ export const voronoiContainerMixin = (base) => class VictoryVoronoiContainer ext
   static displayName = "VictoryVoronoiContainer";
   static propTypes = {
     ...VictoryContainer.propTypes,
-    onActivated: React.PropTypes.func,
-    onDeactivated: React.PropTypes.func,
-    standalone: React.PropTypes.bool,
-    radius: React.PropTypes.number,
-    voronoiPadding: React.PropTypes.number,
-    labelComponent: React.PropTypes.element,
-    labels: React.PropTypes.func,
-    dimension: React.PropTypes.oneOf(["x", "y"])
+    onActivated: PropTypes.func,
+    onDeactivated: PropTypes.func,
+    standalone: PropTypes.bool,
+    radius: PropTypes.number,
+    voronoiPadding: PropTypes.number,
+    labelComponent: PropTypes.element,
+    labels: PropTypes.func,
+    dimension: PropTypes.oneOf(["x", "y"])
   };
   static defaultProps = {
     ...VictoryContainer.defaultProps,

--- a/src/components/containers/victory-zoom-container.js
+++ b/src/components/containers/victory-zoom-container.js
@@ -1,4 +1,5 @@
-import React, {PropTypes} from "react";
+import PropTypes from "prop-types";
+import React from "react";
 import { defaults, isEqual } from "lodash";
 import ZoomHelpers from "./zoom-helpers";
 import { VictoryContainer, VictoryClipContainer, PropTypes as CustomPropTypes } from "victory-core";

--- a/src/components/victory-area/victory-area.js
+++ b/src/components/victory-area/victory-area.js
@@ -1,5 +1,6 @@
 import { partialRight, without } from "lodash";
-import React, { PropTypes } from "react";
+import PropTypes from "prop-types";
+import React from "react";
 import AreaHelpers from "./helper-methods";
 import {
   PropTypes as CustomPropTypes, Helpers, VictoryTransition, VictoryLabel, VictoryContainer,

--- a/src/components/victory-axis/victory-axis.js
+++ b/src/components/victory-axis/victory-axis.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react";
+import PropTypes from "prop-types";
+import React from "react";
 import { assign, partialRight } from "lodash";
 import {
   PropTypes as CustomPropTypes, Helpers, VictoryTransition, VictoryLabel,

--- a/src/components/victory-bar/victory-bar.js
+++ b/src/components/victory-bar/victory-bar.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react";
+import PropTypes from "prop-types";
+import React from "react";
 import BarHelpers from "./helper-methods";
 import { partialRight } from "lodash";
 import {

--- a/src/components/victory-candlestick/victory-candlestick.js
+++ b/src/components/victory-candlestick/victory-candlestick.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react";
+import PropTypes from "prop-types";
+import React from "react";
 import { partialRight } from "lodash";
 import {
   PropTypes as CustomPropTypes, Helpers, VictoryTransition, VictoryLabel, addEvents,

--- a/src/components/victory-chart/victory-chart.js
+++ b/src/components/victory-chart/victory-chart.js
@@ -1,5 +1,6 @@
 import { defaults } from "lodash";
-import React, { PropTypes } from "react";
+import PropTypes from "prop-types";
+import React from "react";
 import {
   PropTypes as CustomPropTypes, Helpers, VictorySharedEvents, VictoryContainer,
   VictoryTheme, Scale
@@ -20,9 +21,9 @@ export default class VictoryChart extends React.Component {
 
   static propTypes = {
     animate: PropTypes.object,
-    children: React.PropTypes.oneOfType([
-      React.PropTypes.arrayOf(React.PropTypes.node),
-      React.PropTypes.node
+    children: PropTypes.oneOfType([
+      PropTypes.arrayOf(PropTypes.node),
+      PropTypes.node
     ]),
     containerComponent: PropTypes.element,
     defaultAxes: PropTypes.shape({

--- a/src/components/victory-errorbar/victory-errorbar.js
+++ b/src/components/victory-errorbar/victory-errorbar.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react";
+import PropTypes from "prop-types";
+import React from "react";
 import {
   PropTypes as CustomPropTypes, Helpers, VictoryTransition, VictoryLabel, addEvents,
   VictoryContainer, VictoryTheme, DefaultTransitions, ErrorBar, Data

--- a/src/components/victory-group/victory-group.js
+++ b/src/components/victory-group/victory-group.js
@@ -1,5 +1,6 @@
 import { assign, defaults } from "lodash";
-import React, { PropTypes } from "react";
+import PropTypes from "prop-types";
+import React from "react";
 import { PropTypes as CustomPropTypes, Helpers, VictorySharedEvents,
   VictoryContainer, VictoryTheme, Scale, Data
 } from "victory-core";
@@ -25,8 +26,8 @@ export default class VictoryGroup extends React.Component {
         x: PropTypes.arrayOf(PropTypes.string), y: PropTypes.arrayOf(PropTypes.string)
       })
     ]),
-    children: React.PropTypes.oneOfType([
-      React.PropTypes.arrayOf(React.PropTypes.node), React.PropTypes.node
+    children: PropTypes.oneOfType([
+      PropTypes.arrayOf(PropTypes.node), PropTypes.node
     ]),
     color: PropTypes.string,
     colorScale: PropTypes.oneOfType([

--- a/src/components/victory-line/victory-line.js
+++ b/src/components/victory-line/victory-line.js
@@ -1,5 +1,6 @@
 import { partialRight, without } from "lodash";
-import React, { PropTypes } from "react";
+import PropTypes from "prop-types";
+import React from "react";
 import LineHelpers from "./helper-methods";
 import {
   PropTypes as CustomPropTypes, Helpers, VictoryTransition, VictoryLabel, addEvents,

--- a/src/components/victory-scatter/victory-scatter.js
+++ b/src/components/victory-scatter/victory-scatter.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react";
+import PropTypes from "prop-types";
+import React from "react";
 import { partialRight } from "lodash";
 import {
   PropTypes as CustomPropTypes, Helpers, VictoryTransition, VictoryLabel, addEvents,

--- a/src/components/victory-stack/victory-stack.js
+++ b/src/components/victory-stack/victory-stack.js
@@ -1,5 +1,6 @@
 import { assign, defaults } from "lodash";
-import React, { PropTypes } from "react";
+import PropTypes from "prop-types";
+import React from "react";
 import {
   PropTypes as CustomPropTypes, Helpers, VictorySharedEvents, VictoryContainer,
   VictoryTheme, Scale
@@ -25,8 +26,8 @@ export default class VictoryStack extends React.Component {
         x: PropTypes.arrayOf(PropTypes.string), y: PropTypes.arrayOf(PropTypes.string)
       })
     ]),
-    children: React.PropTypes.oneOfType([
-      React.PropTypes.arrayOf(React.PropTypes.node), React.PropTypes.node
+    children: PropTypes.oneOfType([
+      PropTypes.arrayOf(PropTypes.node), PropTypes.node
     ]),
     colorScale: PropTypes.oneOfType([
       PropTypes.arrayOf(PropTypes.string),

--- a/src/components/victory-voronoi-tooltip/victory-voronoi-tooltip.js
+++ b/src/components/victory-voronoi-tooltip/victory-voronoi-tooltip.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react";
+import React from "react";
+import PropTypes from "prop-types";
 import { partialRight } from "lodash";
 import {
   PropTypes as CustomPropTypes, Helpers, VictoryTransition, VictoryTooltip, addEvents,

--- a/src/components/victory-voronoi/victory-voronoi.js
+++ b/src/components/victory-voronoi/victory-voronoi.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react";
+import PropTypes from "prop-types";
+import React from "react";
 import { partialRight } from "lodash";
 import {
   PropTypes as CustomPropTypes, Helpers, VictoryTransition, VictoryLabel, addEvents,

--- a/src/components/victory-zoom/victory-zoom.js
+++ b/src/components/victory-zoom/victory-zoom.js
@@ -1,7 +1,8 @@
 /*
   This component is being temporarily re-added to suppprt an upgrade to `victory-native`
 */
-import React, {Component, PropTypes} from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { assign, isEqual } from "lodash";
 import ChartHelpers from "../victory-chart/helper-methods";
 import ZoomHelpers from "./helper-methods";
@@ -31,7 +32,7 @@ class VictoryZoom extends Component {
   }
 
   static childContextTypes = {
-    getTimer: React.PropTypes.func
+    getTimer: PropTypes.func
   }
 
   static defaultProps = {


### PR DESCRIPTION
Since React 16 is right around the corner, Facebook released v.15.5 to make the migration easier. This also moved the `PropTypes` into their own npm module `prop-types`.  
More info: https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html

This pull request replaces all the `PropTypes` imports from `react` to the new `prop-types` package and updates `react` and `react-dom` to their current versions.