### PR TITLE
dedup victory-native

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "builder-victory-component": "^3.1.0",
     "d3-voronoi": "^1.1.2",
     "lodash": "^4.12.0",
-    "victory-core": "^14.0.7"
+    "victory-core": "^14.1.1"
   },
   "devDependencies": {
     "builder-victory-component-dev": "^3.1.0",

--- a/src/components/containers/zoom-helpers.js
+++ b/src/components/containers/zoom-helpers.js
@@ -231,6 +231,7 @@ const Helpers = {
   }
 };
 
+export { Helpers as RawZoomHelpers }; // allow victory-native to extend these helpers
 
 export default {
   onMouseDown: Helpers.onMouseDown.bind(Helpers),

--- a/src/index.js
+++ b/src/index.js
@@ -32,10 +32,11 @@ export {
 } from "./components/containers/victory-zoom-container";
 export {
   combineContainerMixins,
+  makeCreateContainerFunction,
   default as createContainer
 } from "./components/containers/create-container";
 export { default as VictoryZoom } from "./components/victory-zoom/victory-zoom";
 export { default as BrushHelpers } from "./components/containers/brush-helpers";
 export { default as SelectionHelpers } from "./components/containers/selection-helpers";
 export { default as VoronoiHelpers } from "./components/containers/voronoi-helpers";
-export { default as ZoomHelpers } from "./components/containers/zoom-helpers";
+export { default as ZoomHelpers, RawZoomHelpers } from "./components/containers/zoom-helpers";


### PR DESCRIPTION
will be `18.2.1`

- add RawZoomHelpers and makeCreateContainerFunction
- combineContainerMixins handles ∞ mixins
- upgrade victory-core to get `getSVGEventCoordinates` native support