### PR TITLE
VictoryCursorContainer

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -17,6 +17,7 @@ import VoronoiDemo from "./components/victory-voronoi-demo";
 import TooltipDemo from "./components/victory-tooltip-demo";
 import ZoomContainerDemo from "./components/victory-zoom-container-demo";
 import VoronoiContainerDemo from "./components/victory-voronoi-container-demo";
+import CursorContainerDemo from "./components/victory-cursor-container-demo";
 import CreateContainerDemo from "./components/create-container-demo";
 import BrushContainerDemo from "./components/victory-brush-container-demo";
 import AnimationDemo from "./components/animation-demo";
@@ -63,6 +64,7 @@ class App extends React.Component {
     case "/tooltip": Child = TooltipDemo; break;
     case "/zoom-container": Child = ZoomContainerDemo; break;
     case "/voronoi-container": Child = VoronoiContainerDemo; break;
+    case "/cursor-container": Child = CursorContainerDemo; break;
     case "/brush-container": Child = BrushContainerDemo; break;
     case "/animation": Child = AnimationDemo; break;
     case "/selection-container": Child = SelectionDemo; break;
@@ -92,6 +94,7 @@ class App extends React.Component {
           <li><a href="#/tooltip">Victory Tooltip Demo</a></li>
           <li><a href="#/zoom-container">Victory Zoom Container Demo</a></li>
           <li><a href="#/voronoi-container">Victory Voronoi Container Demo</a></li>
+          <li><a href="#/cursor-container">Victory Cursor Container Demo</a></li>
           <li><a href="#/brush-container">Victory Brush Container Demo</a></li>
           <li><a href="#/animation">Animation Demo</a></li>
           <li><a href="#/selection-container">Victory Selection Container Demo</a></li>

--- a/demo/components/create-container-demo.js
+++ b/demo/components/create-container-demo.js
@@ -78,6 +78,7 @@ const Charts = ({ CustomContainer }) => { // eslint-disable-line react/prop-type
           }}
           containerComponent={
             <CustomContainer
+              dimension="x"
               selectionStyle={{
                 stroke: "tomato", strokeWidth: 2, fill: "tomato", fillOpacity: 0.1
               }}
@@ -90,7 +91,12 @@ const Charts = ({ CustomContainer }) => { // eslint-disable-line react/prop-type
 
         <VictoryChart
           style={chartStyle}
-          containerComponent={<CustomContainer selectedDomain={{ x: [0, 0] }} />}
+          containerComponent={
+            <CustomContainer
+              selectedDomain={{ x: [0, 0] }}
+              dimension="y"
+            />
+          }
         >
           <VictoryGroup style={chartStyle}>
             <VictoryScatter
@@ -218,6 +224,8 @@ class App extends React.Component {
         <Charts CustomContainer={createContainer("brush", "voronoi")} />
         <pre>createContainer("zoom", "voronoi")</pre>
         <Charts CustomContainer={createContainer("zoom", "voronoi")} />
+        <pre>createContainer("cursor", "voronoi")</pre>
+        <Charts CustomContainer={createContainer("cursor", "voronoi")} />
       </div>
     );
   }

--- a/demo/components/create-container-demo.js
+++ b/demo/components/create-container-demo.js
@@ -1,5 +1,6 @@
 /*eslint-disable no-magic-numbers,react/no-multi-comp */
 import React from "react";
+import { round } from "lodash";
 import {
   VictoryChart, VictoryGroup, VictoryStack, VictoryScatter, VictoryBar, VictoryLine,
   createContainer
@@ -21,6 +22,7 @@ const Charts = ({ CustomContainer }) => { // eslint-disable-line react/prop-type
   return (
     <div className="demo">
       <div style={containerStyle}>
+        {/* A */}
         <VictoryChart style={chartStyle}
           domainPadding={{ y: 2 }}
           containerComponent={
@@ -69,6 +71,7 @@ const Charts = ({ CustomContainer }) => { // eslint-disable-line react/prop-type
           />
         </VictoryChart>
 
+        {/* B */}
         <VictoryScatter
           style={{
             parent: chartStyle.parent,
@@ -79,10 +82,12 @@ const Charts = ({ CustomContainer }) => { // eslint-disable-line react/prop-type
           containerComponent={
             <CustomContainer
               dimension="x"
+              cursorLabel={(d) => round(d.x, 2)}
               selectionStyle={{
                 stroke: "tomato", strokeWidth: 2, fill: "tomato", fillOpacity: 0.1
               }}
               selectedDomain={{ x: [0.4, 0.95], y: [0.5, 0.8] }}
+              defaultCursorValue={0.99}
             />
           }
           size={(datum, active) => active ? 5 : 3}
@@ -150,9 +155,14 @@ const Charts = ({ CustomContainer }) => { // eslint-disable-line react/prop-type
           </VictoryGroup>
         </VictoryChart>
 
+        {/* C */}
         <VictoryStack
           style={chartStyle}
-          containerComponent={<CustomContainer selectedDomain={{ x: [1.5, 2.5], y: [-3, 4] }} />}
+          containerComponent={
+            <CustomContainer
+              selectedDomain={{ x: [1.5, 2.5], y: [-3, 4] }}
+            />
+          }
         >
           <VictoryBar
             style={{

--- a/demo/components/victory-cursor-container-demo.js
+++ b/demo/components/victory-cursor-container-demo.js
@@ -160,6 +160,7 @@ class App extends React.Component {
                 defaultCursorValue={2}
                 dimension="x"
                 labels={(datum) => round(datum.x, 2)}
+                labelOffset={15}
               />
             }
           >

--- a/demo/components/victory-cursor-container-demo.js
+++ b/demo/components/victory-cursor-container-demo.js
@@ -51,7 +51,7 @@ class App extends React.Component {
 
     const chartStyle = { parent: { border: "1px solid #ccc", margin: "2%", maxWidth: "40%" } };
 
-    const labels = (d) => (
+    const cursorLabel = (d) => (
       `${round(d.x, 2)} , ${round(d.y, 2)}`
     );
 
@@ -64,7 +64,7 @@ class App extends React.Component {
             domainPadding={{ y: 2 }}
             containerComponent={
               <VictoryCursorContainer
-                labels={labels}
+                cursorLabel={cursorLabel}
                 defaultCursorValue={this.defaultCursorValue}
                 onChange={(cursorValue) => this.setState({ cursorValue })}
               />
@@ -124,7 +124,7 @@ class App extends React.Component {
             }}
             containerComponent={
               <VictoryCursorContainer
-                labels={(d) => `${round(d.x, 2)}`}
+                cursorLabel={(d) => `${round(d.x, 2)}`}
                 dimension="x"
                 defaultCursorValue={1}
               />
@@ -159,8 +159,8 @@ class App extends React.Component {
               <VictoryCursorContainer
                 defaultCursorValue={2}
                 dimension="x"
-                labels={(datum) => round(datum.x, 2)}
-                labelOffset={15}
+                cursorLabel={(datum) => round(datum.x, 2)}
+                cursorLabelOffset={15}
               />
             }
           >

--- a/demo/components/victory-cursor-container-demo.js
+++ b/demo/components/victory-cursor-container-demo.js
@@ -1,0 +1,273 @@
+/*global window:false*/
+/*eslint-disable no-magic-numbers */
+import React from "react";
+import { random, range, round } from "lodash";
+import {
+  VictoryChart, VictoryGroup, VictoryStack, VictoryScatter, VictoryBar, VictoryLine,
+  VictoryCursorContainer
+} from "../../src/index";
+import { VictoryTooltip, VictoryTheme, VictoryLabel } from "victory-core";
+
+class App extends React.Component {
+
+  constructor() {
+    super();
+    this.defaultCursorValue = { x: 2.25, y: 1.75 };
+    this.state = {
+      data: this.getData(),
+      cursorValue: this.defaultCursorValue
+    };
+  }
+
+  componentDidMount() {
+    /* eslint-disable react/no-did-mount-set-state */
+    this.setStateInterval = window.setInterval(() => {
+      this.setState({
+        data: this.getData()
+      });
+    }, 3000);
+  }
+
+  componentWillUnmount() {
+    window.clearInterval(this.setStateInterval);
+  }
+
+
+  getData() {
+    const bars = random(6, 10);
+    return range(bars).map((bar) => {
+      return { a: bar + 1, b: random(2, 10) };
+    });
+  }
+
+  render() {
+    const containerStyle = {
+      display: "flex",
+      flexDirection: "row",
+      flexWrap: "wrap",
+      alignItems: "center",
+      justifyContent: "center"
+    };
+
+    const chartStyle = { parent: { border: "1px solid #ccc", margin: "2%", maxWidth: "40%" } };
+
+    const labels = (d) => (
+      `${round(d.x, 2)} , ${round(d.y, 2)}`
+    );
+
+    return (
+      <div className="demo">
+        <div style={containerStyle}>
+
+          <VictoryChart style={chartStyle}
+            theme={VictoryTheme.material}
+            domainPadding={{ y: 2 }}
+            containerComponent={
+              <VictoryCursorContainer
+                labels={labels}
+                defaultCursorValue={this.defaultCursorValue}
+                onChange={(cursorValue) => this.setState({ cursorValue })}
+              />
+            }
+          >
+            <VictoryLabel
+              x={50} y={310}
+              text={
+                `x: ${round(this.state.cursorValue.x, 2)} y: ${round(this.state.cursorValue.y, 2)}`
+              }
+            />
+            <VictoryLine
+              data={[
+                { x: 1, y: 5, l: "one" },
+                { x: 1.5, y: 5, l: "one point five" },
+                { x: 2, y: 4, l: "two" },
+                { x: 3, y: -2, l: "three" }
+              ]}
+              style={{
+                data: { stroke: "tomato", strokeWidth: (d, active) => active ? 4 : 2 },
+                labels: { fill: "tomato" }
+              }}
+            />
+
+            <VictoryLine
+              data={[
+                { x: 1, y: -3, l: "red" },
+                { x: 2, y: 5, l: "green" },
+                { x: 3, y: 3, l: "blue" }
+              ]}
+              style={{
+                data: { stroke: "blue", strokeWidth: (d, active) => active ? 4 : 2 },
+                labels: { fill: "blue" }
+              }}
+            />
+
+            <VictoryLine
+              data={[
+                { x: 1, y: 5, l: "cat" },
+                { x: 2, y: -4, l: "dog" },
+                { x: 3, y: -2, l: "bird" }
+              ]}
+              style={{
+                data: { stroke: "black", strokeWidth: (d, active) => active ? 4 : 2 },
+                labels: { fill: "black" }
+              }}
+            />
+          </VictoryChart>
+
+          <VictoryScatter
+            animate={{ duration: 1000 }}
+            style={{
+              parent: chartStyle.parent,
+              data: {
+                fill: (datum, active) => active ? "tomato" : "black"
+              }
+            }}
+            containerComponent={
+              <VictoryCursorContainer
+                labels={(d) => `${round(d.x, 2)}`}
+                dimension="x"
+                defaultCursorValue={1}
+              />
+            }
+            size={(datum, active) => active ? 5 : 3}
+            data={this.state.data}
+            x="a"
+            y="b"
+          />
+
+          <VictoryScatter
+            style={{
+              parent: chartStyle.parent,
+              data: {
+                fill: (datum, active) => active ? "tomato" : "black"
+              }
+            }}
+            containerComponent={
+              <VictoryCursorContainer
+                selectionStyle={{
+                  stroke: "tomato", strokeWidth: 2, fill: "tomato", fillOpacity: 0.1
+                }}
+              />
+            }
+            size={(datum, active) => active ? 5 : 3}
+            y={(d) => d.x * d.x}
+          />
+
+          <VictoryChart style={chartStyle} containerComponent={<VictoryCursorContainer/>}>
+            <VictoryGroup style={chartStyle}>
+              <VictoryScatter
+                style={{
+                  data: { fill: "tomato" }
+                }}
+                size={(datum, active) => active ? 5 : 3}
+                labels={(d) => d.y}
+                labelComponent={<VictoryTooltip/>}
+                data={[
+                  { x: 1, y: -5 },
+                  { x: 2, y: 4 },
+                  { x: 3, y: 2 },
+                  { x: 4, y: 0 },
+                  { x: 5, y: 1 },
+                  { x: 6, y: -3 },
+                  { x: 7, y: 3 }
+                ]}
+              />
+              <VictoryScatter
+                style={{
+                  data: { fill: "blue" }
+                }}
+                size={(datum, active) => active ? 5 : 3}
+                labels={(d) => d.y}
+                labelComponent={<VictoryTooltip/>}
+                data={[
+                  { x: 1, y: -3 },
+                  { x: 2, y: 5 },
+                  { x: 3, y: 3 },
+                  { x: 4, y: 0 },
+                  { x: 5, y: -2 },
+                  { x: 6, y: -2 },
+                  { x: 7, y: 5 }
+                ]}
+              />
+              <VictoryScatter
+                data={[
+                  { x: 1, y: 5 },
+                  { x: 2, y: -4 },
+                  { x: 3, y: -2 },
+                  { x: 4, y: -3 },
+                  { x: 5, y: -1 },
+                  { x: 6, y: 3 },
+                  { x: 7, y: -3 }
+                ]}
+                labels={(d) => d.y}
+                labelComponent={<VictoryTooltip/>}
+                size={(datum, active) => active ? 5 : 3}
+              />
+            </VictoryGroup>
+          </VictoryChart>
+
+          <VictoryStack style={chartStyle} containerComponent={<VictoryCursorContainer/>}>
+            <VictoryBar
+              style={{
+                data: {
+                  fill: "tomato",
+                  stroke: (d, active) => active ? "black" : "none",
+                  strokeWidth: 2
+                }
+              }}
+              size={(datum, active) => active ? 5 : 3}
+              data={[
+                { x: 1, y: -5 },
+                { x: 2, y: 4 },
+                { x: 3, y: 2 },
+                { x: 4, y: 3 },
+                { x: 5, y: 1 },
+                { x: 6, y: -3 },
+                { x: 7, y: 3 }
+              ]}
+            />
+            <VictoryBar
+              style={{
+                data: {
+                  fill: "orange",
+                  stroke: (d, active) => active ? "black" : "none",
+                  strokeWidth: 2
+                }
+              }}
+              size={(datum, active) => active ? 5 : 3}
+              data={[
+                { x: 1, y: -3 },
+                { x: 2, y: 5 },
+                { x: 3, y: 3 },
+                { x: 4, y: 0 },
+                { x: 5, y: -2 },
+                { x: 6, y: -2 },
+                { x: 7, y: 5 }
+              ]}
+            />
+            <VictoryBar
+              style={{
+                data: {
+                  fill: "gold",
+                  stroke: (d, active) => active ? "black" : "none",
+                  strokeWidth: 2
+                }
+              }}
+              data={[
+                { x: 1, y: 5 },
+                { x: 2, y: -4 },
+                { x: 3, y: -2 },
+                { x: 4, y: -3 },
+                { x: 5, y: -1 },
+                { x: 6, y: 3 },
+                { x: 7, y: -3 }
+              ]}
+            />
+          </VictoryStack>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default App;

--- a/demo/components/victory-cursor-container-demo.js
+++ b/demo/components/victory-cursor-container-demo.js
@@ -153,7 +153,16 @@ class App extends React.Component {
             y={(d) => d.x * d.x}
           />
 
-          <VictoryChart style={chartStyle} containerComponent={<VictoryCursorContainer/>}>
+          <VictoryChart
+            style={chartStyle}
+            containerComponent={
+              <VictoryCursorContainer
+                defaultCursorValue={2}
+                dimension="x"
+                labels={(datum) => round(datum.x, 2)}
+              />
+            }
+          >
             <VictoryGroup style={chartStyle}>
               <VictoryScatter
                 style={{

--- a/src/components/containers/brush-helpers.js
+++ b/src/components/containers/brush-helpers.js
@@ -259,6 +259,7 @@ const Helpers = {
 };
 
 export default {
+  ...Helpers,
   onMouseDown: Helpers.onMouseDown.bind(Helpers),
   onMouseUp: Helpers.onMouseUp.bind(Helpers),
   onMouseLeave: Helpers.onMouseLeave.bind(Helpers),

--- a/src/components/containers/create-container.js
+++ b/src/components/containers/create-container.js
@@ -5,6 +5,7 @@ import { voronoiContainerMixin } from "./victory-voronoi-container";
 import { zoomContainerMixin } from "./victory-zoom-container";
 import { selectionContainerMixin } from "./victory-selection-container";
 import { brushContainerMixin } from "./victory-brush-container";
+import { cursorContainerMixin } from "./victory-cursor-container";
 
 const ensureArray = (thing) => {
   if (!thing) {
@@ -63,8 +64,13 @@ export const combineContainerMixins = (mixins, Container) => {
   const instances = Classes.map((Class) => new Class());
   const NaiveCombinedContainer = flow(mixins)(Container);
 
+  const displayType = Classes.map((Class) => {
+    const match = Class.displayName.match(/Victory(.*)Container/);
+    return match[1] || "";
+  }).join("");
+
   return class VictoryCombinedContainer extends NaiveCombinedContainer {
-    static displayName = "CustomVictoryContainer";
+    static displayName = `Victory${displayType}Container`;
 
     static propTypes =
       Classes.reduce(
@@ -126,5 +132,6 @@ export default makeCreateContainerFunction({
   zoom: [zoomContainerMixin],
   voronoi: [voronoiContainerMixin],
   selection: [selectionContainerMixin],
+  cursor: [cursorContainerMixin],
   brush: [brushContainerMixin]
 }, VictoryContainer);

--- a/src/components/containers/cursor-helpers.js
+++ b/src/components/containers/cursor-helpers.js
@@ -7,13 +7,13 @@ const CursorHelpers = {
   onMouseMove(evt, targetProps) {
     const { onChange, dimension, domain } = targetProps;
     const cursorSVGPosition = Selection.getSVGEventCoordinates(evt);
-    let cursorPosition = Selection.getDataCoordinates(
+    let cursorValue = Selection.getDataCoordinates(
       targetProps.scale,
       cursorSVGPosition.x,
       cursorSVGPosition.y
     );
 
-    const inBounds = BrushHelpers.withinBounds(cursorPosition, {
+    const inBounds = BrushHelpers.withinBounds(cursorValue, {
       x1: domain.x[0],
       x2: domain.x[1],
       y1: domain.y[0],
@@ -21,14 +21,14 @@ const CursorHelpers = {
     });
 
     if (!inBounds) {
-      cursorPosition = null;
+      cursorValue = null;
     }
 
     if (isFunction(onChange)) {
       if (inBounds) {
-        const value = dimension ? cursorPosition[dimension] : cursorPosition;
+        const value = dimension ? cursorValue[dimension] : cursorValue;
         onChange(value);
-      } else if (cursorPosition !== targetProps.cursorPosition) {
+      } else if (cursorValue !== targetProps.cursorValue) {
         onChange(targetProps.defaultCursorValue || null);
       }
     }
@@ -36,7 +36,7 @@ const CursorHelpers = {
     return [{
       target: "parent",
       eventKey: "parent",
-      mutation: () => ({ cursorPosition })
+      mutation: () => ({ cursorValue })
     }];
   }
 };

--- a/src/components/containers/cursor-helpers.js
+++ b/src/components/containers/cursor-helpers.js
@@ -1,0 +1,49 @@
+import { Selection } from "victory-core";
+import { throttle, isFunction } from "lodash";
+import { attachId } from "../../helpers/event-handlers";
+import BrushHelpers from "./brush-helpers";
+
+const CursorHelpers = {
+  onMouseMove(evt, targetProps) {
+    const { onChange, dimension, domain } = targetProps;
+    const cursorSVGPosition = Selection.getSVGEventCoordinates(evt);
+    let cursorPosition = Selection.getDataCoordinates(
+      targetProps.scale,
+      cursorSVGPosition.x,
+      cursorSVGPosition.y
+    );
+
+    const inBounds = BrushHelpers.withinBounds(cursorPosition, {
+      x1: domain.x[0],
+      x2: domain.x[1],
+      y1: domain.y[0],
+      y2: domain.y[1]
+    });
+
+    if (!inBounds) {
+      cursorPosition = null;
+    }
+
+    if (isFunction(onChange)) {
+      if (inBounds) {
+        const value = dimension ? cursorPosition[dimension] : cursorPosition;
+        onChange(value);
+      } else if (cursorPosition !== targetProps.cursorPosition) {
+        onChange(targetProps.defaultCursorValue || null);
+      }
+    }
+
+    return [{
+      target: "parent",
+      eventKey: "parent",
+      mutation: () => ({ cursorPosition })
+    }];
+  }
+};
+
+export default {
+  onMouseMove: throttle(
+    attachId(CursorHelpers.onMouseMove.bind(CursorHelpers)),
+    32, // eslint-disable-line no-magic-numbers
+    { leading: true, trailing: false })
+};

--- a/src/components/containers/victory-cursor-container.js
+++ b/src/components/containers/victory-cursor-container.js
@@ -9,6 +9,15 @@ export const cursorContainerMixin = (base) => class VictoryCursorContainer exten
   static displayName = "VictoryCursorContainer";
   static propTypes = {
     ...VictoryContainer.propTypes,
+    cursorLabel: PropTypes.func,
+    cursorLabelComponent: PropTypes.element,
+    cursorLabelOffset: PropTypes.oneOfType([
+      PropTypes.number,
+      PropTypes.shape({
+        x: PropTypes.number,
+        y: PropTypes.number
+      })
+    ]),
     defaultCursorValue: PropTypes.oneOfType([
       PropTypes.number,
       PropTypes.shape({
@@ -17,22 +26,13 @@ export const cursorContainerMixin = (base) => class VictoryCursorContainer exten
       })
     ]),
     dimension: PropTypes.oneOf(["x", "y"]),
-    labelComponent: PropTypes.element,
-    labelOffset: PropTypes.oneOfType([
-      PropTypes.number,
-      PropTypes.shape({
-        x: PropTypes.number,
-        y: PropTypes.number
-      })
-    ]),
-    labels: PropTypes.func,
     onChange: PropTypes.func,
     standalone: PropTypes.bool
   };
   static defaultProps = {
     ...VictoryContainer.defaultProps,
-    labelComponent: <VictoryLabel/>,
-    labelOffset: {
+    cursorLabelComponent: <VictoryLabel/>,
+    cursorLabelOffset: {
       x: 5,
       y: -10
     },
@@ -73,25 +73,25 @@ export const cursorContainerMixin = (base) => class VictoryCursorContainer exten
     return defaultCursorValue;
   }
 
-  getLabelOffset(props) {
-    const { labelOffset } = props;
+  getCursorLabelOffset(props) {
+    const { cursorLabelOffset } = props;
 
-    if (isNumber(labelOffset)) {
+    if (isNumber(cursorLabelOffset)) {
       return {
-        x: labelOffset,
-        y: labelOffset
+        x: cursorLabelOffset,
+        y: cursorLabelOffset
       };
     }
 
-    return labelOffset;
+    return cursorLabelOffset;
   }
 
   getCursorElements(props) {
     const {
-      scale, domain, dimension, labelComponent, labels, cursorComponent
+      scale, domain, dimension, cursorLabelComponent, cursorLabel, cursorComponent
     } = props;
     const cursorValue = this.getCursorPosition(props);
-    const labelOffset = this.getLabelOffset(props);
+    const cursorLabelOffset = this.getCursorLabelOffset(props);
 
     if (!cursorValue) { return []; }
 
@@ -102,11 +102,11 @@ export const cursorContainerMixin = (base) => class VictoryCursorContainer exten
       x: scale.x(cursorValue.x),
       y: scale.y(cursorValue.y)
     };
-    if (labels) {
-      newElements.push(React.cloneElement(labelComponent, {
-        x: cursorCoordinates.x + labelOffset.x,
-        y: cursorCoordinates.y + labelOffset.y,
-        text: Helpers.evaluateProp(labels, cursorValue, true),
+    if (cursorLabel) {
+      newElements.push(React.cloneElement(cursorLabelComponent, {
+        x: cursorCoordinates.x + cursorLabelOffset.x,
+        y: cursorCoordinates.y + cursorLabelOffset.y,
+        text: Helpers.evaluateProp(cursorLabel, cursorValue, true),
         active: true,
         key: "cursor-label"
       }));

--- a/src/components/containers/victory-cursor-container.js
+++ b/src/components/containers/victory-cursor-container.js
@@ -1,0 +1,123 @@
+/*eslint no-magic-numbers: ["error", { "ignore": [0, 1, 5, 10] }]*/
+import PropTypes from "prop-types";
+import React from "react";
+import { VictoryContainer, VictoryLabel, Line, Selection, Helpers } from "victory-core";
+import { isNumber } from "lodash";
+import CursorHelpers from "./cursor-helpers";
+
+export const cursorContainerMixin = (base) => class VictoryCursorContainer extends base {
+  static displayName = "VictoryCursorContainer";
+  static propTypes = {
+    ...VictoryContainer.propTypes,
+    defaultCursorValue: PropTypes.oneOfType([PropTypes.number, PropTypes.object]),
+    dimension: PropTypes.oneOf(["x", "y"]),
+    labelComponent: PropTypes.element,
+    labels: PropTypes.func,
+    onChange: PropTypes.func,
+    standalone: PropTypes.bool
+  };
+  static defaultProps = {
+    ...VictoryContainer.defaultProps,
+    labelComponent: <VictoryLabel/>,
+    cursorComponent: <Line/>
+  };
+
+  static defaultEvents = [{
+    target: "parent",
+    eventHandlers: {
+      onMouseLeave: () => {
+        return [];
+      },
+      onMouseMove: (evt, targetProps) => {
+        const mutations = CursorHelpers.onMouseMove(evt, targetProps);
+
+        if (mutations.id !== this.mouseMoveMutationId) { // eslint-disable-line
+          this.mouseMoveMutationId = mutations.id; // eslint-disable-line
+          return mutations.mutations;
+        }
+
+        return [];
+      }
+    }
+  }];
+
+  getCursorPosition(props) {
+    const { cursorPosition, defaultCursorValue, dimension } = props;
+    if (cursorPosition) { return cursorPosition; }
+
+    if (isNumber(defaultCursorValue)) {
+      return {
+        x: 0,
+        y: 0,
+        [dimension]: defaultCursorValue
+      };
+    }
+
+    return defaultCursorValue;
+  }
+
+  getCursorElements(props) {
+    const {
+      scale, domain, dimension, labelComponent, labels, cursorComponent
+    } = props;
+    const cursorPosition = this.getCursorPosition(props);
+
+    if (!cursorPosition) { return []; }
+
+    const newElements = [];
+    const domainCoordinates = Selection.getDomainCoordinates(scale, domain);
+
+    const cursorCoordinates = {
+      x: scale.x(cursorPosition.x),
+      y: scale.y(cursorPosition.y)
+    };
+    if (labels) {
+      newElements.push(React.cloneElement(labelComponent, {
+        x: cursorCoordinates.x + 5,
+        y: cursorCoordinates.y - 10,
+        text: Helpers.evaluateProp(labels, cursorPosition, true),
+        active: true,
+        key: "cursor-tooltip"
+      }));
+    }
+
+    if (dimension === "x" || dimension === undefined) {
+      newElements.push(React.cloneElement(cursorComponent, {
+        key: "x-cursor",
+        x1: cursorCoordinates.x,
+        x2: cursorCoordinates.x,
+        y1: domainCoordinates.y[0],
+        y2: domainCoordinates.y[1]
+      }));
+    }
+    if (dimension === "y" || dimension === undefined) {
+      newElements.push(React.cloneElement(cursorComponent, {
+        key: "y-cursor",
+        x1: domainCoordinates.x[0],
+        x2: domainCoordinates.x[1],
+        y1: cursorCoordinates.y,
+        y2: cursorCoordinates.y
+      }));
+    }
+    return newElements;
+  }
+
+  getTooltip(props) {
+    const { labels, labelComponent, cursorPosition } = props;
+    if (!labels || !cursorPosition) {
+      return null;
+    }
+    return React.cloneElement(labelComponent, this.getLabelProps(cursorPosition));
+  }
+
+  // Overrides method in VictoryContainer
+  getChildren(props) {
+    return [
+      ...React.Children.toArray(props.children),
+      ...this.getCursorElements(props),
+      this.getTooltip
+    ];
+  }
+};
+
+export default cursorContainerMixin(VictoryContainer);

--- a/src/components/containers/victory-cursor-container.js
+++ b/src/components/containers/victory-cursor-container.js
@@ -18,6 +18,13 @@ export const cursorContainerMixin = (base) => class VictoryCursorContainer exten
     ]),
     dimension: PropTypes.oneOf(["x", "y"]),
     labelComponent: PropTypes.element,
+    labelOffset: PropTypes.oneOfType([
+      PropTypes.number,
+      PropTypes.shape({
+        x: PropTypes.number,
+        y: PropTypes.number
+      })
+    ]),
     labels: PropTypes.func,
     onChange: PropTypes.func,
     standalone: PropTypes.bool
@@ -25,6 +32,10 @@ export const cursorContainerMixin = (base) => class VictoryCursorContainer exten
   static defaultProps = {
     ...VictoryContainer.defaultProps,
     labelComponent: <VictoryLabel/>,
+    labelOffset: {
+      x: 5,
+      y: -10
+    },
     cursorComponent: <Line/>
   };
 
@@ -62,11 +73,25 @@ export const cursorContainerMixin = (base) => class VictoryCursorContainer exten
     return defaultCursorValue;
   }
 
+  getLabelOffset(props) {
+    const { labelOffset } = props;
+
+    if (isNumber(labelOffset)) {
+      return {
+        x: labelOffset,
+        y: labelOffset
+      };
+    }
+
+    return labelOffset;
+  }
+
   getCursorElements(props) {
     const {
       scale, domain, dimension, labelComponent, labels, cursorComponent
     } = props;
     const cursorValue = this.getCursorPosition(props);
+    const labelOffset = this.getLabelOffset(props);
 
     if (!cursorValue) { return []; }
 
@@ -79,8 +104,8 @@ export const cursorContainerMixin = (base) => class VictoryCursorContainer exten
     };
     if (labels) {
       newElements.push(React.cloneElement(labelComponent, {
-        x: cursorCoordinates.x + 5,
-        y: cursorCoordinates.y - 10,
+        x: cursorCoordinates.x + labelOffset.x,
+        y: cursorCoordinates.y + labelOffset.y,
         text: Helpers.evaluateProp(labels, cursorValue, true),
         active: true,
         key: "cursor-label"

--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,10 @@ export {
   default as VictoryVoronoiContainer
 } from "./components/containers/victory-voronoi-container";
 export {
+  cursorContainerMixin,
+  default as VictoryCursorContainer
+} from "./components/containers/victory-cursor-container";
+export {
   zoomContainerMixin,
   default as VictoryZoomContainer
 } from "./components/containers/victory-zoom-container";


### PR DESCRIPTION
Implements VictoryCursorContainer (https://github.com/FormidableLabs/victory/issues/514)

demo at http://localhost:3000/#/cursor-container

Open issues:
- Where should the label go for 1-dimensional cursors? (with mouse [current implementation], outside of chart, middle of chart, something else?)
- createContainer("cursor", "voronoi") works pretty well, but is awkward when `labels` is used (both containers try to create labels, but they are in different places and for different values)