### PR TITLE
Zoom and Brush container fixes

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -22,6 +22,7 @@ import CreateContainerDemo from "./components/create-container-demo";
 import BrushContainerDemo from "./components/victory-brush-container-demo";
 import AnimationDemo from "./components/animation-demo";
 import SelectionDemo from "./components/selection-demo";
+import DebugDemo from "./components/debug-demo";
 
 class Home extends React.Component {
   render() {
@@ -69,6 +70,7 @@ class App extends React.Component {
     case "/animation": Child = AnimationDemo; break;
     case "/selection-container": Child = SelectionDemo; break;
     case "/create-container": Child = CreateContainerDemo; break;
+    case "/debug": Child = DebugDemo; break;
     default: Child = Home;
     }
     return Child;

--- a/demo/components/debug-demo.js
+++ b/demo/components/debug-demo.js
@@ -1,0 +1,66 @@
+/*eslint-disable no-magic-numbers */
+import React from "react";
+import {
+  VictoryChart, VictoryLine, VictoryGroup, VictoryZoomContainer
+} from "../../src/index";
+
+const edata = [
+  { x: 1, y: -3 },
+  { x: 2, y: 5 },
+  { x: 3, y: 3 },
+  { x: 4, y: 0 },
+  { x: 5, y: -2 },
+  { x: 6, y: -2 },
+  { x: 7, y: 5 }
+];
+
+class App extends React.Component {
+  constructor() {
+    super();
+    this.state = { data: edata.slice(3) };
+  }
+
+
+  handleDomainChange(domain) {
+    this.setState({ selectedDomain: domain });
+  }
+  changeDataSet(data) {
+    this.setState({
+      data,
+      selectedDomain: { x: [data[0].x, data[data.length - 1].x] }
+    });
+  }
+
+  render() {
+    return (
+      <div style={{ width: 300 }}>
+        <button onClick={() => this.changeDataSet(edata.slice(3))}>Part</button>
+        <button onClick={() => this.changeDataSet(edata)}>All</button>
+        <VictoryChart
+          containerComponent={
+            <VictoryZoomContainer
+              dimension="x"
+              onDomainChange={this.handleDomainChange.bind(this)}
+              zoomDomain={this.state.selectedDomain}
+            />
+          }
+          style={{ parent: { cursor: "pointer" } }}
+        >
+            <VictoryGroup
+
+              data={this.state.data}
+            >
+              <VictoryLine/>
+            </VictoryGroup>
+         </VictoryChart>
+         <p>
+           currentDomain (domain),
+           domain,
+           cachedZoomDomain
+         </p>
+      </div>
+    );
+  }
+}
+
+export default App;

--- a/demo/components/victory-brush-container-demo.js
+++ b/demo/components/victory-brush-container-demo.js
@@ -12,10 +12,6 @@ class App extends React.Component {
   }
 
   handleZoom(domain) {
-    this.setState({ selectedDomain: domain });
-  }
-
-  handleBrush(domain) {
     this.setState({ zoomDomain: domain });
   }
 
@@ -37,6 +33,7 @@ class App extends React.Component {
             containerComponent={
               <VictoryZoomContainer responsive={false}
                 zoomDomain={this.state.zoomDomain}
+                dimension="x"
                 onDomainChange={this.handleZoom.bind(this)}
               />
             }
@@ -63,8 +60,9 @@ class App extends React.Component {
             width={800} height={100} scale={{ x: "time" }}
             containerComponent={
               <VictoryBrushContainer responsive={false}
-                selectedDomain={this.state.selectedDomain}
-                onDomainChange={this.handleBrush.bind(this)}
+                selectedDomain={this.state.zoomDomain}
+                dimension="x"
+                onDomainChange={this.handleZoom.bind(this)}
               />
             }
           >

--- a/demo/components/victory-zoom-container-demo.js
+++ b/demo/components/victory-zoom-container-demo.js
@@ -89,7 +89,7 @@ export default class App extends React.Component {
           />
 
           <VictoryGroup
-            containerComponent={<VictoryZoomContainer/>}
+            containerComponent={<VictoryZoomContainer dimension="y"/>}
             style={{ parent: parentStyle }} data={this.state.transitionData}
           >
             <VictoryLine animate={{ duration: 1500 }} style={{ data: this.state.style }} />
@@ -99,6 +99,7 @@ export default class App extends React.Component {
             containerComponent={
               <VictoryZoomContainer
                 zoomDomain={{ x: [new Date(1993, 1, 1), new Date(2005, 1, 1)] }}
+                dimension="x"
               />
             }
             scale={{

--- a/src/components/containers/brush-helpers.js
+++ b/src/components/containers/brush-helpers.js
@@ -250,11 +250,14 @@ const Helpers = {
     }];
   },
 
-  onMouseLeave() {
-    return [{
-      target: "parent",
-      mutation: () => ({ isPanning: false, isSelecting: false })
-    }];
+  onMouseLeave(evt) {
+    if (evt.target.nodeName === "svg") {
+      return [{
+        target: "parent",
+        mutation: () => ({ isPanning: false, isSelecting: false })
+      }];
+    }
+    return [];
   }
 };
 


### PR DESCRIPTION
- Fix for https://github.com/FormidableLabs/victory/issues/607 - brush container would stop selecting if you moved the mouse quickly (or even a little bit faster than a crawl). This was an event bubbling issue: `onMouseLeave` was firing for child elements. The fix ensure that the parent `svg` was left (not, e.g., the selected domain `rect`).
- Fix for https://github.com/FormidableLabs/victory/issues/597 - (although it does *not* close the issue, as there is another bug). Zoom container didn't respect outside `zoomDomain` changes; it would revert back to internally cached values once zoom interactions (zoom/pan) resumed. The fix ensures that internal values are updated when outside changes happen.
- Updates to demos: fix a bug in the zoom/brush demo (which made it hard to find the actual zoom container issue), add a debugging demo, showcase diff zoom dimensions.