### PR TITLE
Fix brush pan bug

### DIFF
--- a/demo/components/debug-demo.js
+++ b/demo/components/debug-demo.js
@@ -1,10 +1,10 @@
 /*eslint-disable no-magic-numbers */
 import React from "react";
 import {
-  VictoryChart, VictoryLine, VictoryGroup, VictoryZoomContainer
+  VictoryChart, VictoryLine, VictoryGroup, VictoryBrushContainer
 } from "../../src/index";
 
-const edata = [
+const data = [
   { x: 1, y: -3 },
   { x: 2, y: 5 },
   { x: 3, y: 3 },
@@ -17,47 +17,36 @@ const edata = [
 class App extends React.Component {
   constructor() {
     super();
-    this.state = { data: edata.slice(3) };
+    this.state = {};
   }
-
-
-  handleDomainChange(domain) {
-    this.setState({ selectedDomain: domain });
-  }
-  changeDataSet(data) {
+  handleSelectionChange(domain) {
     this.setState({
-      data,
-      selectedDomain: { x: [data[0].x, data[data.length - 1].x] }
+      selectedDomain: domain
     });
   }
-
+  changeSelection(a, b) {
+    this.setState({
+      selectedDomain: { x: [a, b] }
+    });
+  }
   render() {
     return (
       <div style={{ width: 300 }}>
-        <button onClick={() => this.changeDataSet(edata.slice(3))}>Part</button>
-        <button onClick={() => this.changeDataSet(edata)}>All</button>
+        <button onClick={() => this.changeSelection(1, 3)}>1-3</button>
+        <button onClick={() => this.changeSelection(3, 6)}>3-6</button>
         <VictoryChart
           containerComponent={
-            <VictoryZoomContainer
+            <VictoryBrushContainer
               dimension="x"
-              onDomainChange={this.handleDomainChange.bind(this)}
-              zoomDomain={this.state.selectedDomain}
+              onDomainChange={this.handleSelectionChange.bind(this)}
+              selectedDomain={this.state.selectedDomain}
             />
           }
-          style={{ parent: { cursor: "pointer" } }}
         >
-            <VictoryGroup
-
-              data={this.state.data}
-            >
-              <VictoryLine/>
-            </VictoryGroup>
-         </VictoryChart>
-         <p>
-           currentDomain (domain),
-           domain,
-           cachedZoomDomain
-         </p>
+          <VictoryGroup data={data}>
+            <VictoryLine/>
+          </VictoryGroup>
+       </VictoryChart>
       </div>
     );
   }

--- a/src/components/containers/brush-helpers.js
+++ b/src/components/containers/brush-helpers.js
@@ -150,7 +150,8 @@ const Helpers = {
         target: "parent",
         mutation: () => ({
           isPanning: true, startX: x, startY: y, domainBox, fullDomainBox, currentDomain,
-          cachedSelectedDomain: selectedDomain
+          cachedSelectedDomain: selectedDomain,
+          ...domainBox // set x1, x2, y1, y2
         })
       }];
     } else {


### PR DESCRIPTION
ensure that x1, x2, y1, y2 are updated from outside selectedDomain changes. This was happening just fine during resize, as `getResizeMutation` was called; this fixes the pan code path.

Fixes https://github.com/FormidableLabs/victory/issues/609