### PR TITLE
allow multi-axis, fix polar axis labels

### DIFF
--- a/demo/components/victory-chart-demo.js
+++ b/demo/components/victory-chart-demo.js
@@ -180,7 +180,7 @@ class App extends React.Component {
         <div style={containerStyle}>
           <VictoryChart style={chartStyle}>
             <VictoryScatter
-              data={[{ x: 0, y: 0 }, { x: -2, y: -2 }, { x: -3, y: -3 }]}
+              data={[{ x: -3, y: -3 }]}
             />
           </VictoryChart>
 
@@ -189,7 +189,7 @@ class App extends React.Component {
               dependentAxis
               style={axisStyle}
             />
-          <VictoryAxis style={axisStyle} tickCount={6} />
+          <VictoryAxis style={axisStyle} tickCount={6}/>
             <VictoryBar
               data={[
                 { x: 1, y: 1 },

--- a/demo/components/victory-polar-chart-demo.js
+++ b/demo/components/victory-polar-chart-demo.js
@@ -5,16 +5,25 @@ import {
   VictoryPolarAxis, VictoryScatter, VictoryLine, VictoryArea, VictoryBar, VictorySelectionContainer,
   VictoryStack, VictoryChart, VictoryGroup, VictoryVoronoiContainer, VictoryZoomContainer
 } from "../../src/index";
-import { random, range, merge } from "lodash";
-
+import { random, range, merge, keys } from "lodash";
 import { VictoryTheme, VictoryTooltip } from "victory-core";
+
+
+const multiAxisData = [
+  { strength: 1, intelligence: 250, stealth: 45, charisma: 1000 },
+  { strength: 2, intelligence: 300, stealth: 75, charisma: 2000 },
+  { strength: 5, intelligence: 225, stealth: 60, charisma: 1500 }
+];
+
 class App extends React.Component {
 
   constructor() {
     super();
     this.state = {
       data: this.getData(),
-      staticData: this.getStaticData()
+      staticData: this.getStaticData(),
+      multiAxisData: this.processMultiAxisData(multiAxisData),
+      multiAxisMaxima: this.getMaxData(multiAxisData)
     };
   }
 
@@ -50,6 +59,27 @@ class App extends React.Component {
     });
   }
 
+  getMaxData(data) {
+    const groupedData = keys(data[0]).reduce((memo, key) => {
+      memo[key] = data.map((d) => d[key]);
+      return memo;
+    }, {});
+    return keys(groupedData).reduce((memo, key) => {
+      memo[key] = Math.max(...groupedData[key]);
+      return memo;
+    }, {});
+  }
+
+  processMultiAxisData(data) {
+    const maxByGroup = this.getMaxData(data);
+    const makeDataArray = (d) => {
+      return keys(d).map((key) => {
+        return { x: key, y: d[key] / maxByGroup[key] };
+      });
+    };
+    return data.map((datum) => makeDataArray(datum));
+  }
+
   render() {
     const containerStyle = {
       display: "flex",
@@ -64,6 +94,38 @@ class App extends React.Component {
     return (
       <div className="demo">
         <div style={containerStyle}>
+
+        <VictoryChart polar
+          theme={VictoryTheme.material}
+          startAngle={0}
+          domain={{ y: [ 0, 1 ] }}
+          style={chartStyle}
+        >
+          {
+            keys(this.state.multiAxisMaxima).map((key, i) => {
+              return (
+                <VictoryPolarAxis key={i} dependentAxis
+                  style={{
+                    axisLabel: { padding: 10 }
+                  }}
+                  labelPlacement="perpendicular"
+                  axisValue={i + 1} label={key}
+                  tickFormat={(t) => t * this.state.multiAxisMaxima[key]}
+                  tickValues={[0.25, 0.5, 0.75]}
+                />
+              );
+            })
+          }
+            <VictoryPolarAxis
+              labelPlacement="parallel"
+              tickFormat={() => ""}
+            />
+            <VictoryGroup colorScale="warm">
+              {this.state.multiAxisData.map((data, i) => {
+                return <VictoryLine key={i} data={data}/>;
+              })}
+            </VictoryGroup>
+          </VictoryChart>
 
           <VictoryChart polar
             theme={VictoryTheme.material}
@@ -130,19 +192,8 @@ class App extends React.Component {
             theme={VictoryTheme.material}
             style={chartStyle}
           >
-            <VictoryPolarAxis dependentAxis
-              labelPlacement="perpendicular"
-              style={{ axis: { stroke: "none" } }}
-              axisAngle={120}
-              label={"THING 1"}
-              tickValues={[1, 5, 9]}
-            />
 
             <VictoryPolarAxis dependentAxis
-              labelPlacement="perpendicular"
-              style={{ axis: { stroke: "none" } }}
-              axisAngle={0}
-              label={"THING 2"}
               tickValues={[2, 6, 8]}
             />
 

--- a/demo/components/victory-polar-chart-demo.js
+++ b/demo/components/victory-polar-chart-demo.js
@@ -6,7 +6,7 @@ import {
   VictoryStack, VictoryChart, VictoryGroup, VictoryVoronoiContainer, VictoryZoomContainer
 } from "../../src/index";
 import { random, range, merge, keys } from "lodash";
-import { VictoryTheme, VictoryTooltip } from "victory-core";
+import { VictoryTheme, VictoryTooltip, VictoryLabel } from "victory-core";
 
 
 const multiAxisData = [
@@ -97,7 +97,6 @@ class App extends React.Component {
 
         <VictoryChart polar
           theme={VictoryTheme.material}
-          startAngle={0}
           domain={{ y: [ 0, 1 ] }}
           style={chartStyle}
         >
@@ -108,6 +107,7 @@ class App extends React.Component {
                   style={{
                     axisLabel: { padding: 10 }
                   }}
+                  tickLabelComponent={<VictoryLabel labelPlacement="vertical"/>}
                   labelPlacement="perpendicular"
                   axisValue={i + 1} label={key}
                   tickFormat={(t) => t * this.state.multiAxisMaxima[key]}
@@ -165,7 +165,7 @@ class App extends React.Component {
               <VictoryLine style={{ data: { stroke: "blue" } }}/>
               <VictoryScatter
                 style={{ data: { fill: (d, active) => active ? "blue" : "gray" } }}
-                labels={(d) => d.y}
+                labels={(d) => `y: ${d.y}`}
                 labelComponent={<VictoryTooltip/>}
               />
             </VictoryGroup>
@@ -496,8 +496,8 @@ class App extends React.Component {
               labelPlacement="parallel"
             />
             <VictoryLine
-              labelComponent={<VictoryTooltip/>}
-              labels={(d) => d.x}
+              labelComponent={<VictoryLabel labelPlacement="parallel"/>}
+              labels={(d) => `y: ${Math.round(d.y)}`}
               interpolation="linear"
               style={{
                 data: { stroke: "tomato", strokeWidth: 2 }

--- a/demo/components/victory-polar-chart-demo.js
+++ b/demo/components/victory-polar-chart-demo.js
@@ -131,13 +131,22 @@ class App extends React.Component {
             style={chartStyle}
           >
             <VictoryPolarAxis dependentAxis
-              labelPlacement="vertical"
-              style={{ axis: { stroke: "none" } }}
-              axisAngle={90}
-            />
-            <VictoryPolarAxis
               labelPlacement="perpendicular"
+              style={{ axis: { stroke: "none" } }}
+              axisAngle={120}
+              label={"THING 1"}
+              tickValues={[1, 5, 9]}
             />
+
+            <VictoryPolarAxis dependentAxis
+              labelPlacement="perpendicular"
+              style={{ axis: { stroke: "none" } }}
+              axisAngle={0}
+              label={"THING 2"}
+              tickValues={[2, 6, 8]}
+            />
+
+
             <VictoryGroup
               style={{ data: { width: 10 } }}
               labels={["a", "b", "c"]}

--- a/demo/components/victory-polar-chart-demo.js
+++ b/demo/components/victory-polar-chart-demo.js
@@ -10,9 +10,9 @@ import { VictoryTheme, VictoryTooltip } from "victory-core";
 
 
 const multiAxisData = [
-  { strength: 1, intelligence: 250, stealth: 45, charisma: 1000 },
-  { strength: 2, intelligence: 300, stealth: 75, charisma: 2000 },
-  { strength: 5, intelligence: 225, stealth: 60, charisma: 1500 }
+  { strength: 1, intelligence: 250, stealth: 45 },
+  { strength: 2, intelligence: 300, stealth: 75 },
+  { strength: 5, intelligence: 225, stealth: 60 }
 ];
 
 class App extends React.Component {

--- a/src/components/victory-axis/victory-axis.js
+++ b/src/components/victory-axis/victory-axis.js
@@ -93,7 +93,10 @@ class VictoryAxis extends React.Component {
   }
 
   renderLabel(props) {
-    const { axisLabelComponent } = props;
+    const { axisLabelComponent, label } = props;
+    if (!label) {
+      return null;
+    }
     const axisLabelProps = this.getComponentProps(axisLabelComponent, "axisLabel", 0);
     return React.cloneElement(axisLabelComponent, axisLabelProps);
   }

--- a/src/components/victory-chart/helper-methods.js
+++ b/src/components/victory-chart/helper-methods.js
@@ -21,14 +21,14 @@ export default {
     if (axisComponents.dependent.length === 0 && axisComponents.independent.length === 0) {
       return childComponents.concat([defaultAxes.independent, defaultAxes.dependent]);
     }
-    if (axisComponents.dependent.length > 1 || axisComponents.independent.length > 1) {
-      const msg = "Only one VictoryAxis component of each axis type is allowed when " +
+    if (axisComponents.independent.length > 1) {
+      const msg = "Only one independent VictoryAxis component is allowed when " +
         "using the VictoryChart wrapper. Only the first axis will be used. Please compose " +
         "multi-axis charts manually";
       Log.warn(msg);
       const dataComponents = this.getDataComponents(childComponents);
       return Collection.removeUndefined(
-        dataComponents.concat([axisComponents.dependent[0], axisComponents.independent[0]])
+        dataComponents.concat([...axisComponents.dependent, axisComponents.independent[0]])
       );
     }
     return childComponents;

--- a/src/components/victory-chart/victory-chart.js
+++ b/src/components/victory-chart/victory-chart.js
@@ -107,8 +107,8 @@ export default class VictoryChart extends React.Component {
     return {
       startAngle: props.startAngle,
       endAngle: props.endAngle,
-      domain: domain[axis],
-      scale: scale[axis],
+      domain,
+      scale,
       tickValues,
       tickFormat,
       offsetY: child.props.offsetY !== undefined ? child.props.offsetY : offsetY,

--- a/src/components/victory-chart/victory-chart.js
+++ b/src/components/victory-chart/victory-chart.js
@@ -212,7 +212,8 @@ export default class VictoryChart extends React.Component {
     const { width, height, standalone, theme, polar } = props;
     const { domain, scale, style, origin, radius } = calculatedProps;
     return {
-      domain, scale, width, height, standalone, theme, style: style.parent, polar, origin, radius
+      domain, scale, width, height, standalone, theme, style: style.parent, polar, radius,
+      origin: polar ? origin : undefined
     };
   }
 

--- a/src/components/victory-polar-axis/victory-polar-axis.js
+++ b/src/components/victory-polar-axis/victory-polar-axis.js
@@ -94,13 +94,26 @@ class VictoryPolarAxis extends React.Component {
     return groupComponentProps.transform || transform;
   }
 
+  renderAxisLine(props) {
+    const { dependentAxis } = props;
+    const axisComponent = dependentAxis ? props.axisComponent : props.circularAxisComponent;
+    const axisProps = this.getComponentProps(axisComponent, "axis", 0);
+    return React.cloneElement(axisComponent, axisProps);
+  }
+
+  renderLabel(props) {
+    const { axisLabelComponent, dependentAxis, label } = props;
+    if (!label || !dependentAxis) {
+      return null;
+    }
+    const axisLabelProps = this.getComponentProps(axisLabelComponent, "axisLabel", 0);
+    return React.cloneElement(axisLabelComponent, axisLabelProps);
+  }
+
   renderAxis(props) {
     const { tickComponent, tickLabelComponent, groupComponent } = props;
     const axisType = props.dependentAxis ? "radial" : "angular";
     const gridComponent = axisType === "radial" ? props.circularGridComponent : props.gridComponent;
-    const axisComponent = props.dependentAxis ? props.axisComponent : props.circularAxisComponent;
-    const axisProps = this.getComponentProps(axisComponent, "axis", 0);
-
     const tickComponents = this.dataKeys.map((key, index) => {
       const tickProps = assign(
         { key: `tick-${key}` }, this.getComponentProps(tickComponent, "ticks", index)
@@ -121,9 +134,10 @@ class VictoryPolarAxis extends React.Component {
       );
       return React.cloneElement(tickLabelComponent, tickLabelProps);
     });
+    const axis = this.renderAxisLine(props);
+    const axisLabel = this.renderLabel(props);
     const children = [
-      React.cloneElement(axisComponent, axisProps),
-      ...tickComponents, ...gridComponents, ...tickLabelComponents
+      axis, axisLabel, ...tickComponents, ...gridComponents, ...tickLabelComponents
     ];
     return React.cloneElement(groupComponent, { transform: this.getTransform(props) }, children);
   }
@@ -137,7 +151,8 @@ class VictoryPolarAxis extends React.Component {
     if (this.shouldAnimate()) {
       return this.animateComponent(props, animationWhitelist);
     }
-    return this.renderContainer(props.containerComponent, this.renderAxis(props));
+    const children = this.renderAxis(props);
+    return props.standalone ? this.renderContainer(props.containerComponent, children) : children;
   }
 }
 

--- a/src/components/victory-polar-axis/victory-polar-axis.js
+++ b/src/components/victory-polar-axis/victory-polar-axis.js
@@ -37,7 +37,7 @@ class VictoryPolarAxis extends React.Component {
     axisAngle: PropTypes.number,
     axisComponent: PropTypes.element,
     axisLabelComponent: PropTypes.element,
-    axisValue: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    axisValue: PropTypes.number,
     circularAxisComponent: PropTypes.element,
     circularGridComponent: PropTypes.element,
     containerComponent: PropTypes.element,

--- a/src/components/victory-polar-axis/victory-polar-axis.js
+++ b/src/components/victory-polar-axis/victory-polar-axis.js
@@ -37,6 +37,7 @@ class VictoryPolarAxis extends React.Component {
     axisAngle: PropTypes.number,
     axisComponent: PropTypes.element,
     axisLabelComponent: PropTypes.element,
+    axisValue: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     circularAxisComponent: PropTypes.element,
     circularGridComponent: PropTypes.element,
     containerComponent: PropTypes.element,

--- a/test/client/spec/components/victory-chart/helper-methods.spec.js
+++ b/test/client/spec/components/victory-chart/helper-methods.spec.js
@@ -52,10 +52,10 @@ describe("victory-chart/helpers-methods", () => {
       expect(result[0].props).to.eql(axis.props);
     });
 
-    it("only ever returns one axis of a particular type", () => {
+    it("only ever returns one independent axis", () => {
       const children = [
-        getVictoryAxis({ dependentAxis: true }),
-        getVictoryAxis({ dependentAxis: true, orientation: "right" })
+        getVictoryAxis({ orientation: "top" }),
+        getVictoryAxis({ orientation: "right" })
       ];
       const result = Helpers.getChildComponents({ children }, defaultAxes);
       expect(result).to.have.length(1);


### PR DESCRIPTION
This PR supports multi-axis polar charts, fixes support for axis labels, and adds a `labelValue` convenience helper.

This work is in support of charts like: 
<img width="460" alt="screen shot 2017-06-10 at 12 19 22 am" src="https://user-images.githubusercontent.com/3719995/27000963-8d565384-4d72-11e7-8bce-6c674b1b2ca0.png">

The code looks like:

```
const multiAxisData = [
  { strength: 1, intelligence: 250, stealth: 45 },
  { strength: 2, intelligence: 300, stealth: 75 },
  { strength: 5, intelligence: 225, stealth: 60 }
];

class App extends React.Component {

  constructor() {
    super();
    this.state = {
      multiAxisData: this.processMultiAxisData(multiAxisData),
      multiAxisMaxima: this.getMaxData(multiAxisData)
    };
  }

  getMaxData(data) {
    const groupedData = keys(data[0]).reduce((memo, key) => {
      memo[key] = data.map((d) => d[key]);
      return memo;
    }, {});
    return keys(groupedData).reduce((memo, key) => {
      memo[key] = Math.max(...groupedData[key]);
      return memo;
    }, {});
  }

  processMultiAxisData(data) {
    const maxByGroup = this.getMaxData(data);
    const makeDataArray = (d) => {
      return keys(d).map((key) => {
        return { x: key, y: d[key] / maxByGroup[key] };
      });
    };
    return data.map((datum) => makeDataArray(datum));
  }

  render() {
    return (
      <VictoryChart polar
        theme={VictoryTheme.material}
        domain={{ y: [ 0, 1 ] }}
      >
        {
          keys(this.state.multiAxisMaxima).map((key, i) => {
            return (
              <VictoryPolarAxis key={i} dependentAxis
                style={{
                  axisLabel: { padding: 10 }
                }}
                labelPlacement="perpendicular"
                axisValue={i + 1} label={key}
                tickFormat={(t) => t * this.state.multiAxisMaxima[key]}
                tickValues={[0.25, 0.5, 0.75]}
              />
            );
          })
        }
          <VictoryPolarAxis
            labelPlacement="parallel"
            tickFormat={() => ""}
          />
          <VictoryGroup colorScale="warm">
            {this.state.multiAxisData.map((data, i) => {
              return <VictoryLine key={i} data={data}/>;
            })}
          </VictoryGroup>
        </VictoryChart>
    );
  }
}
```

TODOS: 
- ~Support string values for `axisValue` (currently it is necessary to use the string mapping (i.e. index  + 1)~
- [X] Support independent `labelPlacement` for axis labels and tick labels