### PR TITLE
Remove bad interpolations

### DIFF
--- a/src/components/victory-area/victory-area.js
+++ b/src/components/victory-area/victory-area.js
@@ -23,8 +23,8 @@ class VictoryArea extends React.Component {
     ...BaseProps,
     ...DataProps,
     interpolation: PropTypes.oneOf([
-      "basis", "bundle", "cardinal", "catmullRom", "linear", "monotoneX",
-      "monotoneY", "natural", "radial", "step", "stepAfter", "stepBefore"
+      "basis", "cardinal", "catmullRom", "linear", "monotoneX",
+      "monotoneY", "natural", "step", "stepAfter", "stepBefore"
     ]),
     label: CustomPropTypes.deprecated(
       PropTypes.string,

--- a/src/components/victory-line/victory-line.js
+++ b/src/components/victory-line/victory-line.js
@@ -29,7 +29,7 @@ class VictoryLine extends React.Component {
     ...DataProps,
     interpolation: PropTypes.oneOf([
       "basis", "bundle", "cardinal", "catmullRom", "linear", "monotoneX",
-      "monotoneY", "natural", "radial", "step", "stepAfter", "stepBefore"
+      "monotoneY", "natural", "step", "stepAfter", "stepBefore"
     ]),
     label: CustomPropTypes.deprecated(
       PropTypes.string,


### PR DESCRIPTION
Fixes https://github.com/FormidableLabs/victory/issues/558. Picking up the work from https://github.com/FormidableLabs/victory-core/pull/258.

- remove "radial" interpolation from VictoryLine and VictoryArea (radial used for polar charts)
- remove "bundle" from VictoryArea ("This curve [...] is intended to work with d3.line, not d3.area." - https://github.com/d3/d3-shape#curveBundle)