### PR TITLE
fix victory-area test (victory-core change)

### DIFF
--- a/test/client/spec/components/victory-area/victory-area.spec.js
+++ b/test/client/spec/components/victory-area/victory-area.spec.js
@@ -103,7 +103,7 @@ describe("components/victory-area", () => {
       const DataComponent = wrapper.find(Area);
       DataComponent.forEach((node, index) => {
         const initialProps = DataComponent.at(index).props();
-        node.childAt(0).simulate("click");
+        node.simulate("click");
         expect(clickHandler).called;
         // the first argument is the standard evt object
         expect(omit(clickHandler.args[index][1], ["events", "key"]))


### PR DESCRIPTION
fixes https://github.com/FormidableLabs/victory/issues/628

Looks like https://github.com/FormidableLabs/victory-core/pull/259 broke this hard-cored assumption of the test:

```
node.childAt(0).simulate("click");
```

core's `Area` no longer creates a wrapper when it isn't needed.