### PR TITLE
remove skipped + empty tests

### DIFF
--- a/test/client/spec/helpers/wrapper.spec.js
+++ b/test/client/spec/helpers/wrapper.spec.js
@@ -105,15 +105,4 @@ describe("helpers/wrapper", () => {
       expect(Wrapper.getStringsFromData([], "x")).to.eql([]);
     });
   });
-
-  describe("getCategories", () => {
-    it.skip("returns a set of categories from a component", () => {
-      // const categoryResult = Wrapper.getCategories();
-    });
-
-    it.skip("returns undefined if no categories are defined", () => {
-
-    });
-  });
-
 });


### PR DESCRIPTION
@boygirl is it OK if we remove these two tests that were skipped? they were confusing for a brief second when I started looking at CI results and saw `Executed 194 of 196. FAILED`. I thought two tests failed, but in reality two were skipped, and one failed. 