### PR TITLE
add maximumDomain prop to VictoryZoomContainer

### DIFF
--- a/demo/components/victory-zoom-container-demo.js
+++ b/demo/components/victory-zoom-container-demo.js
@@ -125,6 +125,8 @@ export default class App extends React.Component {
             containerComponent={
               <VictoryZoomContainer
                 minimumZoom={{ x: 5 }}
+                zoomDomain={{ x: [40, 80] }}
+                maximumDomain={{ x: [25, 100] }}
                 dimension="x"
                 clipContainerComponent={
                   <VictoryClipContainer clipPadding={{ top: 15, bottom: 15 }}/>

--- a/src/components/containers/zoom-helpers.js
+++ b/src/components/containers/zoom-helpers.js
@@ -143,7 +143,7 @@ const Helpers = {
   },
 
   getDomain(props) {
-    const { originalDomain, domain, children, dimension } = props;
+    const { originalDomain, domain, children, dimension, maximumDomain } = props;
     const childComponents = Children.toArray(children);
     let childrenDomain = {};
     if (childComponents.length) {
@@ -154,7 +154,7 @@ const Helpers = {
           y: Wrapper.getDomainFromChildren(props, "y", childComponents)
         });
     }
-    return defaults({}, childrenDomain, originalDomain, domain);
+    return defaults({}, maximumDomain, childrenDomain, originalDomain, domain);
   },
 
   onMouseDown(evt) {


### PR DESCRIPTION
cc/ @chrisbolin @HalHaig 

This PR adds a `maximumDomain` prop to `VictoryZoomContainer`. This prop will limit how far out the chart is able to zoom, and will preferentially use the `maximumDomain` when determining the original domain for zooming rather than preferentially using a domain calculated from child data.

Let me know if this seems like the correct solution.
