### PR TITLE
Webpack3 + ES6 Exports

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,3 @@
 {
-  "extends": "builder-victory-component/config/babel/.babelrc"
+  "extends": "builder-victory-component/config/babel/.babelrc-react"
 }

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ bower_components
 coverage
 dist
 lib
+es
 node_modules
 npm-debug.log*
 yarn.lock

--- a/.npmignore.publishr
+++ b/.npmignore.publishr
@@ -1,6 +1,7 @@
 /*
 !/dist
 dist/*.map
+!/es
 !/lib
 !/src
 !LICENSE.txt

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "builder-victory-component": "^5.0.1",
     "d3-voronoi": "^1.1.2",
     "lodash": "^4.17.4",
-    "victory-core": "^16.1.0"
+    "victory-core": "^16.3.0"
   },
   "devDependencies": {
     "builder-victory-component-dev": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "npm": ">=2.0.0"
   },
   "scripts": {
-    "postinstall": "cd lib || builder run npm:postinstall",
+    "postinstall": "builder run npm:postinstall",
     "preversion": "builder run npm:preversion",
     "postversion": "builder run npm:postversion",
     "postpublish": "builder run npm:postpublish",

--- a/package.json
+++ b/package.json
@@ -30,13 +30,13 @@
   },
   "dependencies": {
     "builder": "^3.2.1",
-    "builder-victory-component": "^5.0.0",
+    "builder-victory-component": "^5.0.1",
     "d3-voronoi": "^1.1.2",
     "lodash": "^4.17.4",
     "victory-core": "^16.1.0"
   },
   "devDependencies": {
-    "builder-victory-component-dev": "^5.0.0",
+    "builder-victory-component-dev": "^5.0.1",
     "chai": "^3.5.0",
     "d3-scale": "^1.0.0",
     "d3-shape": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -30,13 +30,13 @@
   },
   "dependencies": {
     "builder": "^3.2.1",
-    "builder-victory-component": "^4.0.2",
+    "builder-victory-component": "^5.0.0",
     "d3-voronoi": "^1.1.2",
     "lodash": "^4.17.4",
-    "victory-core": "^16.0.2"
+    "victory-core": "^16.1.0"
   },
   "devDependencies": {
-    "builder-victory-component-dev": "^4.0.2",
+    "builder-victory-component-dev": "^5.0.0",
     "chai": "^3.5.0",
     "d3-scale": "^1.0.0",
     "d3-shape": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "version": "21.2.4",
   "description": "Chart Component for Victory",
   "main": "lib/index.js",
+  "module": "es/index.js",
+  "jsnext:main": "es/index.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/formidablelabs/victory-chart.git"

--- a/src/components/containers/brush-helpers.js
+++ b/src/components/containers/brush-helpers.js
@@ -1,6 +1,6 @@
 import { Selection } from "victory-core";
 import { assign, throttle, isFunction, isEqual, defaults } from "lodash";
-import { attachId } from "../../helpers/event-handlers.js";
+import { attachId } from "../../helpers/event-handlers";
 
 const Helpers = {
   withinBounds(point, bounds, padding) {

--- a/src/components/containers/selection-helpers.js
+++ b/src/components/containers/selection-helpers.js
@@ -1,7 +1,7 @@
 import { Selection, Data, Helpers } from "victory-core";
 import { assign, throttle, isFunction } from "lodash";
 import React from "react";
-import { attachId } from "../../helpers/event-handlers.js";
+import { attachId } from "../../helpers/event-handlers";
 
 const SelectionHelpers = {
   getDatasets(props) {

--- a/src/components/containers/voronoi-helpers.js
+++ b/src/components/containers/voronoi-helpers.js
@@ -2,7 +2,7 @@ import { Selection, Data, Helpers } from "victory-core";
 import { assign, throttle, isFunction, groupBy, keys, isEqual } from "lodash";
 import { voronoi as d3Voronoi } from "d3-voronoi";
 import React from "react";
-import { attachId } from "../../helpers/event-handlers.js";
+import { attachId } from "../../helpers/event-handlers";
 
 const VoronoiHelpers = {
   withinBounds(props, point) {

--- a/src/components/containers/zoom-helpers.js
+++ b/src/components/containers/zoom-helpers.js
@@ -2,7 +2,7 @@
 import { Children } from "react";
 import { Selection, Collection } from "victory-core";
 import { throttle, isFunction, defaults, isEqual } from "lodash";
-import { attachId } from "../../helpers/event-handlers.js";
+import { attachId } from "../../helpers/event-handlers";
 import Wrapper from "../../helpers/wrapper";
 
 const Helpers = {

--- a/src/helpers/common-props.js
+++ b/src/helpers/common-props.js
@@ -1,101 +1,101 @@
 import PropTypes from "prop-types";
 import { PropTypes as CustomPropTypes } from "victory-core";
 
-export default {
-  DataProps: {
-    categories: PropTypes.oneOfType([
-      PropTypes.arrayOf(PropTypes.string),
-      PropTypes.shape({
-        x: PropTypes.arrayOf(PropTypes.string), y: PropTypes.arrayOf(PropTypes.string)
-      })
-    ]),
-    data: PropTypes.array,
-    dataComponent: PropTypes.element,
-    labelComponent: PropTypes.element,
-    labels: PropTypes.oneOfType([ PropTypes.func, PropTypes.array ]),
-    samples: CustomPropTypes.nonNegative,
-    sortKey: PropTypes.oneOfType([
-      PropTypes.func,
-      CustomPropTypes.allOfType([CustomPropTypes.integer, CustomPropTypes.nonNegative]),
-      PropTypes.string,
-      PropTypes.arrayOf(PropTypes.string)
-    ]),
-    style: PropTypes.shape({
-      parent: PropTypes.object, data: PropTypes.object, labels: PropTypes.object
+export const DataProps = {
+  categories: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.string),
+    PropTypes.shape({
+      x: PropTypes.arrayOf(PropTypes.string), y: PropTypes.arrayOf(PropTypes.string)
+    })
+  ]),
+  data: PropTypes.array,
+  dataComponent: PropTypes.element,
+  labelComponent: PropTypes.element,
+  labels: PropTypes.oneOfType([ PropTypes.func, PropTypes.array ]),
+  samples: CustomPropTypes.nonNegative,
+  sortKey: PropTypes.oneOfType([
+    PropTypes.func,
+    CustomPropTypes.allOfType([CustomPropTypes.integer, CustomPropTypes.nonNegative]),
+    PropTypes.string,
+    PropTypes.arrayOf(PropTypes.string)
+  ]),
+  style: PropTypes.shape({
+    parent: PropTypes.object, data: PropTypes.object, labels: PropTypes.object
+  }),
+  x: PropTypes.oneOfType([
+    PropTypes.func,
+    CustomPropTypes.allOfType([CustomPropTypes.integer, CustomPropTypes.nonNegative]),
+    PropTypes.string,
+    PropTypes.arrayOf(PropTypes.string)
+  ]),
+  y: PropTypes.oneOfType([
+    PropTypes.func,
+    CustomPropTypes.allOfType([CustomPropTypes.integer, CustomPropTypes.nonNegative]),
+    PropTypes.string,
+    PropTypes.arrayOf(PropTypes.string)
+  ]),
+  y0: PropTypes.oneOfType([
+    PropTypes.func,
+    CustomPropTypes.allOfType([CustomPropTypes.integer, CustomPropTypes.nonNegative]),
+    PropTypes.string,
+    PropTypes.arrayOf(PropTypes.string)
+  ])
+};
+
+export const BaseProps = {
+  animate: PropTypes.object,
+  containerComponent: PropTypes.element,
+  domain: PropTypes.oneOfType([
+    CustomPropTypes.domain,
+    PropTypes.shape({ x: CustomPropTypes.domain, y: CustomPropTypes.domain })
+  ]),
+  domainPadding: PropTypes.oneOfType([
+    PropTypes.shape({
+      x: PropTypes.oneOfType([ PropTypes.number, PropTypes.arrayOf(PropTypes.number) ]),
+      y: PropTypes.oneOfType([ PropTypes.number, PropTypes.arrayOf(PropTypes.number) ])
     }),
-    x: PropTypes.oneOfType([
-      PropTypes.func,
-      CustomPropTypes.allOfType([CustomPropTypes.integer, CustomPropTypes.nonNegative]),
-      PropTypes.string,
-      PropTypes.arrayOf(PropTypes.string)
-    ]),
-    y: PropTypes.oneOfType([
-      PropTypes.func,
-      CustomPropTypes.allOfType([CustomPropTypes.integer, CustomPropTypes.nonNegative]),
-      PropTypes.string,
-      PropTypes.arrayOf(PropTypes.string)
-    ]),
-    y0: PropTypes.oneOfType([
-      PropTypes.func,
-      CustomPropTypes.allOfType([CustomPropTypes.integer, CustomPropTypes.nonNegative]),
-      PropTypes.string,
-      PropTypes.arrayOf(PropTypes.string)
-    ])
-  }, BaseProps: {
-    animate: PropTypes.object,
-    containerComponent: PropTypes.element,
-    domain: PropTypes.oneOfType([
-      CustomPropTypes.domain,
-      PropTypes.shape({ x: CustomPropTypes.domain, y: CustomPropTypes.domain })
-    ]),
-    domainPadding: PropTypes.oneOfType([
-      PropTypes.shape({
-        x: PropTypes.oneOfType([ PropTypes.number, PropTypes.arrayOf(PropTypes.number) ]),
-        y: PropTypes.oneOfType([ PropTypes.number, PropTypes.arrayOf(PropTypes.number) ])
-      }),
-      PropTypes.number,
-      PropTypes.arrayOf(PropTypes.number)
-    ]),
+    PropTypes.number,
+    PropTypes.arrayOf(PropTypes.number)
+  ]),
+  eventKey: PropTypes.oneOfType([
+    PropTypes.func,
+    CustomPropTypes.allOfType([CustomPropTypes.integer, CustomPropTypes.nonNegative]),
+    PropTypes.string
+  ]),
+  events: PropTypes.arrayOf(PropTypes.shape({
+    target: PropTypes.oneOf(["data", "labels", "parent"]),
     eventKey: PropTypes.oneOfType([
-      PropTypes.func,
+      PropTypes.array,
       CustomPropTypes.allOfType([CustomPropTypes.integer, CustomPropTypes.nonNegative]),
       PropTypes.string
     ]),
-    events: PropTypes.arrayOf(PropTypes.shape({
-      target: PropTypes.oneOf(["data", "labels", "parent"]),
-      eventKey: PropTypes.oneOfType([
-        PropTypes.array,
-        CustomPropTypes.allOfType([CustomPropTypes.integer, CustomPropTypes.nonNegative]),
-        PropTypes.string
-      ]),
-      eventHandlers: PropTypes.object
-    })),
-    groupComponent: PropTypes.element,
-    height: CustomPropTypes.nonNegative,
-    name: PropTypes.string,
-    origin: PropTypes.shape({ x: PropTypes.number, y: PropTypes.number }),
-    padding: PropTypes.oneOfType([
-      PropTypes.number,
-      PropTypes.shape({
-        top: PropTypes.number, bottom: PropTypes.number,
-        left: PropTypes.number, right: PropTypes.number
-      })
-    ]),
-    polar: PropTypes.bool,
-    range: PropTypes.oneOfType([
-      CustomPropTypes.domain,
-      PropTypes.shape({ x: CustomPropTypes.domain, y: CustomPropTypes.domain })
-    ]),
-    scale: PropTypes.oneOfType([
-      CustomPropTypes.scale,
-      PropTypes.shape({ x: CustomPropTypes.scale, y: CustomPropTypes.scale })
-    ]),
-    sharedEvents: PropTypes.shape({
-      events: PropTypes.array,
-      getEventState: PropTypes.func
-    }),
-    standalone: PropTypes.bool,
-    theme: PropTypes.object,
-    width: CustomPropTypes.nonNegative
-  }
+    eventHandlers: PropTypes.object
+  })),
+  groupComponent: PropTypes.element,
+  height: CustomPropTypes.nonNegative,
+  name: PropTypes.string,
+  origin: PropTypes.shape({ x: PropTypes.number, y: PropTypes.number }),
+  padding: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.shape({
+      top: PropTypes.number, bottom: PropTypes.number,
+      left: PropTypes.number, right: PropTypes.number
+    })
+  ]),
+  polar: PropTypes.bool,
+  range: PropTypes.oneOfType([
+    CustomPropTypes.domain,
+    PropTypes.shape({ x: CustomPropTypes.domain, y: CustomPropTypes.domain })
+  ]),
+  scale: PropTypes.oneOfType([
+    CustomPropTypes.scale,
+    PropTypes.shape({ x: CustomPropTypes.scale, y: CustomPropTypes.scale })
+  ]),
+  sharedEvents: PropTypes.shape({
+    events: PropTypes.array,
+    getEventState: PropTypes.func
+  }),
+  standalone: PropTypes.bool,
+  theme: PropTypes.object,
+  width: CustomPropTypes.nonNegative
 };


### PR DESCRIPTION
This PR modernizes the Victory build and offerings. Generally:

- Provide an `es/` directory alongside `lib/` that has ES module export / imports (but everything else babel built) per the `redux` model. This model allows webpack2+ to use ESM resolution and enable tree-shaking, while is still backwards compatible with webpack1 which will use `lib/`
- Remove all references to `.jsx` since we don't use those anymore.
- Clean up and hone down a lot of stuff.

/cc @boygirl @chrisbolin

### Cross-reference PRs

First, infrastructure:

* https://github.com/FormidableLabs/builder-victory-component-dev/pull/7
* https://github.com/FormidableLabs/builder-victory-component/pull/92

Second, core:

* https://github.com/FormidableLabs/victory-core/pull/266

Third, dependers:

* https://github.com/FormidableLabs/victory-pie/pull/149
* https://github.com/FormidableLabs/victory-chart/pull/495

Finally, parent:

* https://github.com/FormidableLabs/victory/pull/651

### Tickets

Implemented / fixed:

- Provide es6 build to use with Webpack. Fixes https://github.com/FormidableLabs/victory/issues/256
- Provide efficient webpack helpers for tree-shaking + DCE. Fixes https://github.com/FormidableLabs/victory/issues/548

Opened / still open:

- Webpack tree shaking does not completely remove unused re-exports. https://github.com/FormidableLabs/victory/issues/549

### Bundles

The main goal here is not the victory _bundle_, but enabling webpack2+ users to get more efficient builds going off the `es/` directory. And with the dedupe plugin being removed in webpack2+, our dev bundle is definitely bigger. But, fortunately, the prod minified bundles aren't that different:

*Before / webpack1*

```
$ find ../victory*/dist -type f -exec wc -c {} \;
  993198 ../victory-chart/dist/victory-chart.js
 1323555 ../victory-chart/dist/victory-chart.js.map
  438868 ../victory-chart/dist/victory-chart.min.js
 2634923 ../victory-chart/dist/victory-chart.min.js.map
  659513 ../victory-core/dist/victory-core.js
  915723 ../victory-core/dist/victory-core.js.map
  276427 ../victory-core/dist/victory-core.min.js
 1734458 ../victory-core/dist/victory-core.min.js.map
  674687 ../victory-pie/dist/victory-pie.js
  836742 ../victory-pie/dist/victory-pie.js.map
  284790 ../victory-pie/dist/victory-pie.min.js
 1814890 ../victory-pie/dist/victory-pie.min.js.map
 1013340 ../victory/dist/victory.js
 1235399 ../victory/dist/victory.js.map
  450323 ../victory/dist/victory.min.js
 2747731 ../victory/dist/victory.min.js.map
```

*After / webpack3*

```
$ find ../victory*/dist -type f -exec wc -c {} \;
 1663000 ../victory-chart/dist/victory-chart.js
 1602704 ../victory-chart/dist/victory-chart.js.map
  434851 ../victory-chart/dist/victory-chart.min.js
 3349108 ../victory-chart/dist/victory-chart.min.js.map
  975040 ../victory-core/dist/victory-core.js
  941706 ../victory-core/dist/victory-core.js.map
  265075 ../victory-core/dist/victory-core.min.js
 1930341 ../victory-core/dist/victory-core.min.js.map
 1219152 ../victory-pie/dist/victory-pie.js
 1092945 ../victory-pie/dist/victory-pie.js.map
  304427 ../victory-pie/dist/victory-pie.min.js
 2396990 ../victory-pie/dist/victory-pie.min.js.map
 1869374 ../victory/dist/victory.js
 1680468 ../victory/dist/victory.js.map
  487115 ../victory/dist/victory.min.js
 3846520 ../victory/dist/victory.min.js.map
```