### PR TITLE
Passing props to clipContainerComponent in VictoryZoomContainer

### DIFF
--- a/src/components/containers/victory-zoom-container.js
+++ b/src/components/containers/victory-zoom-container.js
@@ -115,7 +115,8 @@ export const zoomContainerMixin = (base) => class VictoryZoomContainer extends b
         children: child,
         polar,
         origin: polar ? origin : undefined,
-        radius: polar ? radius : undefined
+        radius: polar ? radius : undefined,
+        ...clipContainerComponent.props
       });
     };
     return React.Children.toArray(children).map((child, index) => {


### PR DESCRIPTION
To make it possible to use the work around described in FormidableLabs/victory-core#301 it needs to be possible to supply a `clipId` to all components that use `VictoryClipContainer`

This works great for `VictoryLine` and `VictoryArea` but `VictoryZoomContainer` doesn't pass along the props provided to the `VictoryClipContainer` that's passed into its `clipContainerComponent` prop.  