### PR TITLE
no props name overlap for containers

### DIFF
--- a/demo/components/create-container-demo.js
+++ b/demo/components/create-container-demo.js
@@ -30,7 +30,7 @@ const Charts = ({ behaviors }) => { // eslint-disable-line react/prop-types
           padding={{ top: 100, bottom: 50, left: 50, right: 50 }}
           domainPadding={{ y: 2 }}
           containerComponent={
-            <CustomContainer dimension="x"
+            <CustomContainer voronoiDimension="x"
               labels={(d) => `y: ${d.y}`}
               labelComponent={<VictoryTooltip cornerRadius={0} flyoutStyle={{ fill: "white" }}/>}
               selectedDomain={{ x: [1.5, 2] }}

--- a/demo/components/victory-brush-container-demo.js
+++ b/demo/components/victory-brush-container-demo.js
@@ -34,8 +34,8 @@ class App extends React.Component {
             containerComponent={
               <VictoryZoomContainer responsive={false}
                 zoomDomain={this.state.zoomDomain}
-                dimension="x"
-                onDomainChange={this.handleZoom.bind(this)}
+                zoomDimension="x"
+                onZoomDomainChange={this.handleZoom.bind(this)}
               />
             }
           >
@@ -61,9 +61,9 @@ class App extends React.Component {
             width={800} height={100} scale={{ x: "time" }}
             containerComponent={
               <VictoryBrushContainer responsive={false}
-                selectedDomain={this.state.zoomDomain}
-                dimension="x"
-                onDomainChange={this.handleZoom.bind(this)}
+                brushDomain={this.state.zoomDomain}
+                brushDimension="x"
+                onBrushDomainChange={this.handleZoom.bind(this)}
               />
             }
           >
@@ -100,7 +100,7 @@ class App extends React.Component {
             height={400}
             padding={{ top: 100, bottom: 50, left: 50, right: 50 }}
             containerComponent={
-              <VictoryBrushContainer dimension={null}/>
+              <VictoryBrushContainer brushDimension={null}/>
             }
           >
             <VictoryLegend x={120} y={20}
@@ -166,7 +166,7 @@ class App extends React.Component {
             domain={{ x: [0, 10], y: [-5, 5] }}
             containerComponent={
               <VictoryBrushContainer
-                selectedDomain={{ x: [0, 10] }}
+                brushDomain={{ x: [0, 10] }}
               />
             }
             size={(datum, active) => active ? 5 : 3}
@@ -310,8 +310,8 @@ class App extends React.Component {
           <VictoryLine style={chartStyle}
             containerComponent={
               <VictoryBrushContainer
-                selectedDomain={{ y: [-3, 3] }}
-                selectionComponent={<rect style={{ fill: "teal" }}/>}
+                brushDomain={{ y: [-3, 3] }}
+                brushComponent={<rect style={{ fill: "teal" }}/>}
               />
             }
             style={{

--- a/demo/components/victory-voronoi-container-demo.js
+++ b/demo/components/victory-voronoi-container-demo.js
@@ -56,7 +56,7 @@ class App extends React.Component {
             theme={VictoryTheme.material}
             domainPadding={{ y: 2 }}
             containerComponent={
-              <VictoryVoronoiContainer dimension="x"
+              <VictoryVoronoiContainer voronoiDimension="x"
                 labels={(d) => `y:${d.y}`}
                 labelComponent={
                   <VictoryTooltip
@@ -114,7 +114,7 @@ class App extends React.Component {
                 fill: (datum, active) => active ? "tomato" : "black"
               }
             }}
-            containerComponent={<VictoryVoronoiContainer dimension="x"/>}
+            containerComponent={<VictoryVoronoiContainer voronoiDimension="x"/>}
             size={(datum, active) => active ? 5 : 3}
             data={this.state.data}
             x="a"

--- a/demo/components/victory-zoom-container-demo.js
+++ b/demo/components/victory-zoom-container-demo.js
@@ -200,7 +200,7 @@ export default class App extends React.Component {
 
           <VictoryChart
             containerComponent={
-              <VictoryZoomContainer dimension="x" zoomDomain={this.state.zoomDomain} />
+              <VictoryZoomContainer zoomDimension="x" zoomDomain={this.state.zoomDomain} />
             }
             animate={{ duration: 500 }}
             style={{ parent: parentStyle }}

--- a/src/components/containers/selection-helpers.js
+++ b/src/components/containers/selection-helpers.js
@@ -66,7 +66,8 @@ const SelectionHelpers = {
   // eslint-disable-next-line complexity
   onMouseDown(evt, targetProps) {
     evt.preventDefault();
-    const { dimension, polar } = targetProps;
+    const { polar } = targetProps;
+    const dimension = targetProps.selectionDimension;
     const datasets = targetProps.datasets || [];
     const { x, y } = Selection.getSVGEventCoordinates(evt);
     const x1 = polar || dimension !== "y" ? x : Selection.getDomainCoordinates(targetProps).x[0];
@@ -92,7 +93,8 @@ const SelectionHelpers = {
   },
 
   onMouseMove(evt, targetProps) {
-    const { dimension, select, polar } = targetProps;
+    const { select, polar } = targetProps;
+    const dimension = targetProps.selectionDimension;
     if (!select) {
       return {};
     } else {

--- a/src/components/containers/victory-brush-container.js
+++ b/src/components/containers/victory-brush-container.js
@@ -8,32 +8,32 @@ export const brushContainerMixin = (base) => class VictoryBrushContainer extends
   static displayName = "VictoryBrushContainer";
   static propTypes = {
     ...VictoryContainer.propTypes,
-    dimension: PropTypes.oneOf(["x", "y"]),
-    handleComponent: PropTypes.element,
-    handleStyle: PropTypes.object,
-    handleWidth: PropTypes.number,
-    onDomainChange: PropTypes.func,
-    selectedDomain: PropTypes.shape({
+    brushComponent: PropTypes.element,
+    brushDimension: PropTypes.oneOf(["x", "y"]),
+    brushDomain: PropTypes.shape({
       x: PropTypes.array,
       y: PropTypes.array
     }),
-    selectionComponent: PropTypes.element,
-    selectionStyle: PropTypes.object
+    brushStyle: PropTypes.object,
+    handleComponent: PropTypes.element,
+    handleStyle: PropTypes.object,
+    handleWidth: PropTypes.number,
+    onBrushDomainChange: PropTypes.func
   };
   static defaultProps = {
     ...VictoryContainer.defaultProps,
+    brushComponent: <rect/>,
+    brushStyle: {
+      stroke: "transparent",
+      fill: "black",
+      fillOpacity: 0.1
+    },
     handleComponent: <rect/>,
     handleStyle: {
       stroke: "transparent",
       fill: "transparent"
     },
-    handleWidth: 8,
-    selectionComponent: <rect/>,
-    selectionStyle: {
-      stroke: "transparent",
-      fill: "black",
-      fillOpacity: 0.1
-    }
+    handleWidth: 8
   };
 
   static defaultEvents = [{
@@ -82,21 +82,21 @@ export const brushContainerMixin = (base) => class VictoryBrushContainer extends
 
   getSelectBox(props, coordinates) {
     const { x, y } = coordinates;
-    const { selectionStyle, selectionComponent } = props;
-    const selectionComponentStyle = selectionComponent.props && selectionComponent.props.style;
+    const { brushStyle, brushComponent } = props;
+    const brushComponentStyle = brushComponent.props && brushComponent.props.style;
     return x[0] !== x[1] && y[0] !== y[1] ?
-      React.cloneElement(selectionComponent, {
+      React.cloneElement(brushComponent, {
         width: Math.abs(x[1] - x[0]) || 1,
         height: Math.abs(y[1] - y[0]) || 1,
         x: Math.min(x[0], x[1]),
         y: Math.min(y[0], y[1]),
         cursor: "move",
-        style: defaults({}, selectionComponentStyle, selectionStyle)
+        style: defaults({}, brushComponentStyle, brushStyle)
       }) : null;
   }
 
   getHandles(props, coordinates) {
-    const { dimension, handleWidth, handleStyle, handleComponent } = props;
+    const { brushDimension, handleWidth, handleStyle, handleComponent } = props;
     const { x, y } = coordinates;
     const width = Math.abs(x[1] - x[0]) || 1;
     const height = Math.abs(y[1] - y[0]) || 1;
@@ -105,10 +105,10 @@ export const brushContainerMixin = (base) => class VictoryBrushContainer extends
     const yProps = { style, width, height: handleWidth, cursor: "ns-resize" };
     const xProps = { style, width: handleWidth, height, cursor: "ew-resize" };
     const handleProps = {
-      top: dimension !== "x" && assign({ x: x[0], y: y[1] - (handleWidth / 2) }, yProps),
-      bottom: dimension !== "x" && assign({ x: x[0], y: y[0] - (handleWidth / 2) }, yProps),
-      left: dimension !== "y" && assign({ y: y[1], x: x[0] - (handleWidth / 2) }, xProps),
-      right: dimension !== "y" && assign({ y: y[1], x: x[1] - (handleWidth / 2) }, xProps)
+      top: brushDimension !== "x" && assign({ x: x[0], y: y[1] - (handleWidth / 2) }, yProps),
+      bottom: brushDimension !== "x" && assign({ x: x[0], y: y[0] - (handleWidth / 2) }, yProps),
+      left: brushDimension !== "y" && assign({ y: y[1], x: x[0] - (handleWidth / 2) }, xProps),
+      right: brushDimension !== "y" && assign({ y: y[1], x: x[1] - (handleWidth / 2) }, xProps)
     };
     const handles = ["top", "bottom", "left", "right"].reduce((memo, curr) => {
       memo = handleProps[curr] ?
@@ -122,10 +122,10 @@ export const brushContainerMixin = (base) => class VictoryBrushContainer extends
   }
 
   getRect(props) {
-    const { currentDomain, cachedSelectedDomain } = props;
-    const selectedDomain = defaults({}, props.selectedDomain, props.domain);
-    const domain = isEqual(selectedDomain, cachedSelectedDomain) ?
-      defaults({}, currentDomain, selectedDomain) : selectedDomain;
+    const { currentDomain, cachedBrushDomain } = props;
+    const brushDomain = defaults({}, props.brushDomain, props.domain);
+    const domain = isEqual(brushDomain, cachedBrushDomain) ?
+      defaults({}, currentDomain, brushDomain) : brushDomain;
     const coordinates = Selection.getDomainCoordinates(props, domain);
     const selectBox = this.getSelectBox(props, coordinates);
     return selectBox ?

--- a/src/components/containers/victory-cursor-container.js
+++ b/src/components/containers/victory-cursor-container.js
@@ -1,13 +1,14 @@
 import PropTypes from "prop-types";
 import React from "react";
 import { VictoryContainer, VictoryLabel, Line, Helpers } from "victory-core";
-import { defaults, isNumber, isUndefined } from "lodash";
+import { defaults, isNumber, isUndefined, isObject } from "lodash";
 import CursorHelpers from "./cursor-helpers";
 
 export const cursorContainerMixin = (base) => class VictoryCursorContainer extends base {
   static displayName = "VictoryCursorContainer";
   static propTypes = {
     ...VictoryContainer.propTypes,
+    cursorDimension: PropTypes.oneOf(["x", "y"]),
     cursorLabel: PropTypes.func,
     cursorLabelComponent: PropTypes.element,
     cursorLabelOffset: PropTypes.oneOfType([
@@ -24,9 +25,7 @@ export const cursorContainerMixin = (base) => class VictoryCursorContainer exten
         y: PropTypes.number
       })
     ]),
-    dimension: PropTypes.oneOf(["x", "y"]),
-    onChange: PropTypes.func,
-    standalone: PropTypes.bool
+    onCursorChange: PropTypes.func
   };
   static defaultProps = {
     ...VictoryContainer.defaultProps,
@@ -100,7 +99,9 @@ export const cursorContainerMixin = (base) => class VictoryCursorContainer exten
 
   getPadding(props) {
     if (isUndefined(props.padding)) {
-      const child = props.children.find((c) => !isUndefined(c.props.padding));
+      const child = props.children.find((c) => {
+        return isObject(c.props) && !isUndefined(c.props.padding);
+      });
       return Helpers.getPadding(child.props);
     } else {
       return Helpers.getPadding(props);

--- a/src/components/containers/victory-selection-container.js
+++ b/src/components/containers/victory-selection-container.js
@@ -7,12 +7,11 @@ export const selectionContainerMixin = (base) => class VictorySelectionContainer
   static displayName = "VictorySelectionContainer";
   static propTypes = {
     ...VictoryContainer.propTypes,
-    dimension: PropTypes.oneOf(["x", "y"]),
     onSelection: PropTypes.func,
     onSelectionCleared: PropTypes.func,
     selectionComponent: PropTypes.element,
-    selectionStyle: PropTypes.object,
-    standalone: PropTypes.bool
+    selectionDimension: PropTypes.oneOf(["x", "y"]),
+    selectionStyle: PropTypes.object
   };
   static defaultProps = {
     ...VictoryContainer.defaultProps,

--- a/src/components/containers/victory-voronoi-container.js
+++ b/src/components/containers/victory-voronoi-container.js
@@ -8,13 +8,12 @@ export const voronoiContainerMixin = (base) => class VictoryVoronoiContainer ext
   static displayName = "VictoryVoronoiContainer";
   static propTypes = {
     ...VictoryContainer.propTypes,
-    dimension: PropTypes.oneOf(["x", "y"]),
     labelComponent: PropTypes.element,
     labels: PropTypes.func,
     onActivated: PropTypes.func,
     onDeactivated: PropTypes.func,
     radius: PropTypes.number,
-    standalone: PropTypes.bool,
+    voronoiDimension: PropTypes.oneOf(["x", "y"]),
     voronoiPadding: PropTypes.number
   };
   static defaultProps = {
@@ -113,14 +112,14 @@ export const voronoiContainerMixin = (base) => class VictoryVoronoiContainer ext
   }
 
   getLabelPosition(props, points, labelProps) {
-    const { mousePosition, dimension, scale, voronoiPadding } = props;
+    const { mousePosition, voronoiDimension, scale, voronoiPadding } = props;
     const basePosition = Helpers.scalePoint(props, omit(points[0], ["_voronoiX", "_voronoiY"]));
-    if (!dimension || points.length < 2) {
+    if (!voronoiDimension || points.length < 2) {
       return basePosition;
     }
 
-    const x = dimension === "y" ? mousePosition.x : basePosition.x;
-    const y = dimension === "x" ? mousePosition.y : basePosition.y;
+    const x = voronoiDimension === "y" ? mousePosition.x : basePosition.x;
+    const y = voronoiDimension === "x" ? mousePosition.y : basePosition.y;
     if (props.polar) {
       // TODO: Should multi-point tooltips be constrained within a circular chart?
       return { x, y };
@@ -169,8 +168,8 @@ export const voronoiContainerMixin = (base) => class VictoryVoronoiContainer ext
   }
 
   getDefaultLabelProps(props, points) {
-    const { dimension } = props;
-    const multiPoint = dimension && points.length > 1;
+    const { voronoiDimension } = props;
+    const multiPoint = voronoiDimension && points.length > 1;
     return {
       orientation: multiPoint ? "top" : undefined,
       pointerLength: multiPoint ? 0 : undefined

--- a/src/components/containers/victory-zoom-container.js
+++ b/src/components/containers/victory-zoom-container.js
@@ -15,7 +15,6 @@ export const zoomContainerMixin = (base) => class VictoryZoomContainer extends b
     ...VictoryContainer.propTypes,
     allowZoom: PropTypes.bool,
     clipContainerComponent: PropTypes.element.isRequired,
-    dimension: PropTypes.oneOf(["x", "y"]),
     downsample: PropTypes.oneOfType([
       PropTypes.bool,
       PropTypes.number
@@ -24,7 +23,8 @@ export const zoomContainerMixin = (base) => class VictoryZoomContainer extends b
       x: PropTypes.number,
       y: PropTypes.number
     }),
-    onDomainChange: PropTypes.func,
+    onZoomDomainChange: PropTypes.func,
+    zoomDimension: PropTypes.oneOf(["x", "y"]),
     zoomDomain: PropTypes.shape({
       x: CustomPropTypes.domain,
       y: CustomPropTypes.domain
@@ -149,7 +149,7 @@ export const zoomContainerMixin = (base) => class VictoryZoomContainer extends b
     // if data accessors are not used, skip calling expensive Data.formatData
     const data = (childProps.x || childProps.y) ? Data.formatData(rawData, childProps) : rawData;
     const maxPoints = (downsample === true) ? DEFAULT_DOWNSAMPLE : downsample;
-    const dimension = props.dimension || "x";
+    const dimension = props.zoomDimension || "x";
 
     // important: assumes data is ordered by dimension
     // get the start and end of the data that is in the current visible domain
@@ -190,11 +190,11 @@ export const zoomContainerMixin = (base) => class VictoryZoomContainer extends b
       }
 
       let newDomain = props.polar ? this.modifyPolarDomain(domain, originalDomain) : domain;
-      if (newDomain && props.dimension) {
+      if (newDomain && props.zoomDimension) {
         // if zooming is restricted to a dimension, don't squash changes to zoomDomain in other dim
         newDomain = {
           ...zoomDomain,
-          [props.dimension]: newDomain[props.dimension]
+          [props.zoomDimension]: newDomain[props.zoomDimension]
         };
       }
       const newChild = React.cloneElement(

--- a/src/components/containers/voronoi-helpers.js
+++ b/src/components/containers/voronoi-helpers.js
@@ -25,8 +25,8 @@ const VoronoiHelpers = {
       return data.map((datum, index) => {
         const { x, y } = Helpers.getPoint(datum);
         return assign({
-          _voronoiX: props.dimension === "y" ? 0 : x,
-          _voronoiY: props.dimension === "x" ? 0 : y,
+          _voronoiX: props.voronoiDimension === "y" ? 0 : x,
+          _voronoiY: props.voronoiDimension === "x" ? 0 : y,
           childName: name, eventKey: index, continuous, style
         }, datum);
       });
@@ -83,7 +83,7 @@ const VoronoiHelpers = {
       .extent([[padding, padding], [width - padding, height - padding]]);
     const datasets = this.getDatasets(props);
     const voronoi = voronoiFunction(this.mergeDatasets(props, datasets));
-    const size = props.dimension ? undefined : props.radius;
+    const size = props.voronoiDimension ? undefined : props.radius;
     return voronoi.find(mousePosition.x, mousePosition.y, size);
   },
 

--- a/src/components/containers/zoom-helpers.js
+++ b/src/components/containers/zoom-helpers.js
@@ -147,12 +147,12 @@ const Helpers = {
   },
 
   getDomain(props) {
-    const { originalDomain, domain, children, dimension } = props;
+    const { originalDomain, domain, children, zoomDimension } = props;
     const childComponents = Children.toArray(children);
     let childrenDomain = {};
     if (childComponents.length) {
-      childrenDomain = dimension ?
-        { [dimension]: Wrapper.getDomainFromChildren(props, dimension, childComponents) }
+      childrenDomain = zoomDimension ?
+        { [zoomDimension]: Wrapper.getDomainFromChildren(props, zoomDimension, childComponents) }
         : ({
           x: Wrapper.getDomainFromChildren(props, "x", childComponents),
           y: Wrapper.getDomainFromChildren(props, "y", childComponents)
@@ -195,23 +195,23 @@ const Helpers = {
 
   onMouseMove(evt, targetProps, eventKey, ctx) { // eslint-disable-line max-params
     if (targetProps.panning) {
-      const { scale, startX, startY, onDomainChange, dimension, zoomDomain } = targetProps;
+      const { scale, startX, startY, onZoomDomainChange, zoomDimension, zoomDomain } = targetProps;
       const { x, y } = Selection.getSVGEventCoordinates(evt);
       const originalDomain = this.getDomain(targetProps);
       const lastDomain = this.getLastDomain(targetProps, originalDomain);
       const dx = (startX - x) / this.getDomainScale(lastDomain, scale, "x");
       const dy = (y - startY) / this.getDomainScale(lastDomain, scale, "y");
       const currentDomain = {
-        x: dimension === "y" ? originalDomain.x : this.pan(lastDomain.x, originalDomain.x, dx),
-        y: dimension === "x" ? originalDomain.y : this.pan(lastDomain.y, originalDomain.y, dy)
+        x: zoomDimension === "y" ? originalDomain.x : this.pan(lastDomain.x, originalDomain.x, dx),
+        y: zoomDimension === "x" ? originalDomain.y : this.pan(lastDomain.y, originalDomain.y, dy)
       };
       const resumeAnimation = this.handleAnimation(ctx);
       const mutatedProps = {
         parentControlledProps: ["domain"], startX: x, startY: y,
         domain: currentDomain, currentDomain, originalDomain, cachedZoomDomain: zoomDomain
       };
-      if (isFunction(onDomainChange)) {
-        onDomainChange(currentDomain, defaults({}, mutatedProps, targetProps));
+      if (isFunction(onZoomDomainChange)) {
+        onZoomDomainChange(currentDomain, defaults({}, mutatedProps, targetProps));
       }
       return [{
         target: "parent",
@@ -226,13 +226,13 @@ const Helpers = {
     if (!targetProps.allowZoom) {
       return {};
     }
-    const { onDomainChange, dimension, zoomDomain } = targetProps;
+    const { onZoomDomainChange, zoomDimension, zoomDomain } = targetProps;
     const originalDomain = this.getDomain(targetProps);
     const lastDomain = this.getLastDomain(targetProps, originalDomain);
     const { x, y } = lastDomain;
     const currentDomain = {
-      x: dimension === "y" ? lastDomain.x : this.scale(x, evt, targetProps, "x"),
-      y: dimension === "x" ? lastDomain.y : this.scale(y, evt, targetProps, "y")
+      x: zoomDimension === "y" ? lastDomain.x : this.scale(x, evt, targetProps, "x"),
+      y: zoomDimension === "x" ? lastDomain.y : this.scale(y, evt, targetProps, "y")
     };
     const resumeAnimation = this.handleAnimation(ctx);
 
@@ -245,8 +245,8 @@ const Helpers = {
       parentControlledProps: ["domain"], panning: false, zoomActive
     };
 
-    if (isFunction(onDomainChange)) {
-      onDomainChange(currentDomain, defaults({}, mutatedProps, targetProps));
+    if (isFunction(onZoomDomainChange)) {
+      onZoomDomainChange(currentDomain, defaults({}, mutatedProps, targetProps));
     }
 
     return [{


### PR DESCRIPTION
**Breaking Changes for Containers**

This PR changes the names of several container props so that there is no naming conflict. This was an issue for users using the `createContainer` helper. Props like `dimension` that had the same name across containers were not able to be individually assigned in hybrid containers. Issues like https://github.com/FormidableLabs/victory/issues/756 would occur as a consequence. 

**Naming Changes:**

`VictoryBrushContainer`
- `dimension` -> `brushDimension`
- `selectionComponent` -> `brushComponent`
- `selectedDomain` -> `brushDomain`
- `selectionStyle` -> `brushStyle`
- `onDomainChange` -> `onBrushDomainChange`

`VictoryCursorContainer`
- `dimension` -> `cursorDimension`
- `onChange` -> `onCursorChange`

`VictorySelectionContainer`
- `dimension` -> `selectionDimension`

`VictoryVoronoiContainer`
- `dimension` -> `voronoiDimension`

`VictoryZoomContainer`
- `dimension` -> `zoomDimension`
- `onDomainChange` -> `onZoomDomainChange`