### PR TITLE
Bug/ticks

### DIFF
--- a/demo/components/debug-demo.js
+++ b/demo/components/debug-demo.js
@@ -157,6 +157,12 @@ class App extends React.Component {
               tickValues={[3]}
             />
           </VictoryChart>
+
+          <VictoryChart style={chartStyle}>
+            <VictoryScatter
+              data={[{ x: 1, y: -3 }, { x: 2, y: -2 }, { x: 3, y: -1 }]}
+            />
+          </VictoryChart>
         </div>
       </div>
     );

--- a/demo/components/debug-demo.js
+++ b/demo/components/debug-demo.js
@@ -2,7 +2,7 @@
 
 import React from "react";
 import {
-  VictoryChart, VictoryAxis, VictoryLine, VictoryScatter
+  VictoryChart, VictoryAxis, VictoryLine, VictoryScatter, VictoryBar
 } from "../../src/index";
 
 import { range } from "lodash";
@@ -79,6 +79,29 @@ class App extends React.Component {
             <VictoryLine y={(d) => 0.5 * d.x + 0.5} style={{ data: { stroke: "red" } }}/>
             <VictoryAxis
               tickCount={10}
+            />
+          </VictoryChart>
+
+          <VictoryChart style={chartStyle}>
+            <VictoryBar horizontal
+              data={[{ x: 1, y: 3 }, { x: 2, y: 2 }, { x: 3, y: 1 }]}
+            />
+            <VictoryAxis
+              tickValues={[ 0, 1, 2, 3 ]}
+              tickFormat={(t) => `y: ${t}`}
+            />
+            <VictoryAxis dependentAxis
+              tickValues={[ 0, 1, 2, 3 ]}
+              tickFormat={(t) => `x: ${t}`}
+            />
+          </VictoryChart>
+
+          <VictoryChart style={chartStyle}>
+            <VictoryBar horizontal
+              data={[{ x: 1, y: 4 }, { x: 2, y: 5 }, { x: 3, y: 6 }]}
+            />
+            <VictoryAxis dependentAxis
+              tickFormat={(t) => `x: ${t}`}
             />
           </VictoryChart>
         </div>

--- a/demo/components/debug-demo.js
+++ b/demo/components/debug-demo.js
@@ -1,104 +1,13 @@
 /*eslint-disable no-magic-numbers */
-/*global window:false */
 
 import React from "react";
 import {
-  VictoryChart, VictoryBar, VictoryAxis, VictoryGroup, VictoryLine, VictoryScatter
+  VictoryChart, VictoryAxis, VictoryLine, VictoryScatter
 } from "../../src/index";
 
-import { range, random } from "lodash";
+import { range } from "lodash";
 
 class App extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      lineData: this.getData(),
-      numericBarData: this.getNumericBarData(),
-      barData: this.getBarData(),
-      barTransitionData: this.getBarTransitionData(),
-      multiBarTransitionData: this.getMultiBarTransitionData(),
-    };
-  }
-
-  componentDidMount() {
-    /* eslint-disable react/no-did-mount-set-state */
-    this.setStateInterval = window.setInterval(() => {
-      this.setState({
-        lineData: this.getData(),
-        barData: this.getBarData(),
-        barTransitionData: this.getBarTransitionData(),
-        multiBarTransitionData: this.getMultiBarTransitionData(),
-        numericBarData: this.getNumericBarData(),
-      });
-    }, 4000);
-  }
-
-  componentWillUnmount() {
-    window.clearInterval(this.setStateInterval);
-  }
-
-  getData() {
-    return range(20).map((i) => {
-      return {
-        x: i,
-        y: Math.random()
-      };
-    });
-  }
-
-  getNumericBarData() {
-    return range(5).map(() => {
-      return [
-        {
-          x: random(1, 3),
-          y: random(1, 5)
-        },
-        {
-          x: random(4, 7),
-          y: random(1, 10)
-        },
-        {
-          x: random(9, 11),
-          y: random(1, 15)
-        }
-      ];
-    });
-  }
-
-  getBarData() {
-    return range(5).map(() => {
-      return [
-        {
-          x: "apples",
-          y: random(2, 5)
-        },
-        {
-          x: "bananas",
-          y: random(2, 10)
-        },
-        {
-          x: "oranges",
-          y: random(0, 15)
-        }
-      ];
-    });
-  }
-
-  getBarTransitionData() {
-    const bars = random(6, 10);
-    return range(bars).map((bar) => {
-      return { x: bar, y: random(2, 10) };
-    });
-  }
-
-  getMultiBarTransitionData() {
-    const bars = random(6, 10);
-    return range(5).map(() => {
-      return range(bars).map((bar) => {
-        return { x: bar, y: random(2, 10) };
-      });
-    });
-  }
 
   render() {
     const containerStyle = {
@@ -109,12 +18,6 @@ class App extends React.Component {
       justifyContent: "center"
     };
     const chartStyle = { parent: { border: "1px solid #ccc", margin: "2%", maxWidth: "40%" } };
-    const axisStyle = {
-      grid: { stroke: "grey", strokeWidth: 1 },
-      axis: { stroke: "transparent" },
-      ticks: { stroke: "transparent" },
-      tickLabels: { fill: "none" }
-    };
     return (
       <div className="demo">
         <h1>VictoryChart</h1>
@@ -161,6 +64,21 @@ class App extends React.Component {
           <VictoryChart style={chartStyle}>
             <VictoryScatter
               data={[{ x: 1, y: -3 }, { x: 2, y: -2 }, { x: 3, y: -1 }]}
+            />
+          </VictoryChart>
+
+          <VictoryChart style={chartStyle} domain={[0, 100]}>
+            <VictoryLine y={(d) => 0.5 * d.x + 0.5} style={{ data: { stroke: "red" } }}/>
+            <VictoryAxis
+              tickValues={range(100)}
+              tickCount={10}
+            />
+          </VictoryChart>
+
+          <VictoryChart style={chartStyle} domain={[0, 100]}>
+            <VictoryLine y={(d) => 0.5 * d.x + 0.5} style={{ data: { stroke: "red" } }}/>
+            <VictoryAxis
+              tickCount={10}
             />
           </VictoryChart>
         </div>

--- a/demo/components/debug-demo.js
+++ b/demo/components/debug-demo.js
@@ -1,47 +1,163 @@
 /*eslint-disable no-magic-numbers */
-/*global setInterval:false */
+/*global window:false */
 
 import React from "react";
 import {
-  VictoryChart, VictoryLine, VictoryZoomContainer
+  VictoryChart, VictoryBar, VictoryAxis, VictoryGroup, VictoryLine, VictoryScatter
 } from "../../src/index";
 
-import { range, last } from "lodash";
-
-const y = (x) => Math.sin(x / 10);
-const initData = () => range(70).map((x) => ({ x, y: y(x) }));
+import { range, random } from "lodash";
 
 class App extends React.Component {
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
     this.state = {
-      data: initData(),
-      zoomDomain: null
+      lineData: this.getData(),
+      numericBarData: this.getNumericBarData(),
+      barData: this.getBarData(),
+      barTransitionData: this.getBarTransitionData(),
+      multiBarTransitionData: this.getMultiBarTransitionData(),
     };
-
-    setInterval(() => {
-      const { data } = this.state;
-      const x = last(data).x + 1;
-
-      if (x > 1000) {
-        this.setState({ data: initData() });
-      } else {
-        data.push({ x, y: y(x) });
-        this.setState({ data });
-      }
-    }, 20);
   }
+
+  componentDidMount() {
+    /* eslint-disable react/no-did-mount-set-state */
+    this.setStateInterval = window.setInterval(() => {
+      this.setState({
+        lineData: this.getData(),
+        barData: this.getBarData(),
+        barTransitionData: this.getBarTransitionData(),
+        multiBarTransitionData: this.getMultiBarTransitionData(),
+        numericBarData: this.getNumericBarData(),
+      });
+    }, 4000);
+  }
+
+  componentWillUnmount() {
+    window.clearInterval(this.setStateInterval);
+  }
+
+  getData() {
+    return range(20).map((i) => {
+      return {
+        x: i,
+        y: Math.random()
+      };
+    });
+  }
+
+  getNumericBarData() {
+    return range(5).map(() => {
+      return [
+        {
+          x: random(1, 3),
+          y: random(1, 5)
+        },
+        {
+          x: random(4, 7),
+          y: random(1, 10)
+        },
+        {
+          x: random(9, 11),
+          y: random(1, 15)
+        }
+      ];
+    });
+  }
+
+  getBarData() {
+    return range(5).map(() => {
+      return [
+        {
+          x: "apples",
+          y: random(2, 5)
+        },
+        {
+          x: "bananas",
+          y: random(2, 10)
+        },
+        {
+          x: "oranges",
+          y: random(0, 15)
+        }
+      ];
+    });
+  }
+
+  getBarTransitionData() {
+    const bars = random(6, 10);
+    return range(bars).map((bar) => {
+      return { x: bar, y: random(2, 10) };
+    });
+  }
+
+  getMultiBarTransitionData() {
+    const bars = random(6, 10);
+    return range(5).map(() => {
+      return range(bars).map((bar) => {
+        return { x: bar, y: random(2, 10) };
+      });
+    });
+  }
+
   render() {
+    const containerStyle = {
+      display: "flex",
+      flexDirection: "row",
+      flexWrap: "wrap",
+      alignItems: "center",
+      justifyContent: "center"
+    };
+    const chartStyle = { parent: { border: "1px solid #ccc", margin: "2%", maxWidth: "40%" } };
+    const axisStyle = {
+      grid: { stroke: "grey", strokeWidth: 1 },
+      axis: { stroke: "transparent" },
+      ticks: { stroke: "transparent" },
+      tickLabels: { fill: "none" }
+    };
     return (
-      <div style={{ maxWidth: 500 }}>
-        <VictoryChart containerComponent={<VictoryZoomContainer dimension="x" />}>
-          <VictoryLine
-            data={this.state.data}
-          />
-          <VictoryLine
-            data={this.state.data}
-          />
-        </VictoryChart>
+      <div className="demo">
+        <h1>VictoryChart</h1>
+        <div style={containerStyle}>
+          <VictoryChart style={chartStyle}
+            padding={{ top: 80, bottom: 10, left: 80, right: 10 }}
+          >
+            <VictoryAxis label={"A LABEL"} dependentAxis/>
+            <VictoryAxis label={"A LABEL"}/>
+            <VictoryLine y={(d) => 0.5 * d.x + 0.5} style={{ data: { stroke: "red" } }}/>
+            <VictoryScatter y={(d) => d.x * d.x} style={{ data: { stroke: "red" } }}/>
+          </VictoryChart>
+
+          <VictoryChart style={chartStyle}>
+            <VictoryAxis label={"A LABEL"} dependentAxis orientation="right" invertAxis/>
+            <VictoryAxis label={"A LABEL"} orientation="top" invertAxis/>
+            <VictoryLine y={(d) => 0.5 * d.x + 0.5} style={{ data: { stroke: "red" } }}/>
+            <VictoryScatter y={(d) => d.x * d.x} style={{ data: { stroke: "red" } }}/>
+          </VictoryChart>
+
+          <VictoryChart style={chartStyle} domain={[-10, 10]}>
+            <VictoryAxis dependentAxis orientation="right"/>
+            <VictoryAxis orientation="top"/>
+            <VictoryLine y={(d) => 0.5 * d.x + 0.5} style={{ data: { stroke: "red" } }}/>
+            <VictoryScatter y={(d) => d.x * d.x} style={{ data: { stroke: "red" } }}/>
+          </VictoryChart>
+
+          <VictoryChart style={chartStyle} domain={{ x: [-10, 10], y: [-2, 10] }}>
+            <VictoryAxis dependentAxis orientation="right"/>
+            <VictoryAxis orientation="top"/>
+            <VictoryLine y={(d) => 0.5 * d.x + 0.5} style={{ data: { stroke: "red" } }}/>
+            <VictoryScatter y={(d) => d.x * d.x} style={{ data: { stroke: "red" } }}/>
+          </VictoryChart>
+
+          <VictoryChart style={chartStyle}>
+            <VictoryScatter
+              data={[{ x: 3, y: 3 }]}
+            />
+            <VictoryAxis
+              tickValues={[3]}
+            />
+          </VictoryChart>
+        </div>
       </div>
     );
   }

--- a/src/components/victory-axis/helper-methods.js
+++ b/src/components/victory-axis/helper-methods.js
@@ -265,7 +265,7 @@ export default {
     const x = isVertical ? globalTransform.x + (sign * labelPadding) :
       ((props.width - hPadding) / 2) + padding.left + globalTransform.x;
     const y = isVertical ?
-      ((props.height - vPadding) / 2) + padding.bottom + globalTransform.y :
+      ((props.height - vPadding) / 2) + padding.top + globalTransform.y :
       (sign * labelPadding) + globalTransform.y;
 
     return {

--- a/src/components/victory-axis/helper-methods.js
+++ b/src/components/victory-axis/helper-methods.js
@@ -280,15 +280,19 @@ export default {
   },
 
   getTicks(props, scale) {
-    const { tickValues, tickCount, crossAxis } = props;
-    if (props.tickValues) {
-      if (Helpers.stringTicks(props)) {
-        return range(1, props.tickValues.length + 1);
-      }
-      return tickValues.length ? tickValues : scale.domain();
+    const { tickCount, crossAxis } = props;
+    const tickValues = props.tickValues || props.tickFormat;
+    if (Array.isArray(tickValues) && tickValues.length) {
+      return Helpers.stringTicks(props) ?
+        Axis.downsampleTicks(range(1, props.tickValues.length + 1), tickCount) :
+        Axis.downsampleTicks(tickValues, tickCount);
     } else if (scale.ticks && isFunction(scale.ticks)) {
-      const scaleTicks = scale.ticks(tickCount);
-      const ticks = Array.isArray(scaleTicks) && scaleTicks.length ? scaleTicks : scale.domain();
+      // eslint-disable-next-line no-magic-numbers
+      const defaultTickCount = tickCount || 5;
+      const scaleTicks = scale.ticks(defaultTickCount);
+      const tickArray = Array.isArray(scaleTicks) && scaleTicks.length ?
+        scaleTicks : scale.domain();
+      const ticks = Axis.downsampleTicks(tickArray, tickCount);
       if (crossAxis) {
         const filteredTicks = includes(ticks, 0) ? without(ticks, 0) : ticks;
         return filteredTicks.length ? filteredTicks : ticks;

--- a/src/components/victory-axis/helper-methods.js
+++ b/src/components/victory-axis/helper-methods.js
@@ -281,8 +281,8 @@ export default {
 
   getTicks(props, scale) {
     const { tickCount, crossAxis } = props;
-    const tickValues = props.tickValues || props.tickFormat;
-    if (Array.isArray(tickValues) && tickValues.length) {
+    const tickValues = Axis.getTickArray(props.tickValues, props.tickFormat);
+    if (tickValues) {
       return Helpers.stringTicks(props) ?
         Axis.downsampleTicks(range(1, props.tickValues.length + 1), tickCount) :
         Axis.downsampleTicks(tickValues, tickCount);

--- a/src/components/victory-axis/victory-axis.js
+++ b/src/components/victory-axis/victory-axis.js
@@ -64,6 +64,7 @@ class VictoryAxis extends React.Component {
     fixLabelOverlap: PropTypes.bool,
     gridComponent: PropTypes.element,
     groupComponent: PropTypes.element,
+    invertAxis: PropTypes.bool,
     label: PropTypes.any,
     offsetX: PropTypes.number,
     offsetY: PropTypes.number,

--- a/src/components/victory-axis/victory-axis.js
+++ b/src/components/victory-axis/victory-axis.js
@@ -92,7 +92,6 @@ class VictoryAxis extends React.Component {
     scale: "linear",
     standalone: true,
     theme: VictoryTheme.grayscale,
-    tickCount: 5,
     containerComponent: <VictoryContainer />,
     groupComponent: <g role="presentation"/>,
     fixLabelOverlap: false

--- a/src/components/victory-chart/helper-methods.js
+++ b/src/components/victory-chart/helper-methods.js
@@ -78,8 +78,8 @@ export default {
     const { top, bottom, left, right } = padding;
     // make the axes line up, and cross when appropriate
     const axisOrientations = {
-      x: Axis.getOrientation(axisComponents.x, "x", originSign.x),
-      y: Axis.getOrientation(axisComponents.y, "y", originSign.y)
+      x: Axis.getOrientation(axisComponents.x, "x", originSign.y),
+      y: Axis.getOrientation(axisComponents.y, "y", originSign.x)
     };
     const orientationOffset = {
       y: axisOrientations.x === "bottom" ? bottom : top,

--- a/src/components/victory-chart/helper-methods.js
+++ b/src/components/victory-chart/helper-methods.js
@@ -106,7 +106,7 @@ export default {
     };
   },
 
-  getTicksFromData(calculatedProps, axis) {
+  getTicksFromData(calculatedProps, axis, axisComponent) {
     const currentAxis = Helpers.getCurrentAxis(axis, calculatedProps.horizontal);
     const stringMap = calculatedProps.stringMap[currentAxis];
     // if tickValues are defined for an axis component use them
@@ -115,19 +115,23 @@ export default {
       categoryArray.map((tick) => stringMap[tick]) : categoryArray;
     const ticksFromStringMap = stringMap && values(stringMap);
     // when ticks is undefined, axis will determine its own ticks
-    return ticksFromCategories && ticksFromCategories.length !== 0 ?
+    const ticks = ticksFromCategories && ticksFromCategories.length !== 0 ?
       ticksFromCategories : ticksFromStringMap;
+    const tickCount = axisComponent && axisComponent.props && axisComponent.props.tickCount;
+    return Axis.downsampleTicks(ticks, tickCount);
   },
 
-  getTicksFromAxis(calculatedProps, axis, component) {
-    const tickValues = component.props.tickValues;
-    if (!tickValues) {
+  getTicksFromAxis(calculatedProps, axis, axisComponent) {
+    const axisProps = axisComponent && axisComponent.props || {};
+    const tickArray = axisProps.tickValues || axisProps.tickFormat;
+    if (!Array.isArray(tickArray)) {
       return undefined;
     }
     const currentAxis = Helpers.getCurrentAxis(axis, calculatedProps.horizontal);
     const stringMap = calculatedProps.stringMap[currentAxis];
-    return Collection.containsOnlyStrings(tickValues) && stringMap ?
-      tickValues.map((tick) => stringMap[tick]) : tickValues;
+    const ticks = Collection.containsOnlyStrings(tickArray) && stringMap ?
+      tickArray.map((tick) => stringMap[tick]) : tickArray;
+    return Axis.downsampleTicks(ticks, axisProps.tickCount);
   },
 
   getTicks(...args) {

--- a/src/components/victory-chart/victory-chart.js
+++ b/src/components/victory-chart/victory-chart.js
@@ -183,9 +183,11 @@ export default class VictoryChart extends React.Component {
 
     const defaultDomainPadding = ChartHelpers.getDefaultDomainPadding(childComponents, horizontal);
 
+    const padding = Helpers.getPadding(props);
+
     return {
       axisComponents, categories, domain, range, horizontal, scale, stringMap,
-      style, origin, originSign, defaultDomainPadding
+      style, origin, originSign, defaultDomainPadding, padding
     };
   }
 
@@ -203,7 +205,7 @@ export default class VictoryChart extends React.Component {
         height, polar, theme, width, style,
         origin: polar ? origin : undefined,
         animate: getAnimationProps(props, child, index),
-        padding: Helpers.getPadding(props),
+        padding: calculatedProps.padding,
         key: index,
         standalone: false
       }, childProps);

--- a/src/components/victory-chart/victory-chart.js
+++ b/src/components/victory-chart/victory-chart.js
@@ -100,6 +100,7 @@ export default class VictoryChart extends React.Component {
   getAxisProps(child, props, calculatedProps) {
     const { domain, scale, originSign, stringMap } = calculatedProps;
     const axis = child.type.getAxis(child.props);
+    const otherAxis = axis === "x" ? "y" : "x";
     const axisOffset = ChartHelpers.getAxisOffset(props, calculatedProps);
     const tickValues = ChartHelpers.getTicks(calculatedProps, axis, child);
     const tickFormat = child.props.tickFormat ?
@@ -108,7 +109,7 @@ export default class VictoryChart extends React.Component {
     const offsetY = axis === "y" ? undefined : axisOffset.y;
     const offsetX = axis === "x" ? undefined : axisOffset.x;
     const crossAxis = child.props.crossAxis === false ? false : true;
-    const orientation = Axis.getOrientation(child, axis, originSign[axis]);
+    const orientation = Axis.getOrientation(child, axis, originSign[otherAxis]);
     return {
       startAngle: props.startAngle,
       endAngle: props.endAngle,

--- a/src/components/victory-polar-axis/helper-methods.js
+++ b/src/components/victory-polar-axis/helper-methods.js
@@ -327,8 +327,8 @@ export default {
 
   getTicks(props, scale) {
     const { tickCount } = props;
-    const tickValues = props.tickValues || props.tickFormat;
-    if (Array.isArray(tickValues) && tickValues.length) {
+    const tickValues = Axis.getTickArray(props.tickValues, props.tickFormat);
+    if (tickValues) {
       return Helpers.stringTicks(props) ?
         Axis.downsampleTicks(lodashRange(1, tickValues.length + 1), tickCount) :
         Axis.downsampleTicks(tickValues, tickCount);

--- a/src/components/victory-polar-axis/helper-methods.js
+++ b/src/components/victory-polar-axis/helper-methods.js
@@ -1,6 +1,7 @@
 import {
   assign, uniqBy, includes, defaults, defaultsDeep, isFunction, range as lodashRange, without
 } from "lodash";
+import Axis from "../../helpers/axis";
 import { Helpers, LabelHelpers, Scale, Domain, Collection } from "victory-core";
 
 export default {
@@ -325,15 +326,19 @@ export default {
   },
 
   getTicks(props, scale) {
-    const { tickValues, tickCount } = props;
-    if (tickValues && Array.isArray(tickValues)) {
-      if (Helpers.stringTicks(props)) {
-        return lodashRange(1, props.tickValues.length + 1);
-      }
-      return tickValues.length ? tickValues : scale.domain();
+    const { tickCount } = props;
+    const tickValues = props.tickValues || props.tickFormat;
+    if (Array.isArray(tickValues) && tickValues.length) {
+      return Helpers.stringTicks(props) ?
+        Axis.downsampleTicks(lodashRange(1, tickValues.length + 1), tickCount) :
+        Axis.downsampleTicks(tickValues, tickCount);
     } else if (scale.ticks && isFunction(scale.ticks)) {
-      const scaleTicks = scale.ticks(tickCount);
-      const ticks = Array.isArray(scaleTicks) && scaleTicks.length ? scaleTicks : scale.domain();
+      // eslint-disable-next-line no-magic-numbers
+      const defaultTickCount = tickCount || 5;
+      const scaleTicks = scale.ticks(defaultTickCount);
+      const tickArray = Array.isArray(scaleTicks) && scaleTicks.length ?
+        scaleTicks : scale.domain();
+      const ticks = Axis.downsampleTicks(tickArray, tickCount);
       const filteredTicks = includes(ticks, 0) ? without(ticks, 0) : ticks;
       return filteredTicks.length ? filteredTicks : ticks;
     }

--- a/src/components/victory-polar-axis/victory-polar-axis.js
+++ b/src/components/victory-polar-axis/victory-polar-axis.js
@@ -95,7 +95,6 @@ class VictoryPolarAxis extends React.Component {
     standalone: true,
     theme: VictoryTheme.grayscale,
     tickComponent: <Line type={"tick"}/>,
-    tickCount: 5,
     tickLabelComponent: <VictoryLabel/>
   };
 

--- a/src/helpers/axis.js
+++ b/src/helpers/axis.js
@@ -140,17 +140,6 @@ export default {
   },
 
   /**
-   * @param {Array} childComponents: an array of children
-   * @returns {Object} an object with orientations specified for x and y
-   */
-  getAxisOrientations(childComponents) {
-    return {
-      x: this.getOrientation(this.getAxisComponent(childComponents, "x"), "x"),
-      y: this.getOrientation(this.getAxisComponent(childComponents, "y"), "y")
-    };
-  },
-
-  /**
    * @param {Object} props: axis component props
    * @returns {Boolean} true when the axis is vertical
    */

--- a/src/helpers/axis.js
+++ b/src/helpers/axis.js
@@ -176,5 +176,13 @@ export default {
     } else {
       return (x) => x;
     }
+  },
+
+  downsampleTicks(ticks, tickCount) {
+    if (!tickCount || !Array.isArray(ticks) || ticks.length <= tickCount) {
+      return ticks;
+    }
+    const k = Math.floor(ticks.length / tickCount);
+    return ticks.filter((d, i) => i % k === 0);
   }
 };

--- a/src/helpers/axis.js
+++ b/src/helpers/axis.js
@@ -1,5 +1,5 @@
 import { Collection } from "victory-core";
-import { identity, isFunction, invert } from "lodash";
+import { identity, isFunction, invert, uniq } from "lodash";
 import React from "react";
 
 export default {
@@ -176,6 +176,11 @@ export default {
     } else {
       return (x) => x;
     }
+  },
+
+  getTickArray(tickValues, tickFormat) {
+    const tickArray = tickValues ? uniq(tickValues) : tickFormat;
+    return Array.isArray(tickArray) && tickArray.length ? tickArray : undefined;
   },
 
   downsampleTicks(ticks, tickCount) {


### PR DESCRIPTION
**Breaking Changes**
- adds an `invertAxis` prop for `VictoryAxis` that will flip the domain of a given axis when true. Changing the `orientation` prop of a given axis will no longer flip the domain on that axis _unless_ the `invertAxis` prop is also set. Closes https://github.com/FormidableLabs/victory/issues/739
- `tickFormat` as an array will set the number of ticks if `tickValues` are not given. Closes https://github.com/FormidableLabs/victory/issues/424
- `tickValues` will be forced to a unique array. `tickFormat` may still have non-unique values. Fixes https://github.com/FormidableLabs/victory/issues/475
- `tickCount` will now always have an effect when set. Previously, this prop would do nothing when `tickValues` were provided. Now `tickCount` will downsample any array provided to either `tickValues` or `tickFormat`. Closes https://github.com/FormidableLabs/victory/issues/730

- Fixes https://github.com/FormidableLabs/victory/issues/780
- Fixes https://github.com/FormidableLabs/victory/issues/697

