### PR TITLE
Updated default export of selection-helpers.js

### DIFF
--- a/src/components/containers/selection-helpers.js
+++ b/src/components/containers/selection-helpers.js
@@ -147,6 +147,7 @@ const SelectionHelpers = {
 };
 
 export default {
+  ...SelectionHelpers,
   onMouseDown: SelectionHelpers.onMouseDown.bind(SelectionHelpers),
   onMouseUp: SelectionHelpers.onMouseUp.bind(SelectionHelpers),
   onMouseMove: throttle(


### PR DESCRIPTION
Following this pattern https://github.com/FormidableLabs/victory-chart/blob/master/src/components/containers/brush-helpers.js#L261 of exporting the helper functions so that code can be re-used.