### PR TITLE
VictoryGroup fails to render children

### DIFF
--- a/src/components/victory-group/victory-group.js
+++ b/src/components/victory-group/victory-group.js
@@ -178,7 +178,7 @@ export default class VictoryGroup extends React.Component {
     const dataset = props.data || props.y ? Data.getData(props) : defaultDataset;
     const xOffset = offset || 0;
     return dataset.map((datum) => {
-      const _x1 = datum._x instanceof Date ? new Date(datum._x + xOffset) : datum._x + xOffset;
+      const _x1 = datum._x instanceof Date ? new Date(datum._x.getTime() + xOffset) : datum._x + xOffset;
       return assign({}, datum, { _x1 });
     });
   }

--- a/src/components/victory-group/victory-group.js
+++ b/src/components/victory-group/victory-group.js
@@ -178,7 +178,10 @@ export default class VictoryGroup extends React.Component {
     const dataset = props.data || props.y ? Data.getData(props) : defaultDataset;
     const xOffset = offset || 0;
     return dataset.map((datum) => {
-      const _x1 = datum._x instanceof Date ? new Date(datum._x.getTime() + xOffset) : datum._x + xOffset;
+      const _x1 = datum._x instanceof Date
+        ? new Date(datum._x.getTime() + xOffset)
+        : datum._x + xOffset;
+
       return assign({}, datum, { _x1 });
     });
   }


### PR DESCRIPTION
Apparently using a constructor with the plus syntax (or invalid values that eventually get into this
code path) result in VictoryGroup being unable to render children properly and displaying empty
graphs. This change invokes `getTime()` first after the `instanceof Date` check which should always
succeed.

See: FormidableLabs/victory-native#128, FormidableLabs/victory#728 and FormidableLabs/victory#438