### PR TITLE
Fix panning of zoomed area. Remove duplicate code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ node_modules
 npm-debug.log*
 yarn.lock
 yarn-error.log*
+
+#Webstorm
+.idea

--- a/demo/components/victory-axis-demo.js
+++ b/demo/components/victory-axis-demo.js
@@ -81,7 +81,8 @@ export default class App extends React.Component {
             <VictoryAxis
               style={{
                 parent: styleOverrides.parent,
-                grid: { stroke: "#CFD8DC" }
+                grid: { stroke: "#CFD8DC" },
+                tickLabels: { "xml:space": "preserve" }
               }}
               padding={60}
               label={"animation\nwow!"}

--- a/demo/components/victory-brush-container-demo.js
+++ b/demo/components/victory-brush-container-demo.js
@@ -2,14 +2,18 @@
 import React from "react";
 import {
   VictoryChart, VictoryGroup, VictoryStack, VictoryScatter, VictoryBar, VictoryLine,
-  VictoryBrushContainer, VictoryZoomContainer, VictoryAxis
+  VictoryBrushContainer, VictoryAxis, createContainer
 } from "../../src/index";
 import { VictoryLegend } from "victory-core";
+
+const CustomContainer = createContainer("zoom", "cursor");
 
 class App extends React.Component {
   constructor() {
     super();
-    this.state = {};
+    this.state = {
+      zoomDomain: { x: [new Date(1990, 1, 1), new Date(2009, 1, 1)] }
+    };
   }
 
   handleZoom(domain) {
@@ -32,7 +36,7 @@ class App extends React.Component {
         <div style={containerStyle}>
           <VictoryChart width={800} height={500} scale={{ x: "time" }}
             containerComponent={
-              <VictoryZoomContainer responsive={false}
+              <CustomContainer responsive={false}
                 zoomDomain={this.state.zoomDomain}
                 zoomDimension="x"
                 onZoomDomainChange={this.handleZoom.bind(this)}

--- a/src/components/containers/brush-helpers.js
+++ b/src/components/containers/brush-helpers.js
@@ -1,11 +1,11 @@
 import { Selection } from "victory-core";
-import { assign, throttle, isFunction, isEqual, defaults } from "lodash";
+import { assign, throttle, isFunction, isEqual, defaults, mapValues } from "lodash";
 import { attachId } from "../../helpers/event-handlers";
 
 const Helpers = {
   withinBounds(point, bounds, padding) {
-    const { x1, x2, y1, y2 } = bounds;
-    const { x, y } = point;
+    const { x1, x2, y1, y2 } = mapValues(bounds, Number);
+    const { x, y } = mapValues(point, Number);
     padding = padding ? padding / 2 : 0;
     return x + padding >= Math.min(x1, x2) &&
       x - padding <= Math.max(x1, x2) &&
@@ -101,7 +101,7 @@ const Helpers = {
   },
 
   constrainBox(box, fullDomainBox) {
-    const { x1, y1, x2, y2 } = fullDomainBox;
+    const { x1, y1, x2, y2 } = mapValues(fullDomainBox, Number);
     return {
       x1: box.x2 > x2 ? x2 - Math.abs(box.x2 - box.x1) : Math.max(box.x1, x1),
       y1: box.y2 > y2 ? y2 - Math.abs(box.y2 - box.y1) : Math.max(box.y1, y1),
@@ -186,7 +186,7 @@ const Helpers = {
       allowResize, allowDrag
     } = targetProps;
     const { x, y } = Selection.getSVGEventCoordinates(evt);
-      // Ignore events that occur outside of the maximum domain region
+    // Ignore events that occur outside of the maximum domain region
     if ((!allowResize && !allowDrag) || !this.withinBounds({ x, y }, fullDomainBox)) {
       return {};
     }

--- a/src/components/containers/container-helpers.js
+++ b/src/components/containers/container-helpers.js
@@ -135,12 +135,16 @@ const Helpers = {
 
   getSelectedData(dataset, bounds) {
     const { x, y } = bounds;
-    const withinBounds = (d) => {
-      return d._x >= x[0] && d._x <= x[1] && d._y >= y[0] && d._y <= y[1];
+    const bounds2 = {
+      x1: x[0],
+      x2: x[1],
+      y1: y[0],
+      y2: y[1]
     };
 
     const selectedData = dataset.reduce((accum, datum, index) => {
-      if (withinBounds(datum)) {
+      const point = { x: datum._x, y: datum._y };
+      if (this.withinBounds(point, bounds2)) {
         accum.data.push(datum);
         accum.eventKey.push(datum.eventKey === undefined ? index : datum.eventKey);
       }

--- a/src/components/containers/container-helpers.js
+++ b/src/components/containers/container-helpers.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { isFunction } from "lodash";
+import { isFunction, mapValues } from "lodash";
 import { Data, Collection } from "victory-core";
 
 const Helpers = {
@@ -155,8 +155,8 @@ const Helpers = {
   },
 
   withinBounds(point, bounds, padding) {
-    const { x1, x2, y1, y2 } = bounds;
-    const { x, y } = point;
+    const { x1, x2, y1, y2 } = mapValues(bounds, Number);
+    const { x, y } = mapValues(point, Number);
     padding = padding ? padding / 2 : 0;
     return x + padding >= Math.min(x1, x2) &&
       x - padding <= Math.max(x1, x2) &&

--- a/src/components/containers/container-helpers.js
+++ b/src/components/containers/container-helpers.js
@@ -1,0 +1,190 @@
+import React from "react";
+import { isFunction } from "lodash";
+import { Data, Collection } from "victory-core";
+
+const Helpers = {
+  getParentSVG(target) {
+    if (target.nodeName === "svg") {
+      return target;
+    } else {
+      return this.getParentSVG(target.parentNode);
+    }
+  },
+
+  getTransformationMatrix(svg) {
+    return svg.getScreenCTM().inverse();
+  },
+
+  getSVGEventCoordinates(evt) {
+    if (typeof document === "undefined") {
+      // react-native override. relies on the RN.View being the _exact_ same size as its child SVG.
+      // this should be fine: the svg is the only child of View and the View shirks to its children
+      return {
+        x: evt.nativeEvent.locationX,
+        y: evt.nativeEvent.locationY
+      };
+    }
+    evt = evt.changedTouches && evt.changedTouches.length ? evt.changedTouches[0] : evt;
+    const svg = this.getParentSVG(evt.target);
+    const matrix = this.getTransformationMatrix(svg);
+    return {
+      x: this.transformTarget(evt.clientX, matrix, "x"),
+      y: this.transformTarget(evt.clientY, matrix, "y")
+    };
+  },
+
+  transformTarget(target, matrix, dimension) {
+    const { a, d, e, f } = matrix;
+    return dimension === "y" ?
+      d * target + f : a * target + e;
+  },
+
+  getDomainCoordinates(props, domain) {
+    const { scale } = props;
+    domain = domain || { x: scale.x.domain(), y: scale.y.domain() };
+    return {
+      x: [scale.x(domain.x[0]), scale.x(domain.x[1])],
+      y: [scale.y(domain.y[0]), scale.y(domain.y[1])]
+    };
+  },
+
+  // eslint-disable-next-line max-params
+  getDataCoordinates(props, scale, x, y) {
+    const { polar } = props;
+    if (!polar) {
+      return {
+        x: scale.x.invert(x),
+        y: scale.y.invert(y)
+      };
+    } else {
+      const origin = props.origin || { x: 0, y: 0 };
+      const baseX = x - origin.x;
+      const baseY = y - origin.y;
+      const radius = Math.abs(baseX * Math.sqrt(1 + Math.pow((-baseY / baseX), 2)));
+      const angle = (-Math.atan2(baseY, baseX) + (Math.PI * 2)) % (Math.PI * 2);
+      return {
+        x: scale.x.invert(angle),
+        y: scale.y.invert(radius)
+      };
+    }
+  },
+
+  getBounds(props) {
+    const { x1, x2, y1, y2, scale } = props;
+    const point1 = this.getDataCoordinates(props, scale, x1, y1);
+    const point2 = this.getDataCoordinates(props, scale, x2, y2);
+    const makeBound = (a, b) => {
+      return [ Collection.getMinValue([a, b]), Collection.getMaxValue([a, b]) ];
+    };
+
+    return {
+      x: makeBound(point1.x, point2.x),
+      y: makeBound(point1.y, point2.y)
+    };
+  },
+
+  getDatasets(props) { // eslint-disable-line max-statements
+    if (props.data) {
+      return [{ data: props.data }];
+    }
+    const getData = (childProps) => {
+      const data = Data.getData(childProps);
+      return Array.isArray(data) && data.length > 0 ? data : undefined;
+    };
+
+    // Reverse the child array to maintain correct order when looping over
+    // children starting from the end of the array.
+    const children = React.Children.toArray(props.children).reverse();
+    let childrenLength = children.length;
+    const dataArr = [];
+    let dataArrLength = 0;
+    let childIndex = 0;
+    while (childrenLength > 0) {
+      const child = children[--childrenLength];
+      const childName = child.props.name || childIndex;
+      childIndex++;
+      if (child.type && child.type.role === "axis") {
+        childIndex++;
+      } else if (child.type && isFunction(child.type.getData)) {
+        dataArr[dataArrLength++] = { childName, data: child.type.getData(child.props) };
+      } else if (child.props && child.props.children) {
+        const newChildren = React.Children.toArray(child.props.children);
+        const newChildrenLength = newChildren.length;
+        for (let index = 0; index < newChildrenLength; index++) {
+          children[childrenLength++] = newChildren[index];
+        }
+      } else {
+        dataArr[dataArrLength++] = { childName, data: getData(child.props) };
+      }
+    }
+    return dataArr;
+  },
+
+  filterDatasets(datasets, bounds) {
+    const filtered = datasets.reduce((memo, dataset) => {
+      const selectedData = this.getSelectedData(dataset.data, bounds);
+      memo = selectedData ?
+        memo.concat({
+          childName: dataset.childName, eventKey: selectedData.eventKey, data: selectedData.data
+        }) :
+        memo;
+      return memo;
+    }, []);
+    return filtered.length ? filtered : null;
+  },
+
+  getSelectedData(dataset, bounds) {
+    const { x, y } = bounds;
+    const withinBounds = (d) => {
+      return d._x >= x[0] && d._x <= x[1] && d._y >= y[0] && d._y <= y[1];
+    };
+
+    const selectedData = dataset.reduce((accum, datum, index) => {
+      if (withinBounds(datum)) {
+        accum.data.push(datum);
+        accum.eventKey.push(datum.eventKey === undefined ? index : datum.eventKey);
+      }
+
+      return accum;
+    }, {
+      data: [],
+      eventKey: []
+    });
+
+    return selectedData.data.length > 0 ? selectedData : null;
+  },
+
+  withinBounds(point, bounds, padding) {
+    const { x1, x2, y1, y2 } = bounds;
+    const { x, y } = point;
+    padding = padding ? padding / 2 : 0;
+    return x + padding >= Math.min(x1, x2) &&
+      x - padding <= Math.max(x1, x2) &&
+      y + padding >= Math.min(y1, y2) &&
+      y - padding <= Math.max(y1, y2);
+  },
+
+  checkDomainEquality(a, b) {
+    const checkDimension = (dim) => {
+      const val1 = a && a[dim];
+      const val2 = b && b[dim];
+      if (!val1 && !val2) {
+        return true;
+      } else if (!val1 || !val2) {
+        return false;
+      }
+      return +val1[0] === +val2[0] && +val1[1] === +val2[1];
+    };
+    return checkDimension("x") && checkDimension("y");
+  }
+};
+
+export default {
+  getSVGEventCoordinates: Helpers.getSVGEventCoordinates.bind(Helpers),
+  getDomainCoordinates: Helpers.getDomainCoordinates.bind(Helpers),
+  getBounds: Helpers.getBounds.bind(Helpers),
+  withinBounds: Helpers.withinBounds.bind(Helpers),
+  getDataCoordinates: Helpers.getDataCoordinates.bind(Helpers),
+  checkDomainEquality: Helpers.checkDomainEquality.bind(Helpers)
+};
+

--- a/src/components/containers/cursor-helpers.js
+++ b/src/components/containers/cursor-helpers.js
@@ -1,7 +1,7 @@
 import { Selection } from "victory-core";
 import { throttle, isFunction } from "lodash";
 import { attachId } from "../../helpers/event-handlers";
-import BrushHelpers from "./brush-helpers";
+import ContainerHelpers from "./container-helpers";
 
 const CursorHelpers = {
   onMouseMove(evt, targetProps) {
@@ -14,12 +14,16 @@ const CursorHelpers = {
       cursorSVGPosition.y
     );
 
-    const inBounds = BrushHelpers.withinBounds(cursorValue, {
+    const inBounds = ContainerHelpers.withinBounds(cursorValue, {
       x1: domain.x[0],
       x2: domain.x[1],
       y1: domain.y[0],
       y2: domain.y[1]
     });
+    // console.log("//////");
+    // console.log(inBounds);
+    // console.log(cursorValue);
+    // console.log(targetProps);
 
     if (!inBounds) {
       cursorValue = null;

--- a/src/components/containers/selection-helpers.js
+++ b/src/components/containers/selection-helpers.js
@@ -2,6 +2,7 @@ import { Selection, Data, Helpers } from "victory-core";
 import { assign, defaults, throttle, isFunction } from "lodash";
 import React from "react";
 import { attachId } from "../../helpers/event-handlers";
+import ContainerHelpers from "./container-helpers";
 
 const SelectionHelpers = {
   getDatasets(props) {
@@ -43,23 +44,17 @@ const SelectionHelpers = {
   },
 
   getSelectedData(props, dataset) {
-    const { x1, y1, x2, y2 } = props;
-    const withinBounds = (d) => {
-      const scaledPoint = Helpers.scalePoint(props, d);
-      return scaledPoint.x >= Math.min(x1, x2) && scaledPoint.x <= Math.max(x1, x2) &&
-        scaledPoint.y >= Math.min(y1, y2) && scaledPoint.y <= Math.max(y1, y2);
-    };
     const eventKey = [];
     const data = [];
     let count = 0;
-    for (let index = 0, len = dataset.length; index < len; index++) {
-      const datum = dataset[index];
-      if (withinBounds(datum)) {
+    dataset.forEach((datum, index) => {
+      const scaledPoint = Helpers.scalePoint(props, datum);
+      if (ContainerHelpers.withinBounds(scaledPoint, props)) {
         data[count] = datum;
         eventKey[count] = datum.eventKey === undefined ? index : datum.eventKey;
         count++;
       }
-    }
+    });
     return count > 0 ? { eventKey, data } : null;
   },
 

--- a/src/components/containers/victory-brush-container.js
+++ b/src/components/containers/victory-brush-container.js
@@ -2,7 +2,8 @@ import PropTypes from "prop-types";
 import React from "react";
 import { VictoryContainer, Selection } from "victory-core";
 import BrushHelpers from "./brush-helpers";
-import { assign, defaults, isEqual } from "lodash";
+import ContainerHelpers from "./container-helpers";
+import { assign, defaults } from "lodash";
 
 export const brushContainerMixin = (base) => class VictoryBrushContainer extends base {
   static displayName = "VictoryBrushContainer";
@@ -128,7 +129,7 @@ export const brushContainerMixin = (base) => class VictoryBrushContainer extends
   getRect(props) {
     const { currentDomain, cachedBrushDomain } = props;
     const brushDomain = defaults({}, props.brushDomain, props.domain);
-    const domain = isEqual(brushDomain, cachedBrushDomain) ?
+    const domain = ContainerHelpers.checkDomainEquality(brushDomain, cachedBrushDomain) ?
       defaults({}, currentDomain, brushDomain) : brushDomain;
     const coordinates = Selection.getDomainCoordinates(props, domain);
     const selectBox = this.getSelectBox(props, coordinates);

--- a/src/components/containers/victory-zoom-container.js
+++ b/src/components/containers/victory-zoom-container.js
@@ -170,14 +170,8 @@ export const zoomContainerMixin = (base) => class VictoryZoomContainer extends b
       const originalDomain = defaults({}, props.originalDomain, props.domain);
       const zoomDomain = defaults({}, props.zoomDomain, props.domain);
       const cachedZoomDomain = defaults({}, props.cachedZoomDomain, props.domain);
-      const checkDomainEquality = (a, b) => {
-        return +a.x[0] === +b.x[0] &&
-          +a.x[1] === +b.x[1] &&
-          +a.y[0] === +b.y[0] &&
-          +a.y[1] === +b.y[1];
-      };
       let domain;
-      if (!checkDomainEquality(zoomDomain, cachedZoomDomain)) {
+      if (!ZoomHelpers.checkDomainEquality(zoomDomain, cachedZoomDomain)) {
         // if zoomDomain has been changed, use it
         domain = zoomDomain;
       } else if (allowZoom && !zoomActive) {
@@ -196,7 +190,7 @@ export const zoomContainerMixin = (base) => class VictoryZoomContainer extends b
           [props.zoomDimension]: newDomain[props.zoomDimension]
         };
       }
-      const newChild = React.cloneElement(
+      return React.cloneElement(
         currentChild,
         defaults({
           domain: newDomain,
@@ -204,7 +198,6 @@ export const zoomContainerMixin = (base) => class VictoryZoomContainer extends b
             undefined : this.downsampleZoomData(props, currentChild.props, newDomain)
         }, currentChild.props)
       );
-      return newChild;
     });
   }
 

--- a/src/components/containers/victory-zoom-container.js
+++ b/src/components/containers/victory-zoom-container.js
@@ -2,6 +2,7 @@ import PropTypes from "prop-types";
 import React from "react";
 import { defaults, get } from "lodash";
 import ZoomHelpers from "./zoom-helpers";
+import ContainerHelpers from "./container-helpers";
 import {
   VictoryContainer, VictoryClipContainer, Data, PropTypes as CustomPropTypes
 } from "victory-core";
@@ -171,7 +172,7 @@ export const zoomContainerMixin = (base) => class VictoryZoomContainer extends b
       const zoomDomain = defaults({}, props.zoomDomain, props.domain);
       const cachedZoomDomain = defaults({}, props.cachedZoomDomain, props.domain);
       let domain;
-      if (!ZoomHelpers.checkDomainEquality(zoomDomain, cachedZoomDomain)) {
+      if (!ContainerHelpers.checkDomainEquality(zoomDomain, cachedZoomDomain)) {
         // if zoomDomain has been changed, use it
         domain = zoomDomain;
       } else if (allowZoom && !zoomActive) {

--- a/src/components/containers/victory-zoom-container.js
+++ b/src/components/containers/victory-zoom-container.js
@@ -37,8 +37,7 @@ export const zoomContainerMixin = (base) => class VictoryZoomContainer extends b
     ...VictoryContainer.defaultProps,
     clipContainerComponent: <VictoryClipContainer/>,
     allowPan: true,
-    allowZoom: true,
-    zoomActive: false
+    allowZoom: true
   };
 
   static defaultEvents = [{
@@ -167,10 +166,11 @@ export const zoomContainerMixin = (base) => class VictoryZoomContainer extends b
     return childComponents.map((child) => {
       const role = child && child.type && child.type.role;
       const currentChild = child;
-      const { currentDomain, zoomActive, allowZoom } = props;
+      const { currentDomain, allowZoom } = props;
       const originalDomain = defaults({}, props.originalDomain, props.domain);
       const zoomDomain = defaults({}, props.zoomDomain, props.domain);
       const cachedZoomDomain = defaults({}, props.cachedZoomDomain, props.domain);
+      const zoomActive = !ContainerHelpers.checkDomainEquality(currentDomain, originalDomain);
       let domain;
       if (!ContainerHelpers.checkDomainEquality(zoomDomain, cachedZoomDomain)) {
         // if zoomDomain has been changed, use it

--- a/src/components/containers/zoom-helpers.js
+++ b/src/components/containers/zoom-helpers.js
@@ -1,7 +1,7 @@
 /*eslint no-magic-numbers: ["error", { "ignore": [-1, 0, 1, 2, 1000] }]*/
 import { Children } from "react";
 import { Selection, Collection } from "victory-core";
-import { throttle, isFunction, defaults, isEqual } from "lodash";
+import { throttle, isFunction, defaults } from "lodash";
 import { attachId } from "../../helpers/event-handlers";
 import Wrapper from "../../helpers/wrapper";
 
@@ -227,10 +227,15 @@ const Helpers = {
         y: zoomDimension === "x" ? originalDomain.y : this.pan(lastDomain.y, originalDomain.y, dy)
       };
       const resumeAnimation = this.handleAnimation(ctx);
+
+      const zoomActive = !this.checkDomainEquality(originalDomain, lastDomain);
+
       const mutatedProps = {
         parentControlledProps: ["domain"], startX: x, startY: y,
-        domain: currentDomain, currentDomain, originalDomain, cachedZoomDomain: zoomDomain
+        domain: currentDomain, currentDomain, originalDomain, cachedZoomDomain: zoomDomain,
+        zoomActive
       };
+
       if (isFunction(onZoomDomainChange)) {
         onZoomDomainChange(currentDomain, defaults({}, mutatedProps, targetProps));
       }
@@ -258,8 +263,8 @@ const Helpers = {
     const resumeAnimation = this.handleAnimation(ctx);
 
     const zoomActive = !this.zoommingOut(evt) // if zoomming in or
-      // if zoomActive is already set AND user hasn't zoommed out all the way
-      || (targetProps.zoomActive && !isEqual(originalDomain, lastDomain));
+    //   if zoomActive is already set AND user hasn't zoommed out all the way
+      || (targetProps.zoomActive && !this.checkDomainEquality(originalDomain, lastDomain));
 
     const mutatedProps = {
       domain: currentDomain, currentDomain, originalDomain, cachedZoomDomain: zoomDomain,
@@ -281,6 +286,7 @@ const Helpers = {
 export { Helpers as RawZoomHelpers }; // allow victory-native to extend these helpers
 
 export default {
+  checkDomainEquality: Helpers.checkDomainEquality.bind(Helpers),
   onMouseDown: Helpers.onMouseDown.bind(Helpers),
   onMouseUp: Helpers.onMouseUp.bind(Helpers),
   onMouseLeave: Helpers.onMouseLeave.bind(Helpers),

--- a/src/components/containers/zoom-helpers.js
+++ b/src/components/containers/zoom-helpers.js
@@ -4,21 +4,9 @@ import { Selection, Collection } from "victory-core";
 import { throttle, isFunction, defaults } from "lodash";
 import { attachId } from "../../helpers/event-handlers";
 import Wrapper from "../../helpers/wrapper";
+import ContainerHelpers from "./container-helpers";
 
 const Helpers = {
-  checkDomainEquality(a, b) {
-    const checkDimension = (dim) => {
-      const val1 = a && a[dim];
-      const val2 = b && b[dim];
-      if (!val1 && !val2) {
-        return true;
-      } else if (!val1 || !val2) {
-        return false;
-      }
-      return +val1[0] === +val2[0] && +val1[1] === +val2[1];
-    };
-    return checkDimension("x") && checkDimension("y");
-  },
   /**
    * Generates a new domain scaled by factor and constrained by the original domain.
    * @param  {[Number, Number]} currentDomain  The domain to be scaled.
@@ -148,7 +136,7 @@ const Helpers = {
 
   getLastDomain(targetProps, originalDomain) {
     const { zoomDomain, cachedZoomDomain, currentDomain, domain } = targetProps;
-    if (zoomDomain && !this.checkDomainEquality(zoomDomain, cachedZoomDomain)) {
+    if (zoomDomain && !ContainerHelpers.checkDomainEquality(zoomDomain, cachedZoomDomain)) {
       return defaults(
         {}, zoomDomain, domain
       );
@@ -228,7 +216,7 @@ const Helpers = {
       };
       const resumeAnimation = this.handleAnimation(ctx);
 
-      const zoomActive = !this.checkDomainEquality(originalDomain, lastDomain);
+      const zoomActive = !ContainerHelpers.checkDomainEquality(originalDomain, lastDomain);
 
       const mutatedProps = {
         parentControlledProps: ["domain"], startX: x, startY: y,
@@ -263,8 +251,9 @@ const Helpers = {
     const resumeAnimation = this.handleAnimation(ctx);
 
     const zoomActive = !this.zoommingOut(evt) // if zoomming in or
-    //   if zoomActive is already set AND user hasn't zoommed out all the way
-      || (targetProps.zoomActive && !this.checkDomainEquality(originalDomain, lastDomain));
+      // if zoomActive is already set AND user hasn't zoommed out all the way
+      || (targetProps.zoomActive
+        && !ContainerHelpers.checkDomainEquality(originalDomain, lastDomain));
 
     const mutatedProps = {
       domain: currentDomain, currentDomain, originalDomain, cachedZoomDomain: zoomDomain,
@@ -286,7 +275,6 @@ const Helpers = {
 export { Helpers as RawZoomHelpers }; // allow victory-native to extend these helpers
 
 export default {
-  checkDomainEquality: Helpers.checkDomainEquality.bind(Helpers),
   onMouseDown: Helpers.onMouseDown.bind(Helpers),
   onMouseUp: Helpers.onMouseUp.bind(Helpers),
   onMouseLeave: Helpers.onMouseLeave.bind(Helpers),

--- a/src/components/containers/zoom-helpers.js
+++ b/src/components/containers/zoom-helpers.js
@@ -101,12 +101,12 @@ const Helpers = {
     const lowerBound = fromCurrent + delta;
     const upperBound = toCurrent + delta;
     let newDomain;
-    if (lowerBound > fromOriginal && upperBound < toOriginal) {
+    if (lowerBound >= fromOriginal && upperBound <= toOriginal) {
       newDomain = [lowerBound, upperBound];
-    } else if (lowerBound < fromOriginal) { // Clamp to lower limit
+    } else if (lowerBound <= fromOriginal) { // Clamp to lower limit
       const dx = toCurrent - fromCurrent;
       newDomain = [fromOriginal, fromOriginal + dx];
-    } else if (upperBound > toOriginal) { // Clamp to upper limit
+    } else if (upperBound >= toOriginal) { // Clamp to upper limit
       const dx = toCurrent - fromCurrent;
       newDomain = [toOriginal - dx, toOriginal];
     } else {
@@ -216,12 +216,9 @@ const Helpers = {
       };
       const resumeAnimation = this.handleAnimation(ctx);
 
-      const zoomActive = !ContainerHelpers.checkDomainEquality(originalDomain, lastDomain);
-
       const mutatedProps = {
         parentControlledProps: ["domain"], startX: x, startY: y,
-        domain: currentDomain, currentDomain, originalDomain, cachedZoomDomain: zoomDomain,
-        zoomActive
+        domain: currentDomain, currentDomain, originalDomain, cachedZoomDomain: zoomDomain
       };
 
       if (isFunction(onZoomDomainChange)) {
@@ -250,14 +247,9 @@ const Helpers = {
     };
     const resumeAnimation = this.handleAnimation(ctx);
 
-    const zoomActive = !this.zoommingOut(evt) // if zoomming in or
-      // if zoomActive is already set AND user hasn't zoommed out all the way
-      || (targetProps.zoomActive
-        && !ContainerHelpers.checkDomainEquality(originalDomain, lastDomain));
-
     const mutatedProps = {
       domain: currentDomain, currentDomain, originalDomain, cachedZoomDomain: zoomDomain,
-      parentControlledProps: ["domain"], panning: false, zoomActive
+      parentControlledProps: ["domain"], panning: false
     };
 
     if (isFunction(onZoomDomainChange)) {

--- a/src/components/victory-chart/victory-chart.js
+++ b/src/components/victory-chart/victory-chart.js
@@ -23,8 +23,8 @@ export default class VictoryChart extends React.Component {
   static propTypes = {
     ...BaseProps,
     children: PropTypes.oneOfType([
-      PropTypes.arrayOf(PropTypes.node),
-      PropTypes.node
+      PropTypes.arrayOf(PropTypes.element),
+      PropTypes.element
     ]),
     defaultAxes: PropTypes.shape({
       independent: PropTypes.element,

--- a/src/components/victory-group/victory-group.js
+++ b/src/components/victory-group/victory-group.js
@@ -22,7 +22,7 @@ export default class VictoryGroup extends React.Component {
   static propTypes = {
     ...BaseProps,
     ...DataProps,
-    children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]),
+    children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.element), PropTypes.element]),
     color: PropTypes.string,
     colorScale: PropTypes.oneOfType([
       PropTypes.arrayOf(PropTypes.string),

--- a/src/components/victory-stack/victory-stack.js
+++ b/src/components/victory-stack/victory-stack.js
@@ -26,7 +26,7 @@ export default class VictoryStack extends React.Component {
       })
     ]),
     children: PropTypes.oneOfType([
-      PropTypes.arrayOf(PropTypes.node), PropTypes.node
+      PropTypes.arrayOf(PropTypes.element), PropTypes.element
     ]),
     colorScale: PropTypes.oneOfType([
       PropTypes.arrayOf(PropTypes.string),

--- a/test/client/spec/components/containers/brush-helpers.spec.js
+++ b/test/client/spec/components/containers/brush-helpers.spec.js
@@ -1,0 +1,53 @@
+/* eslint-disable no-unused-expressions,react/no-multi-comp */
+import BrushHelpers from "src/components/containers/brush-helpers";
+
+describe("containers/brush-helpers", () => {
+
+  describe("withinBounds", () => {
+
+    it("returns true when within bounds", () => {
+      const point = { x: 1, y: 1 };
+      const bounds = { x1: 0, x2: 2, y1: 0, y2: 2 };
+      const isWithinBoundsResults = BrushHelpers.withinBounds(point, bounds);
+      expect(isWithinBoundsResults).to.eql(true);
+    });
+
+    it("returns false when not within bounds", () => {
+      const point = { x: 10, y: 1 };
+      const bounds = { x1: 0, x2: 2, y1: 0, y2: 2 };
+      const isWithinBoundsResults = BrushHelpers.withinBounds(point, bounds);
+      expect(isWithinBoundsResults).to.eql(false);
+    });
+
+    it("returns true when within bounds using dates", () => {
+      const point = { x: new Date("1/2/2017"), y: 1 };
+      const bounds = { x1: new Date("1/1/2017"), x2: new Date("2/1/2017"), y1: 0, y2: 2 };
+      const isWithinBoundsResults = BrushHelpers.withinBounds(point, bounds);
+      expect(isWithinBoundsResults).to.eql(true);
+    });
+
+    it("returns false when not within bounds using dates", () => {
+      const point = { x: new Date("3/2/2017"), y: 1 };
+      const bounds = { x1: new Date("1/1/2017"), x2: new Date("2/1/2017"), y1: 0, y2: 2 };
+      const isWithinBoundsResults = BrushHelpers.withinBounds(point, bounds);
+      expect(isWithinBoundsResults).to.eql(false);
+    });
+  });
+
+  describe("constrainBox", () => {
+
+    it("returns correct box", () => {
+      const fullDomainBox = { x1: 0, x2: 2, y1: 0, y2: 2 };
+      const box = { x1: 1, x2: 2, y1: 1, y2: 2 };
+      const constrainBoxResult = BrushHelpers.constrainBox(box, fullDomainBox);
+      expect(constrainBoxResult).to.eql({ x1: 1, y1: 1, x2: 2, y2: 2 });
+    });
+
+    it("returns correct box when x axis is dates", () => {
+      const fullDomainBox = { x1: new Date("1/2/2017"), x2: new Date("2/1/2017"), y1: 0, y2: 2 };
+      const box = { x1: new Date("1/1/2017"), x2: new Date("1/10/2017"), y1: 1, y2: 2 };
+      const constrainBoxResult = BrushHelpers.constrainBox(box, fullDomainBox);
+      expect(constrainBoxResult).to.eql({ x1: 1483344000000, y1: 1, x2: 1484121600000, y2: 2 });
+    });
+  });
+});

--- a/test/client/spec/components/containers/brush-helpers.spec.js
+++ b/test/client/spec/components/containers/brush-helpers.spec.js
@@ -44,8 +44,9 @@ describe("containers/brush-helpers", () => {
     });
 
     it("returns correct box when x axis is dates", () => {
-      const fullDomainBox = { x1: new Date("1/2/2017"), x2: new Date("2/1/2017"), y1: 0, y2: 2 };
-      const box = { x1: new Date("1/1/2017"), x2: new Date("1/10/2017"), y1: 1, y2: 2 };
+      const fullDomainBox = { x1: new Date("1/2/2017 PST"),
+        x2: new Date("2/1/2017 PST"), y1: 0, y2: 2 };
+      const box = { x1: new Date("1/1/2017 PST"), x2: new Date("1/10/2017 PST"), y1: 1, y2: 2 };
       const constrainBoxResult = BrushHelpers.constrainBox(box, fullDomainBox);
       expect(constrainBoxResult).to.eql({ x1: 1483344000000, y1: 1, x2: 1484121600000, y2: 2 });
     });

--- a/test/client/spec/components/containers/brush-helpers.spec.js
+++ b/test/client/spec/components/containers/brush-helpers.spec.js
@@ -3,37 +3,6 @@ import BrushHelpers from "src/components/containers/brush-helpers";
 
 describe("containers/brush-helpers", () => {
 
-  describe("withinBounds", () => {
-
-    it("returns true when within bounds", () => {
-      const point = { x: 1, y: 1 };
-      const bounds = { x1: 0, x2: 2, y1: 0, y2: 2 };
-      const isWithinBoundsResults = BrushHelpers.withinBounds(point, bounds);
-      expect(isWithinBoundsResults).to.eql(true);
-    });
-
-    it("returns false when not within bounds", () => {
-      const point = { x: 10, y: 1 };
-      const bounds = { x1: 0, x2: 2, y1: 0, y2: 2 };
-      const isWithinBoundsResults = BrushHelpers.withinBounds(point, bounds);
-      expect(isWithinBoundsResults).to.eql(false);
-    });
-
-    it("returns true when within bounds using dates", () => {
-      const point = { x: new Date("1/2/2017"), y: 1 };
-      const bounds = { x1: new Date("1/1/2017"), x2: new Date("2/1/2017"), y1: 0, y2: 2 };
-      const isWithinBoundsResults = BrushHelpers.withinBounds(point, bounds);
-      expect(isWithinBoundsResults).to.eql(true);
-    });
-
-    it("returns false when not within bounds using dates", () => {
-      const point = { x: new Date("3/2/2017"), y: 1 };
-      const bounds = { x1: new Date("1/1/2017"), x2: new Date("2/1/2017"), y1: 0, y2: 2 };
-      const isWithinBoundsResults = BrushHelpers.withinBounds(point, bounds);
-      expect(isWithinBoundsResults).to.eql(false);
-    });
-  });
-
   describe("constrainBox", () => {
 
     it("returns correct box", () => {

--- a/test/client/spec/components/containers/container-helpers.spec.js
+++ b/test/client/spec/components/containers/container-helpers.spec.js
@@ -1,0 +1,36 @@
+/* eslint-disable no-unused-expressions,react/no-multi-comp */
+import ContainerHelpers from "src/components/containers/container-helpers";
+
+describe("containers/container-helpers", () => {
+
+  describe("withinBounds", () => {
+
+    it("returns true when within bounds", () => {
+      const point = { x: 1, y: 1 };
+      const bounds = { x1: 0, x2: 2, y1: 0, y2: 2 };
+      const isWithinBoundsResults = ContainerHelpers.withinBounds(point, bounds);
+      expect(isWithinBoundsResults).to.eql(true);
+    });
+
+    it("returns false when not within bounds", () => {
+      const point = { x: 10, y: 1 };
+      const bounds = { x1: 0, x2: 2, y1: 0, y2: 2 };
+      const isWithinBoundsResults = ContainerHelpers.withinBounds(point, bounds);
+      expect(isWithinBoundsResults).to.eql(false);
+    });
+
+    it("returns true when within bounds using dates", () => {
+      const point = { x: new Date("1/2/2017"), y: 1 };
+      const bounds = { x1: new Date("1/1/2017"), x2: new Date("2/1/2017"), y1: 0, y2: 2 };
+      const isWithinBoundsResults = ContainerHelpers.withinBounds(point, bounds);
+      expect(isWithinBoundsResults).to.eql(true);
+    });
+
+    it("returns false when not within bounds using dates", () => {
+      const point = { x: new Date("3/2/2017"), y: 1 };
+      const bounds = { x1: new Date("1/1/2017"), x2: new Date("2/1/2017"), y1: 0, y2: 2 };
+      const isWithinBoundsResults = ContainerHelpers.withinBounds(point, bounds);
+      expect(isWithinBoundsResults).to.eql(false);
+    });
+  });
+});


### PR DESCRIPTION
Panning a zoomed area using a brush container fails sometimes when panning to the edges. This was due to compares using <, > and not =<, >=. Also removed duplicate code for withinBounds and checkDomainEquality. Replaced lodash.isEqual with checkDomainEquality. Added a brush / zoom chart to the brush demo to help test the panning issues.