### PR TITLE
Remove coercion of renderInPortal to false. Fix #791.

### DIFF
--- a/src/components/containers/victory-voronoi-container.js
+++ b/src/components/containers/victory-voronoi-container.js
@@ -195,7 +195,6 @@ export const voronoiContainerMixin = (base) => class VictoryVoronoiContainer ext
         active: true,
         datum: omit(points[0], ["childName", "style", "continuous"]),
         flyoutStyle: this.getStyle(props, points, "flyout")[0],
-        renderInPortal: false,
         scale, style, theme, text
       },
       componentProps,


### PR DESCRIPTION
This PR removes the coercion of the `renderInPortal` prop to `false` for `VictoryTooltip` components passed via the `labelComponent` prop used in a `VictoryVoronoiContainer` ([fix for #791](https://github.com/FormidableLabs/victory/issues/791)). By default, `renderInPortal` will now be `true` due to the way `VictoryTooltip` sets `defaultProps` (`renderInPortal` as `true` if no `renderInPortal` prop is received). If a user **does not** want to render the tooltip in a portal, they must specify `labelComponent={<VictoryTooltip renderInPortal={false} />}`.

For example, this code:

```
<VictoryChart style={chartStyle}
  theme={VictoryTheme.material}
  domainPadding={{ y: 2 }}
  containerComponent={
    <VictoryVoronoiContainer voronoiDimension="x"
      voronoiBlacklist={["first"]}
      labels={(d) => `y:${d.y}`}
      labelComponent={
        <VictoryTooltip
          y={150}
          flyoutStyle={{ fill: "white" }}
          style={[{ fill: "green" }, { fill: "magenta" }]}
          // this is the important line - explicitly pass false
          renderInPortal={false}
        />
      }
    />
  }
>
  <VictoryLine name="first"
    data={[
      { x: 1, y: 5, l: "one" },
      { x: 1.5, y: 5, l: "one point five" },
      { x: 2, y: 4, l: "two" },
      { x: 3, y: -2, l: "three" }
    ]}
    style={{
      data: { stroke: "tomato", strokeWidth: (d, active) => active ? 4 : 2 },
      labels: { fill: "tomato" }
    }}
  />

  <VictoryLine name="second"
    data={[
      { x: 1, y: -3, l: "red" },
      { x: 2, y: 5, l: "green" },
      { x: 3, y: 3, l: "blue" }
    ]}
    style={{
      data: { stroke: "blue", strokeWidth: (d, active) => active ? 4 : 2 },
      labels: { fill: "blue" }
    }}
  />

  <VictoryLine name="third"
    data={[
      { x: 1, y: 5, l: "cat" },
      { x: 2, y: -4, l: "dog" },
      { x: 3, y: -2, l: "bird" }
    ]}
    style={{
      data: { stroke: "black", strokeWidth: (d, active) => active ? 4 : 2 },
      labels: { fill: "black" }
    }}
  />
</VictoryChart>
```

results in this component tree.

<img width="1279" alt="formidable-victory-render-in-portal-false" src="https://user-images.githubusercontent.com/19421190/35123596-c5a6e1d8-fc57-11e7-8a50-fff9793bf714.png">

Notice that `<Flyout />` and `<VictoryLabel />` get rendered **outside** of `<Portal />`. If we don't specify `renderInPortal` to explicitly be `false`, `<Flyout />` and `<VictoryLabel />` will be rendered inside of `<Portal />`. For example, this code:

```
<VictoryScatter
  style={{
    parent: chartStyle.parent,
    data: {
      fill: (datum, active) => active ? "tomato" : "black"
    }
  }}
  containerComponent={
    <VictoryVoronoiContainer
      selectionStyle={{
        stroke: "tomato", strokeWidth: 2, fill: "tomato", fillOpacity: 0.1
      }}
      labels={(d) => d.y}
      labelComponent={<VictoryTooltip />}
    />
  }
  size={(datum, active) => active ? 5 : 3}
  y={(d) => d.x * d.x}
/>
```

results in this component tree.

<img width="1276" alt="formidable-victory-render-in-portal-true" src="https://user-images.githubusercontent.com/19421190/35123665-12fa0898-fc58-11e7-930e-5d7e3f607ff6.png">

Notice that `<Flyout />` and `<VictoryLabel />` get rendered **inside** of `<Portal />`. We may need to address in a subsequent PR the issue with tooltips not updating with labels rendered in a portal.


