### PR TITLE
Support for a wickStrokeWidth style prop

### DIFF
--- a/src/components/victory-candlestick/helper-methods.js
+++ b/src/components/victory-candlestick/helper-methods.js
@@ -12,7 +12,7 @@ export default {
     } = props;
     const initialChildProps = { parent: {
       domain, scale, width, height, data, standalone, theme, polar, origin,
-      style: style.parent, padding, wickStrokeWidth
+      style: style.parent, padding
     } };
 
     return data.reduce((childProps, datum, index) => {

--- a/src/components/victory-candlestick/helper-methods.js
+++ b/src/components/victory-candlestick/helper-methods.js
@@ -6,7 +6,10 @@ export default {
     props = Helpers.modifyProps(props, fallbackProps, "candlestick");
     const calculatedValues = this.getCalculatedValues(props);
     const { data, style, scale, domain, origin } = calculatedValues;
-    const { groupComponent, width, height, padding, standalone, theme, polar, wickStrokeWidth } = props;
+    const {
+      groupComponent, width, height, padding, standalone,
+      theme, polar, wickStrokeWidth
+    } = props;
     const initialChildProps = { parent: {
       domain, scale, width, height, data, standalone, theme, polar, origin,
       style: style.parent, padding, wickStrokeWidth

--- a/src/components/victory-candlestick/helper-methods.js
+++ b/src/components/victory-candlestick/helper-methods.js
@@ -17,8 +17,8 @@ export default {
       const x = scale.x(datum._x1 !== undefined ? datum._x1 : datum._x);
       const y1 = scale.y(datum._high);
       const y2 = scale.y(datum._low);
-      const highWick = scale.y(datum._close);
-      const lowWick = scale.y(datum._open);
+      const highWick = scale.y(Math.max(datum._open, datum._close));
+      const lowWick = scale.y(Math.min(datum._open, datum._close));
       const candleHeight = Math.abs(scale.y(datum._open) - scale.y(datum._close));
       const y = scale.y(Math.max(datum._open, datum._close));
       const dataStyle = this.getDataStyles(datum, style.data, props);

--- a/src/components/victory-candlestick/helper-methods.js
+++ b/src/components/victory-candlestick/helper-methods.js
@@ -6,10 +6,10 @@ export default {
     props = Helpers.modifyProps(props, fallbackProps, "candlestick");
     const calculatedValues = this.getCalculatedValues(props);
     const { data, style, scale, domain, origin } = calculatedValues;
-    const { groupComponent, width, height, padding, standalone, theme, polar } = props;
+    const { groupComponent, width, height, padding, standalone, theme, polar, wickStrokeWidth } = props;
     const initialChildProps = { parent: {
       domain, scale, width, height, data, standalone, theme, polar, origin,
-      style: style.parent, padding
+      style: style.parent, padding, wickStrokeWidth
     } };
 
     return data.reduce((childProps, datum, index) => {
@@ -19,10 +19,12 @@ export default {
       const y2 = scale.y(datum._low);
       const candleHeight = Math.abs(scale.y(datum._open) - scale.y(datum._close));
       const y = scale.y(Math.max(datum._open, datum._close));
+      const highWick = y;
+      const lowWick = scale.y(Math.min(datum._open, datum._close));
       const dataStyle = this.getDataStyles(datum, style.data, props);
       const dataProps = {
-        x, y, y1, y2, candleHeight, scale, data, datum, groupComponent,
-        index, style: dataStyle, padding, width, polar, origin
+        x, y, y1, y2, candleHeight, scale, data, datum, groupComponent, highWick, lowWick,
+        index, style: dataStyle, padding, width, polar, origin, wickStrokeWidth
       };
 
       childProps[eventKey] = {

--- a/src/components/victory-candlestick/helper-methods.js
+++ b/src/components/victory-candlestick/helper-methods.js
@@ -16,15 +16,14 @@ export default {
       const eventKey = datum.eventKey || index;
       const x = scale.x(datum._x1 !== undefined ? datum._x1 : datum._x);
       const high = scale.y(datum._high);
+      const close = scale.y(datum._close);
+      const open = scale.y(datum._open);
       const low = scale.y(datum._low);
       const candleHeight = Math.abs(scale.y(datum._open) - scale.y(datum._close));
-      const y = scale.y(Math.max(datum._open, datum._close));
-      const highWick = y;
-      const lowWick = scale.y(Math.min(datum._open, datum._close));
       const dataStyle = this.getDataStyles(datum, style.data, props);
       const dataProps = {
-        x, y, high, low, candleHeight, scale, data, datum, groupComponent, highWick, lowWick,
-        index, style: dataStyle, padding, width, polar, origin, wickStrokeWidth
+        x, high, low, candleHeight, scale, data, datum, groupComponent, index,
+        style: dataStyle, padding, width, polar, origin, wickStrokeWidth, open, close
       };
 
       childProps[eventKey] = {

--- a/src/components/victory-candlestick/helper-methods.js
+++ b/src/components/victory-candlestick/helper-methods.js
@@ -17,11 +17,13 @@ export default {
       const x = scale.x(datum._x1 !== undefined ? datum._x1 : datum._x);
       const y1 = scale.y(datum._high);
       const y2 = scale.y(datum._low);
+      const highWick = scale.y(datum._close);
+      const lowWick = scale.y(datum._open);
       const candleHeight = Math.abs(scale.y(datum._open) - scale.y(datum._close));
       const y = scale.y(Math.max(datum._open, datum._close));
       const dataStyle = this.getDataStyles(datum, style.data, props);
       const dataProps = {
-        x, y, y1, y2, candleHeight, scale, data, datum, groupComponent,
+        x, y, y1, y2, highWick, lowWick, candleHeight, scale, data, datum, groupComponent,
         index, style: dataStyle, padding, width, polar, origin
       };
 

--- a/src/components/victory-candlestick/helper-methods.js
+++ b/src/components/victory-candlestick/helper-methods.js
@@ -15,15 +15,15 @@ export default {
     return data.reduce((childProps, datum, index) => {
       const eventKey = datum.eventKey || index;
       const x = scale.x(datum._x1 !== undefined ? datum._x1 : datum._x);
-      const y1 = scale.y(datum._high);
-      const y2 = scale.y(datum._low);
+      const high = scale.y(datum._high);
+      const low = scale.y(datum._low);
       const candleHeight = Math.abs(scale.y(datum._open) - scale.y(datum._close));
       const y = scale.y(Math.max(datum._open, datum._close));
       const highWick = y;
       const lowWick = scale.y(Math.min(datum._open, datum._close));
       const dataStyle = this.getDataStyles(datum, style.data, props);
       const dataProps = {
-        x, y, y1, y2, candleHeight, scale, data, datum, groupComponent, highWick, lowWick,
+        x, y, high, low, candleHeight, scale, data, datum, groupComponent, highWick, lowWick,
         index, style: dataStyle, padding, width, polar, origin, wickStrokeWidth
       };
 
@@ -40,11 +40,11 @@ export default {
   },
 
   getLabelProps(dataProps, text, style) {
-    const { x, y1, index, scale, datum, data } = dataProps;
+    const { x, high, index, scale, datum, data } = dataProps;
     const labelStyle = style.labels || {};
     return {
       style: labelStyle,
-      y: y1 - (labelStyle.padding || 0),
+      y: high - (labelStyle.padding || 0),
       x,
       text,
       index,

--- a/src/components/victory-candlestick/helper-methods.js
+++ b/src/components/victory-candlestick/helper-methods.js
@@ -17,13 +17,11 @@ export default {
       const x = scale.x(datum._x1 !== undefined ? datum._x1 : datum._x);
       const y1 = scale.y(datum._high);
       const y2 = scale.y(datum._low);
-      const highWick = scale.y(Math.max(datum._open, datum._close));
-      const lowWick = scale.y(Math.min(datum._open, datum._close));
       const candleHeight = Math.abs(scale.y(datum._open) - scale.y(datum._close));
       const y = scale.y(Math.max(datum._open, datum._close));
       const dataStyle = this.getDataStyles(datum, style.data, props);
       const dataProps = {
-        x, y, y1, y2, highWick, lowWick, candleHeight, scale, data, datum, groupComponent,
+        x, y, y1, y2, candleHeight, scale, data, datum, groupComponent,
         index, style: dataStyle, padding, width, polar, origin
       };
 


### PR DESCRIPTION
## Overview

Supply a `wickStrokeWidth` value to see a difference between the candle's stroke width and the wick's stroke width.

When supplied a `wickStrokeWidth` without a separate `strokeWidth` assignment, the candlestick will fallback to the `wickStrokeWidth` for the candle's `strokeWidth`.

Prerequisite PR in victory-core [here](https://github.com/FormidableLabs/victory-core/pull/330).

## Example

```
<VictoryCandlestick
  wickStrokeWidth={12}
  style={{ data: { 
    fill: "#c43a31", 
    fillOpacity: 0.7, 
    stroke: "#c43a31", 
    strokeWidth: 3 
  }, parent: style.parent }}
  data={data}
/>
```

renders this chart:

<img width="452" alt="screen shot 2018-01-25 at 1 17 56 pm" src="https://user-images.githubusercontent.com/30479228/35410292-304a40b4-01d2-11e8-9bd5-661b55ee57dc.png">

## Original Issue:
[Victory Issue #886](https://github.com/FormidableLabs/victory/issues/886)