### PR TITLE
fix "undefined is not an object (evaluating 'event.eventHandlers')" when using react-native

### DIFF
--- a/src/components/containers/create-container.js
+++ b/src/components/containers/create-container.js
@@ -47,7 +47,11 @@ const combineDefaultEvents = (defaultEvents) => {
     ([target, eventsArray]) => {
       return {
         target,
-        eventHandlers: combineEventHandlers(eventsArray.map((event) => event.eventHandlers))
+        eventHandlers: combineEventHandlers(eventsArray.map((event) => {
+          // prevent "undefined is not an object (evaluating 'event.eventHandlers')".
+          // if eventsArray = [undefined]
+          return (typeof event !== "undefined") ? event.eventHandlers : {};
+        }))
         // note: does not currently handle eventKey or childName
       };
     }


### PR DESCRIPTION
# The Problem
following error occurred through victory-native.

![screen shot 2018-02-09 at 17 20 35](https://user-images.githubusercontent.com/5501268/36020943-a83c0318-0dc7-11e8-9db8-c6333c1e065e.png)

# Environment

### OS
- macOS 10.13.2

### node
- node v9.4.0

### npm
- react@16.0.0
- react-native@0.52.0
- victory-native@0.17.0
- react-native-svg@6.1.3

# Reproduction
1. during depelopment RN app on iOSsimulator with `react-native@0.52.0` and `react@16.0.0`
1. `yarn add victory-native@0.17.0`
1. `yarn add react-native-svg@6.1.3` acording to [Peer Dependencies and Version Requirements](https://github.com/FormidableLabs/victory-native#peer-dependencies-and-version-requirements) of victory-native README.
1. `node_modules/.bin/react-native link react-native-svg`
1. import victory-native in any component, like `import { VictoryBar } from 'victory-native'`   
 (`src/containers/SignalDetailContainer.js:line 25` by the above image)
1. display `undefined is not an object (evaluating 'event.eventHandlers')`

# How to Fix
add undefined check to problem line.

# Notes
I don't know if platoform other than victory-native has same error occurred.
and I don't know how to handle it false case.

```javascript
return (typeof event !== "undefined") ? event.eventHandlers : {}; // here
```

could you please add some improve change if you can?

thank you so much :bow: