### PR TITLE
add activate props, and selectionBlacklist

### DIFF
--- a/src/components/containers/victory-selection-container.js
+++ b/src/components/containers/victory-selection-container.js
@@ -7,16 +7,19 @@ export const selectionContainerMixin = (base) => class VictorySelectionContainer
   static displayName = "VictorySelectionContainer";
   static propTypes = {
     ...VictoryContainer.propTypes,
+    activateSelectedData: PropTypes.bool,
     allowSelection: PropTypes.bool,
     disable: PropTypes.bool,
     onSelection: PropTypes.func,
     onSelectionCleared: PropTypes.func,
+    selectionBlacklist: PropTypes.arrayOf(PropTypes.string),
     selectionComponent: PropTypes.element,
     selectionDimension: PropTypes.oneOf(["x", "y"]),
     selectionStyle: PropTypes.object
   };
   static defaultProps = {
     ...VictoryContainer.defaultProps,
+    activateSelectedData: true,
     allowSelection: true,
     selectionComponent: <rect/>,
     selectionStyle: {

--- a/src/components/containers/victory-voronoi-container.js
+++ b/src/components/containers/victory-voronoi-container.js
@@ -8,6 +8,8 @@ export const voronoiContainerMixin = (base) => class VictoryVoronoiContainer ext
   static displayName = "VictoryVoronoiContainer";
   static propTypes = {
     ...VictoryContainer.propTypes,
+    activateData: PropTypes.bool,
+    activateLabels: PropTypes.bool,
     disable: PropTypes.bool,
     labelComponent: PropTypes.element,
     labels: PropTypes.func,
@@ -20,6 +22,8 @@ export const voronoiContainerMixin = (base) => class VictoryVoronoiContainer ext
   };
   static defaultProps = {
     ...VictoryContainer.defaultProps,
+    activateData: true,
+    activateLabels: true,
     labelComponent: <VictoryTooltip/>,
     voronoiPadding: 5
   };

--- a/src/components/containers/voronoi-helpers.js
+++ b/src/components/containers/voronoi-helpers.js
@@ -1,5 +1,5 @@
 import { Selection, Data, Helpers } from "victory-core";
-import { assign, throttle, isFunction, groupBy, keys, isEqual, includes } from "lodash";
+import { assign, throttle, isFunction, isEmpty, groupBy, keys, isEqual, includes } from "lodash";
 import { voronoi as d3Voronoi } from "d3-voronoi";
 import React from "react";
 
@@ -94,7 +94,15 @@ const VoronoiHelpers = {
 
   getActiveMutations(props, point) {
     const { childName, continuous } = point;
-    const targets = props.labels ? ["data"] : ["data", "labels"];
+    const { activateData, activateLabels, labels } = props;
+    if (!activateData && !activateLabels) {
+      return [];
+    }
+    const defaultTarget = activateData ? ["data"] : [];
+    const targets = labels && !activateLabels ? defaultTarget : defaultTarget.concat("labels");
+    if (isEmpty(targets)) {
+      return [];
+    }
     return targets.map((target) => {
       const eventKey = continuous === true && target === "data" ? "all" : point.eventKey;
       return {
@@ -105,7 +113,15 @@ const VoronoiHelpers = {
 
   getInactiveMutations(props, point) {
     const { childName, continuous } = point;
-    const targets = props.labels ? ["data"] : ["data", "labels"];
+    const { activateData, activateLabels, labels } = props;
+    if (!activateData && !activateLabels) {
+      return [];
+    }
+    const defaultTarget = activateData ? ["data"] : [];
+    const targets = labels && !activateLabels ? defaultTarget : defaultTarget.concat("labels");
+    if (isEmpty(targets)) {
+      return [];
+    }
     return targets.map((target) => {
       const eventKey = continuous && target === "data" ? "all" : point.eventKey;
       return {


### PR DESCRIPTION
- Adds a `selectionBlacklist` prop for `VictorySelectionContainer` to enable ignoring data
- Adds `activateData` and `activateLabels` props to `VictoryVoronoiContainer` (true by default). Setting these to false should help perf by avoiding unnecessary mutations for users who don't need to activate data / labels 
- Adds `activateSelectedData` prop to `VictorySelectionContainer`. This prop operates the same way as `activateData` in `VictoryVoronoiContainer`. The naming differs to avoid collision in `createContainer`