### PR TITLE
Export helper methods as named exports

### DIFF
--- a/src/components/victory-area/helper-methods.js
+++ b/src/components/victory-area/helper-methods.js
@@ -1,7 +1,7 @@
 import { assign } from "lodash";
 import { Helpers, LabelHelpers, Data, Domain, Scale } from "victory-core";
 
-export const getDataWithBaseline = (props, scale) => {
+const getDataWithBaseline = (props, scale) => {
   let data = Data.getData(props);
 
   if (data.length < 2) {
@@ -39,7 +39,7 @@ const getCalculatedValues = (props) => {
   return { style, data, scale, domain, origin };
 };
 
-export const getBaseProps = (props, fallbackProps) => {
+const getBaseProps = (props, fallbackProps) => {
   const modifiedProps = Helpers.modifyProps(props, fallbackProps, "area");
   props = assign({}, modifiedProps, getCalculatedValues(modifiedProps));
   const {
@@ -64,3 +64,5 @@ export const getBaseProps = (props, fallbackProps) => {
     return childProps;
   }, initialChildProps);
 };
+
+export { getBaseProps, getDataWithBaseline };

--- a/src/components/victory-area/helper-methods.js
+++ b/src/components/victory-area/helper-methods.js
@@ -1,69 +1,66 @@
 import { assign } from "lodash";
 import { Helpers, LabelHelpers, Data, Domain, Scale } from "victory-core";
 
-export default {
+export const getDataWithBaseline = (props, scale) => {
+  let data = Data.getData(props);
 
-  getBaseProps(props, fallbackProps) {
-    const modifiedProps = Helpers.modifyProps(props, fallbackProps, "area");
-    props = assign({}, modifiedProps, this.getCalculatedValues(modifiedProps));
-    const {
-      data, domain, events, groupComponent, height, interpolation, origin, padding, polar,
-      scale, sharedEvents, standalone, style, theme, width
-    } = props;
-    const initialChildProps = {
-      parent: {
-        style: style.parent, width, height, scale, data, domain,
-        standalone, theme, polar, origin, padding
-      },
-      all: {
-        data: { polar, origin, scale, data, interpolation, groupComponent, style: style.data }
-      }
-    };
-    return data.reduce((childProps, datum, index) => {
-      const text = LabelHelpers.getText(props, datum, index);
-      if (text !== undefined && text !== null || events || sharedEvents) {
-        const eventKey = datum.eventKey || index;
-        childProps[eventKey] = { labels: LabelHelpers.getProps(props, index) };
-      }
-      return childProps;
-    }, initialChildProps);
-  },
-
-  getCalculatedValues(props) {
-    const { theme, polar } = props;
-    const defaultStyles = theme && theme.area && theme.area.style ? theme.area.style : {};
-    const style = Helpers.getStyles(props.style, defaultStyles);
-    const range = {
-      x: Helpers.getRange(props, "x"),
-      y: Helpers.getRange(props, "y")
-    };
-    const domain = {
-      x: Domain.getDomainWithZero(props, "x"),
-      y: Domain.getDomainWithZero(props, "y")
-    };
-    const scale = {
-      x: Scale.getBaseScale(props, "x").domain(domain.x).range(range.x),
-      y: Scale.getBaseScale(props, "y").domain(domain.y).range(range.y)
-    };
-    const origin = polar ? props.origin || Helpers.getPolarOrigin(props) : undefined;
-    const data = this.getDataWithBaseline(props, scale);
-    return { style, data, scale, domain, origin };
-  },
-
-  getDataWithBaseline(props, scale) {
-    let data = Data.getData(props);
-
-    if (data.length < 2) {
-      data = [];
-    }
-    const defaultMin = Scale.getType(scale.y) === "log" ? 1 / Number.MAX_SAFE_INTEGER : 0;
-    const domainY = scale.y.domain();
-    const minY = Math.min(...domainY) > 0 ? Math.min(...domainY) : defaultMin;
-
-    return data.map((datum) => {
-      const _y1 = datum._y1 !== undefined ? datum._y1 : datum._y;
-      const _y0 = datum._y0 !== undefined ? datum._y0 : minY;
-      return assign({}, datum, { _y0, _y1 });
-    });
+  if (data.length < 2) {
+    data = [];
   }
+  const defaultMin = Scale.getType(scale.y) === "log" ? 1 / Number.MAX_SAFE_INTEGER : 0;
+  const domainY = scale.y.domain();
+  const minY = Math.min(...domainY) > 0 ? Math.min(...domainY) : defaultMin;
+
+  return data.map((datum) => {
+    const _y1 = datum._y1 !== undefined ? datum._y1 : datum._y;
+    const _y0 = datum._y0 !== undefined ? datum._y0 : minY;
+    return assign({}, datum, { _y0, _y1 });
+  });
+};
+
+const getCalculatedValues = (props) => {
+  const { theme, polar } = props;
+  const defaultStyles = theme && theme.area && theme.area.style ? theme.area.style : {};
+  const style = Helpers.getStyles(props.style, defaultStyles);
+  const range = {
+    x: Helpers.getRange(props, "x"),
+    y: Helpers.getRange(props, "y")
+  };
+  const domain = {
+    x: Domain.getDomainWithZero(props, "x"),
+    y: Domain.getDomainWithZero(props, "y")
+  };
+  const scale = {
+    x: Scale.getBaseScale(props, "x").domain(domain.x).range(range.x),
+    y: Scale.getBaseScale(props, "y").domain(domain.y).range(range.y)
+  };
+  const origin = polar ? props.origin || Helpers.getPolarOrigin(props) : undefined;
+  const data = getDataWithBaseline(props, scale);
+  return { style, data, scale, domain, origin };
+};
+
+export const getBaseProps = (props, fallbackProps) => {
+  const modifiedProps = Helpers.modifyProps(props, fallbackProps, "area");
+  props = assign({}, modifiedProps, getCalculatedValues(modifiedProps));
+  const {
+    data, domain, events, groupComponent, height, interpolation, origin, padding, polar,
+    scale, sharedEvents, standalone, style, theme, width
+  } = props;
+  const initialChildProps = {
+    parent: {
+      style: style.parent, width, height, scale, data, domain,
+      standalone, theme, polar, origin, padding
+    },
+    all: {
+      data: { polar, origin, scale, data, interpolation, groupComponent, style: style.data }
+    }
+  };
+  return data.reduce((childProps, datum, index) => {
+    const text = LabelHelpers.getText(props, datum, index);
+    if (text !== undefined && text !== null || events || sharedEvents) {
+      const eventKey = datum.eventKey || index;
+      childProps[eventKey] = { labels: LabelHelpers.getProps(props, index) };
+    }
+    return childProps;
+  }, initialChildProps);
 };

--- a/src/components/victory-area/victory-area.js
+++ b/src/components/victory-area/victory-area.js
@@ -1,7 +1,7 @@
 import { partialRight } from "lodash";
 import PropTypes from "prop-types";
 import React from "react";
-import AreaHelpers from "./helper-methods";
+import { getBaseProps } from "./helper-methods";
 import {
   PropTypes as CustomPropTypes, Helpers, VictoryLabel, VictoryContainer,
   DefaultTransitions, Area, VictoryClipContainer, addEvents, VictoryTheme, Data, Domain
@@ -58,7 +58,7 @@ class VictoryArea extends React.Component {
   static defaultPolarTransitions = DefaultTransitions.continuousPolarTransitions();
   static getDomain = Domain.getDomainWithZero.bind(Domain);
   static getData = Data.getData.bind(Data);
-  static getBaseProps = partialRight(AreaHelpers.getBaseProps.bind(AreaHelpers), fallbackProps);
+  static getBaseProps = partialRight(getBaseProps.bind(getBaseProps), fallbackProps);
   static expectedComponents = [
     "dataComponent", "labelComponent", "groupComponent", "containerComponent"
   ];

--- a/src/components/victory-area/victory-area.js
+++ b/src/components/victory-area/victory-area.js
@@ -58,7 +58,7 @@ class VictoryArea extends React.Component {
   static defaultPolarTransitions = DefaultTransitions.continuousPolarTransitions();
   static getDomain = Domain.getDomainWithZero.bind(Domain);
   static getData = Data.getData.bind(Data);
-  static getBaseProps = partialRight(getBaseProps.bind(getBaseProps), fallbackProps);
+  static getBaseProps = partialRight(getBaseProps, fallbackProps);
   static expectedComponents = [
     "dataComponent", "labelComponent", "groupComponent", "containerComponent"
   ];

--- a/src/components/victory-bar/helper-methods.js
+++ b/src/components/victory-bar/helper-methods.js
@@ -44,7 +44,7 @@ const getCalculatedValues = (props) => {
   return { style, data, scale, domain, origin };
 };
 
-export const getBaseProps = (props, fallbackProps) => {
+const getBaseProps = (props, fallbackProps) => {
   const modifiedProps = Helpers.modifyProps(props, fallbackProps, "bar");
   props = assign({}, modifiedProps, getCalculatedValues(modifiedProps));
   const {
@@ -76,3 +76,5 @@ export const getBaseProps = (props, fallbackProps) => {
     return childProps;
   }, initialChildProps);
 };
+
+export { getBaseProps };

--- a/src/components/victory-bar/helper-methods.js
+++ b/src/components/victory-bar/helper-methods.js
@@ -1,81 +1,78 @@
 import { assign, defaults, keys, omit, isNaN } from "lodash";
 import { Helpers, LabelHelpers, Data, Domain, Scale } from "victory-core";
 
-export default {
+const getBarPosition = (props, datum) => {
+  const getDefaultMin = (axis) => {
+    const defaultMin = Scale.getType(props.scale[axis]) === "log" ?
+      1 / Number.MAX_SAFE_INTEGER : 0;
+    return datum[`_${axis}`] instanceof Date ? new Date(defaultMin) : defaultMin;
+  };
+  const _y0 = datum._y0 !== undefined ? datum._y0 : getDefaultMin("y");
+  const _x0 = datum._x0 !== undefined ? datum._x0 : getDefaultMin("x");
+  return Helpers.scalePoint(props, assign({}, datum, { _y0, _x0 }));
+};
 
-  getBarPosition(props, datum) {
-    const getDefaultMin = (axis) => {
-      const defaultMin = Scale.getType(props.scale[axis]) === "log" ?
-        1 / Number.MAX_SAFE_INTEGER : 0;
-      return datum[`_${axis}`] instanceof Date ? new Date(defaultMin) : defaultMin;
+const getBarStyle = (datum, baseStyle) => {
+  const numKeys = keys(datum).filter((k) => isNaN(k));
+  const omitKeys = [
+    "x", "y", "y0", "_x", "_y", "_y0", "name", "label", "eventKey"
+  ];
+  const styleData = omit(datum, [...omitKeys, ...numKeys]);
+  return defaults({}, styleData, baseStyle);
+};
+
+const getCalculatedValues = (props) => {
+  const { theme, horizontal, polar } = props;
+  const defaultStyles = theme && theme.bar && theme.bar.style ? theme.bar.style : {};
+  const style = Helpers.getStyles(props.style, defaultStyles);
+  const data = Data.getData(props);
+  const range = {
+    x: Helpers.getRange(props, "x"),
+    y: Helpers.getRange(props, "y")
+  };
+  const domain = {
+    x: Domain.getDomainWithZero(props, "x"),
+    y: Domain.getDomainWithZero(props, "y")
+  };
+  const xScale = Scale.getBaseScale(props, "x").domain(domain.x).range(range.x);
+  const yScale = Scale.getBaseScale(props, "y").domain(domain.y).range(range.y);
+  const scale = {
+    x: horizontal ? yScale : xScale,
+    y: horizontal ? xScale : yScale
+  };
+  const origin = polar ? props.origin || Helpers.getPolarOrigin(props) : undefined;
+  return { style, data, scale, domain, origin };
+};
+
+export const getBaseProps = (props, fallbackProps) => {
+  const modifiedProps = Helpers.modifyProps(props, fallbackProps, "bar");
+  props = assign({}, modifiedProps, getCalculatedValues(modifiedProps));
+  const {
+    alignment, barRatio, cornerRadius, data, domain, events, height, horizontal, origin, padding,
+    polar, scale, sharedEvents, standalone, style, theme, width
+  } = props;
+  const initialChildProps = { parent: {
+    domain, scale, width, height, data, standalone,
+    theme, polar, origin, padding, style: style.parent
+  } };
+
+  return data.reduce((childProps, datum, index) => {
+    const eventKey = datum.eventKey || index;
+    const { x, y, y0, x0 } = getBarPosition(props, datum);
+    const barStyle = getBarStyle(datum, style.data);
+    const dataProps = {
+      alignment, barRatio, cornerRadius, data, datum, horizontal, index, padding, polar, origin,
+      scale, style: barStyle, width, height, x, y, y0, x0
     };
-    const _y0 = datum._y0 !== undefined ? datum._y0 : getDefaultMin("y");
-    const _x0 = datum._x0 !== undefined ? datum._x0 : getDefaultMin("x");
-    return Helpers.scalePoint(props, assign({}, datum, { _y0, _x0 }));
-  },
 
-  getBarStyle(datum, baseStyle) {
-    const numKeys = keys(datum).filter((k) => isNaN(k));
-    const omitKeys = [
-      "x", "y", "y0", "_x", "_y", "_y0", "name", "label", "eventKey"
-    ];
-    const styleData = omit(datum, [...omitKeys, ...numKeys]);
-    return defaults({}, styleData, baseStyle);
-  },
-
-  getCalculatedValues(props) {
-    const { theme, horizontal, polar } = props;
-    const defaultStyles = theme && theme.bar && theme.bar.style ? theme.bar.style : {};
-    const style = Helpers.getStyles(props.style, defaultStyles);
-    const data = Data.getData(props);
-    const range = {
-      x: Helpers.getRange(props, "x"),
-      y: Helpers.getRange(props, "y")
+    childProps[eventKey] = {
+      data: dataProps
     };
-    const domain = {
-      x: Domain.getDomainWithZero(props, "x"),
-      y: Domain.getDomainWithZero(props, "y")
-    };
-    const xScale = Scale.getBaseScale(props, "x").domain(domain.x).range(range.x);
-    const yScale = Scale.getBaseScale(props, "y").domain(domain.y).range(range.y);
-    const scale = {
-      x: horizontal ? yScale : xScale,
-      y: horizontal ? xScale : yScale
-    };
-    const origin = polar ? props.origin || Helpers.getPolarOrigin(props) : undefined;
-    return { style, data, scale, domain, origin };
-  },
 
-  getBaseProps(props, fallbackProps) {
-    const modifiedProps = Helpers.modifyProps(props, fallbackProps, "bar");
-    props = assign({}, modifiedProps, this.getCalculatedValues(modifiedProps));
-    const {
-      alignment, barRatio, cornerRadius, data, domain, events, height, horizontal, origin, padding,
-      polar, scale, sharedEvents, standalone, style, theme, width
-    } = props;
-    const initialChildProps = { parent: {
-      domain, scale, width, height, data, standalone,
-      theme, polar, origin, padding, style: style.parent
-    } };
-
-    return data.reduce((childProps, datum, index) => {
-      const eventKey = datum.eventKey || index;
-      const { x, y, y0, x0 } = this.getBarPosition(props, datum);
-      const barStyle = this.getBarStyle(datum, style.data);
-      const dataProps = {
-        alignment, barRatio, cornerRadius, data, datum, horizontal, index, padding, polar, origin,
-        scale, style: barStyle, width, height, x, y, y0, x0
-      };
-
-      childProps[eventKey] = {
-        data: dataProps
-      };
-
-      const text = LabelHelpers.getText(props, datum, index);
-      if (text !== undefined && text !== null || events || sharedEvents) {
-        childProps[eventKey].labels = LabelHelpers.getProps(props, index);
-      }
-      return childProps;
-    }, initialChildProps);
-  }
+    const text = LabelHelpers.getText(props, datum, index);
+    if (text !== undefined && text !== null || events || sharedEvents) {
+      childProps[eventKey].labels = LabelHelpers.getProps(props, index);
+    }
+    return childProps;
+  }, initialChildProps);
 };

--- a/src/components/victory-bar/victory-bar.js
+++ b/src/components/victory-bar/victory-bar.js
@@ -1,6 +1,6 @@
 import PropTypes from "prop-types";
 import React from "react";
-import BarHelpers from "./helper-methods";
+import { getBaseProps } from "./helper-methods";
 import { partialRight } from "lodash";
 import {
   Helpers, VictoryLabel, VictoryContainer, VictoryTheme, Bar, addEvents, Data, Domain
@@ -68,7 +68,7 @@ class VictoryBar extends React.Component {
 
   static getDomain = Domain.getDomainWithZero.bind(Domain);
   static getData = Data.getData.bind(Data);
-  static getBaseProps = partialRight(BarHelpers.getBaseProps.bind(BarHelpers), fallbackProps);
+  static getBaseProps = partialRight(getBaseProps.bind(getBaseProps), fallbackProps);
   static expectedComponents = [
     "dataComponent", "labelComponent", "groupComponent", "containerComponent"
   ];

--- a/src/components/victory-bar/victory-bar.js
+++ b/src/components/victory-bar/victory-bar.js
@@ -68,7 +68,7 @@ class VictoryBar extends React.Component {
 
   static getDomain = Domain.getDomainWithZero.bind(Domain);
   static getData = Data.getData.bind(Data);
-  static getBaseProps = partialRight(getBaseProps.bind(getBaseProps), fallbackProps);
+  static getBaseProps = partialRight(getBaseProps, fallbackProps);
   static expectedComponents = [
     "dataComponent", "labelComponent", "groupComponent", "containerComponent"
   ];

--- a/src/components/victory-candlestick/helper-methods.js
+++ b/src/components/victory-candlestick/helper-methods.js
@@ -1,190 +1,189 @@
 import { assign, sortBy, keys, omit, defaults, isNaN } from "lodash";
 import { Helpers, LabelHelpers, Scale, Domain, Data } from "victory-core";
 
-export default {
-  getBaseProps(props, fallbackProps) { // eslint-disable-line max-statements
-    props = Helpers.modifyProps(props, fallbackProps, "candlestick");
-    const calculatedValues = this.getCalculatedValues(props);
-    const { data, style, scale, domain, origin } = calculatedValues;
-    const {
-      groupComponent, width, height, padding, standalone,
-      theme, polar, wickStrokeWidth
-    } = props;
-    const initialChildProps = { parent: {
-      domain, scale, width, height, data, standalone, theme, polar, origin,
-      style: style.parent, padding
-    } };
+const sortData = (dataset, sortKey, sortOrder = "ascending") => {
+  if (!sortKey) {
+    return dataset;
+  }
 
-    return data.reduce((childProps, datum, index) => {
-      const eventKey = datum.eventKey || index;
-      const x = scale.x(datum._x1 !== undefined ? datum._x1 : datum._x);
-      const high = scale.y(datum._high);
-      const close = scale.y(datum._close);
-      const open = scale.y(datum._open);
-      const low = scale.y(datum._low);
-      const candleHeight = Math.abs(scale.y(datum._open) - scale.y(datum._close));
-      const dataStyle = this.getDataStyles(datum, style.data, props);
-      const dataProps = {
-        x, high, low, candleHeight, scale, data, datum, groupComponent, index,
-        style: dataStyle, padding, width, polar, origin, wickStrokeWidth, open, close
-      };
+  if (sortKey === "x" || sortKey === "y") {
+    sortKey = `_${sortKey}`;
+  }
 
-      childProps[eventKey] = {
-        data: dataProps
-      };
-      const text = LabelHelpers.getText(props, datum, index);
-      if (text !== undefined && text !== null || props.events || props.sharedEvents) {
-        childProps[eventKey].labels = this.getLabelProps(dataProps, text, style);
-      }
+  const sortedData = sortBy(dataset, sortKey);
 
-      return childProps;
-    }, initialChildProps);
-  },
+  if (sortOrder === "descending") {
+    return sortedData.reverse();
+  }
 
-  getLabelProps(dataProps, text, style) {
-    const { x, high, index, scale, datum, data } = dataProps;
-    const labelStyle = style.labels || {};
-    return {
-      style: labelStyle,
-      y: high - (labelStyle.padding || 0),
-      x,
-      text,
-      index,
-      scale,
-      datum,
-      data,
-      textAnchor: labelStyle.textAnchor,
-      verticalAnchor: labelStyle.verticalAnchor || "end",
-      angle: labelStyle.angle
-    };
-  },
+  return sortedData;
+};
 
-  getCalculatedValues(props) {
-    const { theme, polar } = props;
-    const defaultStyle = theme && theme.candlestick && theme.candlestick.style ?
-      theme.candlestick.style : {};
-    const style = Helpers.getStyles(props.style, defaultStyle);
-    const data = Data.addEventKeys(props, this.getData(props));
-    const range = {
-      x: Helpers.getRange(props, "x"),
-      y: Helpers.getRange(props, "y")
-    };
-    const domain = {
-      x: this.getDomain(props, "x"),
-      y: this.getDomain(props, "y")
-    };
-    const scale = {
-      x: Scale.getBaseScale(props, "x").domain(domain.x).range(range.x),
-      y: Scale.getBaseScale(props, "y").domain(domain.y).range(range.y)
-    };
-    const origin = polar ? props.origin || Helpers.getPolarOrigin(props) : undefined;
-    return { domain, data, scale, style, origin };
-  },
+export const getData = (props) => {
+  if (!props.data || Data.getLength(props.data) < 1) {
+    return [];
+  }
+  const stringMap = {
+    x: Data.createStringMap(props, "x")
+  };
 
-  getData(props) {
-    if (!props.data || Data.getLength(props.data) < 1) {
-      return [];
-    }
-    const stringMap = {
-      x: Data.createStringMap(props, "x")
-    };
+  const accessor = {
+    x: Helpers.createAccessor(props.x !== undefined ? props.x : "x"),
+    open: Helpers.createAccessor(props.open !== undefined ? props.open : "open"),
+    close: Helpers.createAccessor(props.close !== undefined ? props.close : "close"),
+    high: Helpers.createAccessor(props.high !== undefined ? props.high : "high"),
+    low: Helpers.createAccessor(props.low !== undefined ? props.low : "low")
+  };
 
-    const accessor = {
-      x: Helpers.createAccessor(props.x !== undefined ? props.x : "x"),
-      open: Helpers.createAccessor(props.open !== undefined ? props.open : "open"),
-      close: Helpers.createAccessor(props.close !== undefined ? props.close : "close"),
-      high: Helpers.createAccessor(props.high !== undefined ? props.high : "high"),
-      low: Helpers.createAccessor(props.low !== undefined ? props.low : "low")
-    };
+  const formattedData = props.data.reduce((dataArr, datum, index) => {
+    datum = Data.parseDatum(datum);
 
-    const formattedData = props.data.reduce((dataArr, datum, index) => {
-      datum = Data.parseDatum(datum);
+    const evaluatedX = accessor.x(datum);
+    const _x = evaluatedX !== undefined ? evaluatedX : index;
+    const _open = accessor.open(datum);
+    const _close = accessor.close(datum);
+    const _high = accessor.high(datum);
+    const _low = accessor.low(datum);
+    const _y = [_open, _close, _high, _low];
 
-      const evaluatedX = accessor.x(datum);
-      const _x = evaluatedX !== undefined ? evaluatedX : index;
-      const _open = accessor.open(datum);
-      const _close = accessor.close(datum);
-      const _high = accessor.high(datum);
-      const _low = accessor.low(datum);
-      const _y = [_open, _close, _high, _low];
+    dataArr.push(
+      assign(
+        {},
+        datum,
+        { _x, _y, _open, _close, _high, _low },
+        typeof _x === "string" ? { _x: stringMap.x[_x], x: _x } : {}
+      )
+    );
 
-      dataArr.push(
-        assign(
-          {},
-          datum,
-          { _x, _y, _open, _close, _high, _low },
-          typeof _x === "string" ? { _x: stringMap.x[_x], x: _x } : {}
-        )
-      );
+    return dataArr;
+  }, []);
 
-      return dataArr;
-    }, []);
+  return sortData(formattedData, props.sortKey, props.sortOrder);
+};
 
-    return this.sortData(formattedData, props.sortKey, props.sortOrder);
-  },
-
-  sortData(dataset, sortKey, sortOrder = "ascending") {
-    if (!sortKey) {
-      return dataset;
-    }
-
-    if (sortKey === "x" || sortKey === "y") {
-      sortKey = `_${sortKey}`;
-    }
-
-    const sortedData = sortBy(dataset, sortKey);
-
-    if (sortOrder === "descending") {
-      return sortedData.reverse();
-    }
-
-    return sortedData;
-  },
-
-  getDomain(props, axis) {
-    let domain;
-    if (props.domain && props.domain[axis]) {
-      domain = props.domain[axis];
-    } else if (props.domain && Array.isArray(props.domain)) {
-      domain = props.domain;
-    } else {
-      const dataset = this.getData(props);
-      const allData = dataset.reduce((memo, datum) => {
-        return Array.isArray(datum[`_${axis}`]) ?
-         memo.concat(...datum[`_${axis}`]) : memo.concat(datum[`_${axis}`]);
-      },
+export const getDomain = (props, axis) => {
+  let domain;
+  if (props.domain && props.domain[axis]) {
+    domain = props.domain[axis];
+  } else if (props.domain && Array.isArray(props.domain)) {
+    domain = props.domain;
+  } else {
+    const dataset = getData(props);
+    const allData = dataset.reduce((memo, datum) => {
+      return Array.isArray(datum[`_${axis}`]) ?
+        memo.concat(...datum[`_${axis}`]) : memo.concat(datum[`_${axis}`]);
+    },
       []);
 
-      if (allData.length < 1) {
-        return Scale.getBaseScale(props, axis).domain();
-      }
-
-      const min = Math.min(...allData);
-      const max = Math.max(...allData);
-      if (+min === +max) {
-        return Domain.getSinglePointDomain(max);
-      }
-      domain = [min, max];
+    if (allData.length < 1) {
+      return Scale.getBaseScale(props, axis).domain();
     }
-    return Domain.cleanDomain(Domain.padDomain(domain, props, axis), props);
-  },
 
-  isTransparent(attr) {
-    return attr === "none" || attr === "transparent";
-  },
-
-  getDataStyles(datum, style, props) {
-    style = style || {};
-    const numKeys = keys(datum).filter((k) => isNaN(k));
-    const omitKeys = [
-      "x", "_x", "_y", "_y0", "size", "name", "label", "open", "close", "high", "low", "eventKey"
-    ];
-    const stylesFromData = omit(datum, [...omitKeys, ...numKeys]);
-    const candleColor = datum.open > datum.close ?
-      props.candleColors.negative : props.candleColors.positive;
-    const fill = datum.fill || style.fill || candleColor;
-    const strokeColor = datum.stroke || style.stroke;
-    const stroke = this.isTransparent(strokeColor) ? fill : strokeColor || "black";
-    return defaults({}, stylesFromData, { stroke, fill }, style);
+    const min = Math.min(...allData);
+    const max = Math.max(...allData);
+    if (+min === +max) {
+      return Domain.getSinglePointDomain(max);
+    }
+    domain = [min, max];
   }
+  return Domain.cleanDomain(Domain.padDomain(domain, props, axis), props);
+};
+
+const getCalculatedValues = (props) => {
+  const { theme, polar } = props;
+  const defaultStyle = theme && theme.candlestick && theme.candlestick.style ?
+    theme.candlestick.style : {};
+  const style = Helpers.getStyles(props.style, defaultStyle);
+  const data = Data.addEventKeys(props, getData(props));
+  const range = {
+    x: Helpers.getRange(props, "x"),
+    y: Helpers.getRange(props, "y")
+  };
+  const domain = {
+    x: getDomain(props, "x"),
+    y: getDomain(props, "y")
+  };
+  const scale = {
+    x: Scale.getBaseScale(props, "x").domain(domain.x).range(range.x),
+    y: Scale.getBaseScale(props, "y").domain(domain.y).range(range.y)
+  };
+  const origin = polar ? props.origin || Helpers.getPolarOrigin(props) : undefined;
+  return { domain, data, scale, style, origin };
+};
+
+
+const isTransparent = (attr) => {
+  return attr === "none" || attr === "transparent";
+};
+
+const getDataStyles = (datum, style, props) => {
+  style = style || {};
+  const numKeys = keys(datum).filter((k) => isNaN(k));
+  const omitKeys = [
+    "x", "_x", "_y", "_y0", "size", "name", "label", "open", "close", "high", "low", "eventKey"
+  ];
+  const stylesFromData = omit(datum, [...omitKeys, ...numKeys]);
+  const candleColor = datum.open > datum.close ?
+    props.candleColors.negative : props.candleColors.positive;
+  const fill = datum.fill || style.fill || candleColor;
+  const strokeColor = datum.stroke || style.stroke;
+  const stroke = isTransparent(strokeColor) ? fill : strokeColor || "black";
+  return defaults({}, stylesFromData, { stroke, fill }, style);
+};
+
+const getLabelProps = (dataProps, text, style) => {
+  const { x, high, index, scale, datum, data } = dataProps;
+  const labelStyle = style.labels || {};
+  return {
+    style: labelStyle,
+    y: high - (labelStyle.padding || 0),
+    x,
+    text,
+    index,
+    scale,
+    datum,
+    data,
+    textAnchor: labelStyle.textAnchor,
+    verticalAnchor: labelStyle.verticalAnchor || "end",
+    angle: labelStyle.angle
+  };
+};
+
+export const getBaseProps = (props, fallbackProps) => { // eslint-disable-line max-statements
+  props = Helpers.modifyProps(props, fallbackProps, "candlestick");
+  const calculatedValues = getCalculatedValues(props);
+  const { data, style, scale, domain, origin } = calculatedValues;
+  const {
+    groupComponent, width, height, padding, standalone,
+    theme, polar, wickStrokeWidth
+  } = props;
+  const initialChildProps = { parent: {
+    domain, scale, width, height, data, standalone, theme, polar, origin,
+    style: style.parent, padding
+  } };
+
+  return data.reduce((childProps, datum, index) => {
+    const eventKey = datum.eventKey || index;
+    const x = scale.x(datum._x1 !== undefined ? datum._x1 : datum._x);
+    const high = scale.y(datum._high);
+    const close = scale.y(datum._close);
+    const open = scale.y(datum._open);
+    const low = scale.y(datum._low);
+    const candleHeight = Math.abs(scale.y(datum._open) - scale.y(datum._close));
+    const dataStyle = getDataStyles(datum, style.data, props);
+    const dataProps = {
+      x, high, low, candleHeight, scale, data, datum, groupComponent, index,
+      style: dataStyle, padding, width, polar, origin, wickStrokeWidth, open, close
+    };
+
+    childProps[eventKey] = {
+      data: dataProps
+    };
+    const text = LabelHelpers.getText(props, datum, index);
+    if (text !== undefined && text !== null || props.events || props.sharedEvents) {
+      childProps[eventKey].labels = getLabelProps(dataProps, text, style);
+    }
+
+    return childProps;
+  }, initialChildProps);
 };

--- a/src/components/victory-candlestick/helper-methods.js
+++ b/src/components/victory-candlestick/helper-methods.js
@@ -19,7 +19,7 @@ const sortData = (dataset, sortKey, sortOrder = "ascending") => {
   return sortedData;
 };
 
-export const getData = (props) => {
+const getData = (props) => {
   if (!props.data || Data.getLength(props.data) < 1) {
     return [];
   }
@@ -61,7 +61,7 @@ export const getData = (props) => {
   return sortData(formattedData, props.sortKey, props.sortOrder);
 };
 
-export const getDomain = (props, axis) => {
+const getDomain = (props, axis) => {
   let domain;
   if (props.domain && props.domain[axis]) {
     domain = props.domain[axis];
@@ -149,7 +149,7 @@ const getLabelProps = (dataProps, text, style) => {
   };
 };
 
-export const getBaseProps = (props, fallbackProps) => { // eslint-disable-line max-statements
+const getBaseProps = (props, fallbackProps) => { // eslint-disable-line max-statements
   props = Helpers.modifyProps(props, fallbackProps, "candlestick");
   const calculatedValues = getCalculatedValues(props);
   const { data, style, scale, domain, origin } = calculatedValues;
@@ -187,3 +187,5 @@ export const getBaseProps = (props, fallbackProps) => { // eslint-disable-line m
     return childProps;
   }, initialChildProps);
 };
+
+export { getBaseProps, getDomain, getData };

--- a/src/components/victory-candlestick/victory-candlestick.js
+++ b/src/components/victory-candlestick/victory-candlestick.js
@@ -84,9 +84,9 @@ class VictoryCandlestick extends React.Component {
     theme: VictoryTheme.grayscale
   };
 
-  static getDomain = getDomain.bind(getDomain);
-  static getData = getData.bind(getData);
-  static getBaseProps = partialRight(getBaseProps.bind(getBaseProps), fallbackProps);
+  static getDomain = getDomain;
+  static getData = getData;
+  static getBaseProps = partialRight(getBaseProps, fallbackProps);
   static expectedComponents = [
     "dataComponent", "labelComponent", "groupComponent", "containerComponent"
   ];

--- a/src/components/victory-candlestick/victory-candlestick.js
+++ b/src/components/victory-candlestick/victory-candlestick.js
@@ -5,7 +5,7 @@ import {
   PropTypes as CustomPropTypes, Helpers, VictoryLabel, addEvents,
   VictoryContainer, VictoryTheme, DefaultTransitions, Candle
 } from "victory-core";
-import CandlestickHelpers from "./helper-methods";
+import { getDomain, getData, getBaseProps } from "./helper-methods";
 import { BaseProps, DataProps } from "../../helpers/common-props";
 
 /*eslint-disable no-magic-numbers */
@@ -84,10 +84,9 @@ class VictoryCandlestick extends React.Component {
     theme: VictoryTheme.grayscale
   };
 
-  static getDomain = CandlestickHelpers.getDomain.bind(CandlestickHelpers);
-  static getData = CandlestickHelpers.getData.bind(CandlestickHelpers);
-  static getBaseProps = partialRight(
-    CandlestickHelpers.getBaseProps.bind(CandlestickHelpers), fallbackProps);
+  static getDomain = getDomain.bind(getDomain);
+  static getData = getData.bind(getData);
+  static getBaseProps = partialRight(getBaseProps.bind(getBaseProps), fallbackProps);
   static expectedComponents = [
     "dataComponent", "labelComponent", "groupComponent", "containerComponent"
   ];

--- a/src/components/victory-chart/helper-methods.js
+++ b/src/components/victory-chart/helper-methods.js
@@ -3,7 +3,7 @@ import Wrapper from "../../helpers/wrapper";
 import React from "react";
 import { Collection, Log } from "victory-core";
 
-export const getDataComponents = (childComponents) => {
+const getDataComponents = (childComponents) => {
   const findDataComponents = (children) => {
     return children.reduce((memo, child) => {
       if (child.type && child.type.role === "axis") {
@@ -18,7 +18,7 @@ export const getDataComponents = (childComponents) => {
   return findDataComponents(childComponents);
 };
 
-export const getChildComponents = (props, defaultAxes) => {
+const getChildComponents = (props, defaultAxes) => {
   const childComponents = React.Children.toArray(props.children);
   if (childComponents.length === 0) {
     return [defaultAxes.independent, defaultAxes.dependent];
@@ -45,7 +45,7 @@ export const getChildComponents = (props, defaultAxes) => {
   return childComponents;
 };
 
-export const getDefaultDomainPadding = (childComponents, horizontal) => {
+const getDefaultDomainPadding = (childComponents, horizontal) => {
   const groupComponent = childComponents.filter((child) => {
     return child.type && child.type.role && child.type.role === "group-wrapper";
   });
@@ -60,7 +60,7 @@ export const getDefaultDomainPadding = (childComponents, horizontal) => {
     { x: (offset * children.length) / 2 };
 };
 
-export const getDomain = (props, axis, childComponents) => {
+const getDomain = (props, axis, childComponents) => {
   childComponents = childComponents || React.Children.toArray(props.children);
   const domain = Wrapper.getDomain(props, axis, childComponents);
   const axisComponent = Axis.getAxisComponent(childComponents, axis);
@@ -69,7 +69,7 @@ export const getDomain = (props, axis, childComponents) => {
 };
 
 // eslint-disable-next-line complexity
-export const getAxisOffset = (props, calculatedProps) => {
+const getAxisOffset = (props, calculatedProps) => {
   const { axisComponents, scale, origin, domain, originSign, padding } = calculatedProps;
   const { top, bottom, left, right } = padding;
   // make the axes line up, and cross when appropriate
@@ -102,11 +102,19 @@ export const getAxisOffset = (props, calculatedProps) => {
   };
 };
 
-export const createStringMap = (props, axis, childComponents) => {
+const createStringMap = (props, axis, childComponents) => {
   const allStrings = Wrapper.getStringsFromChildren(props, axis, childComponents);
   return allStrings.length === 0 ? null :
     allStrings.reduce((memo, string, index) => {
       memo[string] = index + 1;
       return memo;
     }, {});
+};
+
+export { getDomain,
+  getAxisOffset,
+  getDataComponents,
+  getChildComponents,
+  getDefaultDomainPadding,
+  createStringMap
 };

--- a/src/components/victory-chart/helper-methods.js
+++ b/src/components/victory-chart/helper-methods.js
@@ -3,113 +3,110 @@ import Wrapper from "../../helpers/wrapper";
 import React from "react";
 import { Collection, Log } from "victory-core";
 
-
-export default {
-  getChildComponents(props, defaultAxes) {
-    const childComponents = React.Children.toArray(props.children);
-    if (childComponents.length === 0) {
-      return [defaultAxes.independent, defaultAxes.dependent];
-    }
-
-    const axisComponents = {
-      dependent: Axis.getAxisComponentsWithParent(childComponents, "dependent"),
-      independent: Axis.getAxisComponentsWithParent(childComponents, "independent")
-    };
-
-    if (axisComponents.dependent.length === 0 && axisComponents.independent.length === 0) {
-      return childComponents.concat([defaultAxes.independent, defaultAxes.dependent]);
-    }
-    if (axisComponents.independent.length > 1) {
-      const msg = "Only one independent VictoryAxis component is allowed when " +
-        "using the VictoryChart wrapper. Only the first axis will be used. Please compose " +
-        "multi-axis charts manually";
-      Log.warn(msg);
-      const dataComponents = this.getDataComponents(childComponents);
-      return Collection.removeUndefined(
-        dataComponents.concat([...axisComponents.dependent, axisComponents.independent[0]])
-      );
-    }
-    return childComponents;
-  },
-
-  getDefaultDomainPadding(childComponents, horizontal) {
-    const groupComponent = childComponents.filter((child) => {
-      return child.type && child.type.role && child.type.role === "group-wrapper";
-    });
-
-    if (groupComponent.length < 1) {
-      return undefined;
-    }
-
-    const { offset, children } = groupComponent[0].props;
-    return horizontal ?
-      { y: (offset * children.length) / 2 } :
-      { x: (offset * children.length) / 2 };
-  },
-
-  getDataComponents(childComponents) {
-    const findDataComponents = (children) => {
-      return children.reduce((memo, child) => {
-        if (child.type && child.type.role === "axis") {
-          return memo;
-        } else if (child.props && child.props.children) {
-          return memo.concat(findDataComponents(React.Children.toArray(child.props.children)));
-        }
-        return memo.concat(child);
-      }, []);
-    };
-
-    return findDataComponents(childComponents);
-  },
-
-  getDomain(props, axis, childComponents) {
-    childComponents = childComponents || React.Children.toArray(props.children);
-    const domain = Wrapper.getDomain(props, axis, childComponents);
-    const axisComponent = Axis.getAxisComponent(childComponents, axis);
-    const invertDomain = axisComponent && axisComponent.props && axisComponent.props.invertAxis;
-    return invertDomain ? domain.concat().reverse() : domain;
-  },
-
-  // eslint-disable-next-line complexity
-  getAxisOffset(props, calculatedProps) {
-    const { axisComponents, scale, origin, domain, originSign, padding } = calculatedProps;
-    const { top, bottom, left, right } = padding;
-    // make the axes line up, and cross when appropriate
-    const axisOrientations = {
-      x: Axis.getOrientation(axisComponents.x, "x", originSign.y),
-      y: Axis.getOrientation(axisComponents.y, "y", originSign.x)
-    };
-    const orientationOffset = {
-      y: axisOrientations.x === "bottom" ? bottom : top,
-      x: axisOrientations.y === "left" ? left : right
-    };
-    const originOffset = {
-      x: axisOrientations.y === "left" ? 0 : props.width,
-      y: axisOrientations.x === "bottom" ? props.height : 0
-    };
-    const originPosition = {
-      x: origin.x === domain.x[0] || origin.x === domain.x[1] ? 0 : scale.x(origin.x),
-      y: origin.y === domain.y[0] || origin.y === domain.y[1] ? 0 : scale.y(origin.y)
-    };
-    const calculatedOffset = {
-      x: originPosition.x ? Math.abs(originOffset.x - originPosition.x) : orientationOffset.x,
-      y: originPosition.y ? Math.abs(originOffset.y - originPosition.y) : orientationOffset.y
-    };
-
-    return {
-      x: axisComponents.x && axisComponents.x.offsetX !== undefined ?
-        axisComponents.x.offsetX : calculatedOffset.x,
-      y: axisComponents.y && axisComponents.y.offsetY !== undefined ?
-        axisComponents.y.offsetY : calculatedOffset.y
-    };
-  },
-
-  createStringMap(props, axis, childComponents) {
-    const allStrings = Wrapper.getStringsFromChildren(props, axis, childComponents);
-    return allStrings.length === 0 ? null :
-      allStrings.reduce((memo, string, index) => {
-        memo[string] = index + 1;
+export const getDataComponents = (childComponents) => {
+  const findDataComponents = (children) => {
+    return children.reduce((memo, child) => {
+      if (child.type && child.type.role === "axis") {
         return memo;
-      }, {});
+      } else if (child.props && child.props.children) {
+        return memo.concat(findDataComponents(React.Children.toArray(child.props.children)));
+      }
+      return memo.concat(child);
+    }, []);
+  };
+
+  return findDataComponents(childComponents);
+};
+
+export const getChildComponents = (props, defaultAxes) => {
+  const childComponents = React.Children.toArray(props.children);
+  if (childComponents.length === 0) {
+    return [defaultAxes.independent, defaultAxes.dependent];
   }
+
+  const axisComponents = {
+    dependent: Axis.getAxisComponentsWithParent(childComponents, "dependent"),
+    independent: Axis.getAxisComponentsWithParent(childComponents, "independent")
+  };
+
+  if (axisComponents.dependent.length === 0 && axisComponents.independent.length === 0) {
+    return childComponents.concat([defaultAxes.independent, defaultAxes.dependent]);
+  }
+  if (axisComponents.independent.length > 1) {
+    const msg = "Only one independent VictoryAxis component is allowed when " +
+      "using the VictoryChart wrapper. Only the first axis will be used. Please compose " +
+      "multi-axis charts manually";
+    Log.warn(msg);
+    const dataComponents = getDataComponents(childComponents);
+    return Collection.removeUndefined(
+      dataComponents.concat([...axisComponents.dependent, axisComponents.independent[0]])
+    );
+  }
+  return childComponents;
+};
+
+export const getDefaultDomainPadding = (childComponents, horizontal) => {
+  const groupComponent = childComponents.filter((child) => {
+    return child.type && child.type.role && child.type.role === "group-wrapper";
+  });
+
+  if (groupComponent.length < 1) {
+    return undefined;
+  }
+
+  const { offset, children } = groupComponent[0].props;
+  return horizontal ?
+    { y: (offset * children.length) / 2 } :
+    { x: (offset * children.length) / 2 };
+};
+
+export const getDomain = (props, axis, childComponents) => {
+  childComponents = childComponents || React.Children.toArray(props.children);
+  const domain = Wrapper.getDomain(props, axis, childComponents);
+  const axisComponent = Axis.getAxisComponent(childComponents, axis);
+  const invertDomain = axisComponent && axisComponent.props && axisComponent.props.invertAxis;
+  return invertDomain ? domain.concat().reverse() : domain;
+};
+
+// eslint-disable-next-line complexity
+export const getAxisOffset = (props, calculatedProps) => {
+  const { axisComponents, scale, origin, domain, originSign, padding } = calculatedProps;
+  const { top, bottom, left, right } = padding;
+  // make the axes line up, and cross when appropriate
+  const axisOrientations = {
+    x: Axis.getOrientation(axisComponents.x, "x", originSign.y),
+    y: Axis.getOrientation(axisComponents.y, "y", originSign.x)
+  };
+  const orientationOffset = {
+    y: axisOrientations.x === "bottom" ? bottom : top,
+    x: axisOrientations.y === "left" ? left : right
+  };
+  const originOffset = {
+    x: axisOrientations.y === "left" ? 0 : props.width,
+    y: axisOrientations.x === "bottom" ? props.height : 0
+  };
+  const originPosition = {
+    x: origin.x === domain.x[0] || origin.x === domain.x[1] ? 0 : scale.x(origin.x),
+    y: origin.y === domain.y[0] || origin.y === domain.y[1] ? 0 : scale.y(origin.y)
+  };
+  const calculatedOffset = {
+    x: originPosition.x ? Math.abs(originOffset.x - originPosition.x) : orientationOffset.x,
+    y: originPosition.y ? Math.abs(originOffset.y - originPosition.y) : orientationOffset.y
+  };
+
+  return {
+    x: axisComponents.x && axisComponents.x.offsetX !== undefined ?
+      axisComponents.x.offsetX : calculatedOffset.x,
+    y: axisComponents.y && axisComponents.y.offsetY !== undefined ?
+      axisComponents.y.offsetY : calculatedOffset.y
+  };
+};
+
+export const createStringMap = (props, axis, childComponents) => {
+  const allStrings = Wrapper.getStringsFromChildren(props, axis, childComponents);
+  return allStrings.length === 0 ? null :
+    allStrings.reduce((memo, string, index) => {
+      memo[string] = index + 1;
+      return memo;
+    }, {});
 };

--- a/src/components/victory-chart/victory-chart.js
+++ b/src/components/victory-chart/victory-chart.js
@@ -6,7 +6,9 @@ import {
 } from "victory-core";
 import VictoryAxis from "../victory-axis/victory-axis";
 import VictoryPolarAxis from "../victory-polar-axis/victory-polar-axis";
-import ChartHelpers from "./helper-methods";
+import {
+  getDomain, getAxisOffset, getChildComponents, getDefaultDomainPadding, createStringMap
+} from "./helper-methods";
 import Axis from "../../helpers/axis";
 import Wrapper from "../../helpers/wrapper";
 import { BaseProps } from "../../helpers/common-props";
@@ -103,7 +105,7 @@ export default class VictoryChart extends React.Component {
     const axis = child.type.getAxis(childProps);
     const currentAxis = Axis.getCurrentAxis(axis, horizontal);
     const otherAxis = axis === "x" ? "y" : "x";
-    const axisOffset = ChartHelpers.getAxisOffset(props, calculatedProps);
+    const axisOffset = getAxisOffset(props, calculatedProps);
     const offsetY = axis === "y" ? undefined : axisOffset.y;
     const offsetX = axis === "x" ? undefined : axisOffset.x;
     const crossAxis = childProps.crossAxis === false ? false : true;
@@ -142,8 +144,8 @@ export default class VictoryChart extends React.Component {
       y: Axis.getAxisComponent(childComponents, "y")
     };
     const domain = {
-      x: ChartHelpers.getDomain(props, "x", childComponents),
-      y: ChartHelpers.getDomain(props, "y", childComponents)
+      x: getDomain(props, "x", childComponents),
+      y: getDomain(props, "y", childComponents)
     };
     const range = {
       x: props.polar ? Helpers.getPolarRange(props, "x") : Helpers.getRange(props, "x"),
@@ -176,11 +178,11 @@ export default class VictoryChart extends React.Component {
     };
 
     const stringMap = {
-      x: ChartHelpers.createStringMap(props, "x", childComponents),
-      y: ChartHelpers.createStringMap(props, "y", childComponents)
+      x: createStringMap(props, "x", childComponents),
+      y: createStringMap(props, "y", childComponents)
     };
 
-    const defaultDomainPadding = ChartHelpers.getDefaultDomainPadding(childComponents, horizontal);
+    const defaultDomainPadding = getDefaultDomainPadding(childComponents, horizontal);
 
     const padding = Helpers.getPadding(props);
 
@@ -235,7 +237,7 @@ export default class VictoryChart extends React.Component {
       eventKey, containerComponent, groupComponent, standalone, externalEventMutations
     } = modifiedProps;
     const axes = props.polar ? modifiedProps.defaultPolarAxes : modifiedProps.defaultAxes;
-    const childComponents = ChartHelpers.getChildComponents(modifiedProps, axes);
+    const childComponents = getChildComponents(modifiedProps, axes);
     const calculatedProps = this.getCalculatedProps(modifiedProps, childComponents);
     const newChildren = this.getNewChildren(modifiedProps, childComponents, calculatedProps);
     const containerProps = standalone ? this.getContainerProps(modifiedProps, calculatedProps) : {};

--- a/src/components/victory-errorbar/helper-methods.js
+++ b/src/components/victory-errorbar/helper-methods.js
@@ -134,7 +134,7 @@ const getDomainFromData = (props, axis, dataset) => {
   return [min, max];
 };
 
-export const getDomain = (props, axis) => {
+const getDomain = (props, axis) => {
   const propsDomain = Domain.getDomainFromProps(props, axis);
   if (propsDomain) {
     return Domain.padDomain(propsDomain, props, axis);
@@ -205,7 +205,7 @@ const getDataStyles = (datum, style) => {
   return defaults({}, stylesFromData, style);
 };
 
-export const getBaseProps = (props, fallbackProps) => {
+const getBaseProps = (props, fallbackProps) => {
   props = Helpers.modifyProps(props, fallbackProps, "errorbar");
   const { data, style, scale, domain, origin } = getCalculatedValues(props, fallbackProps);
   const { groupComponent, height, width, borderWidth, standalone, theme, polar, padding } = props;
@@ -237,3 +237,5 @@ export const getBaseProps = (props, fallbackProps) => {
     return childProps;
   }, initialChildProps);
 };
+
+export { getBaseProps, getDomain };

--- a/src/components/victory-errorbar/helper-methods.js
+++ b/src/components/victory-errorbar/helper-methods.js
@@ -1,240 +1,239 @@
 import { assign, keys, omit, defaults, isArray, flatten, sortBy, isNaN } from "lodash";
 import { Helpers, LabelHelpers, Scale, Domain, Data } from "victory-core";
 
-export default {
-  getBaseProps(props, fallbackProps) {
-    props = Helpers.modifyProps(props, fallbackProps, "errorbar");
-    const { data, style, scale, domain, origin } = this.getCalculatedValues(props, fallbackProps);
-    const { groupComponent, height, width, borderWidth, standalone, theme, polar, padding } = props;
-    const initialChildProps = { parent: {
-      domain, scale, data, height, width, standalone, theme, polar, origin,
-      padding, style: style.parent
-    } };
+const getErrors = (datum, scale, axis) => {
+  /**
+   * check if it is asymmetric error or symmetric error, asymmetric error should be an array
+   * and the first value is the positive error, the second is the negative error
+   * @param  {Boolean} isArray(errorX)
+   * @return {String or Array}
+   */
 
-    return data.reduce((childProps, datum, index) => {
-      const eventKey = datum.eventKey || index;
-      const x = scale.x(datum._x1 !== undefined ? datum._x1 : datum._x);
-      const y = scale.y(datum._y1 !== undefined ? datum._y1 : datum._y);
+  const errorNames = { x: "errorX", y: "errorY" };
+  const errors = datum[errorNames[axis]];
+  if (errors === 0) {
+    return false;
+  }
 
-      const dataProps = {
-        x, y, scale, datum, data, index, groupComponent, borderWidth,
-        style: this.getDataStyles(datum, style.data),
-        errorX: this.getErrors(datum, scale, "x"),
-        errorY: this.getErrors(datum, scale, "y")
-      };
+  return isArray(errors) ?
+    [ errors[0] === 0 ? false : scale[axis](errors[0] + datum[`_${axis}`]),
+      errors[1] === 0 ? false : scale[axis](datum[`_${axis}`] - errors[1]) ] :
+    [ scale[axis](errors + datum[`_${axis}`]), scale[axis](datum[`_${axis}`] - errors) ];
+};
 
-      childProps[eventKey] = {
-        data: dataProps
-      };
-      const text = LabelHelpers.getText(props, datum, index);
-      if (text !== undefined && text !== null || props.events || props.sharedEvents) {
-        childProps[eventKey].labels = this.getLabelProps(dataProps, text, style);
-      }
+const sortData = (dataset, sortKey, sortOrder = "ascending") => {
+  if (!sortKey) {
+    return dataset;
+  }
 
-      return childProps;
-    }, initialChildProps);
-  },
+  if (sortKey === "x" || sortKey === "y") {
+    sortKey = `_${sortKey}`;
+  }
 
-  getLabelProps(dataProps, text, style) {
-    const { x, index, scale, errorY } = dataProps;
-    const error = errorY && Array.isArray(errorY) ? errorY[0] : errorY;
-    const y = error || dataProps.y;
-    const labelStyle = style.labels || {};
-    return {
-      style: labelStyle,
-      y: y - (labelStyle.padding || 0),
-      x,
-      text,
-      index,
-      scale,
-      datum: dataProps.datum,
-      data: dataProps.data,
-      textAnchor: labelStyle.textAnchor,
-      verticalAnchor: labelStyle.verticalAnchor || "end",
-      angle: labelStyle.angle
-    };
-  },
+  const sortedData = sortBy(dataset, sortKey);
 
-  getErrorData(props) {
-    if (props.data) {
-      if (Data.getLength(props.data) < 1) {
-        return [];
-      }
+  if (sortOrder === "descending") {
+    return sortedData.reverse();
+  }
 
-      return this.formatErrorData(props.data, props);
-    } else {
-      const generatedData = (props.errorX || props.errorY) && this.generateData(props);
-      return this.formatErrorData(generatedData, props);
-    }
-  },
+  return sortedData;
+};
 
-  getErrors(datum, scale, axis) {
-    /**
-     * check if it is asymmetric error or symmetric error, asymmetric error should be an array
-     * and the first value is the positive error, the second is the negative error
-     * @param  {Boolean} isArray(errorX)
-     * @return {String or Array}
-     */
+const formatErrorData = (dataset, props) => {
+  if (!dataset || Data.getLength(dataset) < 1) {
+    return [];
+  }
+  const accessor = {
+    x: Helpers.createAccessor(props.x !== undefined ? props.x : "x"),
+    y: Helpers.createAccessor(props.y !== undefined ? props.y : "y"),
+    errorX: Helpers.createAccessor(props.errorX !== undefined ? props.errorX : "errorX"),
+    errorY: Helpers.createAccessor(props.errorY !== undefined ? props.errorY : "errorY")
+  };
 
-    const errorNames = { x: "errorX", y: "errorY" };
-    const errors = datum[errorNames[axis]];
-    if (errors === 0) {
-      return false;
-    }
+  const replaceNegatives = (errors) => {
+    // check if the value is negative, if it is set to 0
+    const replaceNeg = (val) => !val || val < 0 ? 0 : val;
+    return isArray(errors) ? errors.map((err) => replaceNeg(err)) : replaceNeg(errors);
+  };
 
-    return isArray(errors) ?
-      [ errors[0] === 0 ? false : scale[axis](errors[0] + datum[`_${axis}`]),
-        errors[1] === 0 ? false : scale[axis](datum[`_${axis}`] - errors[1]) ] :
-      [ scale[axis](errors + datum[`_${axis}`]), scale[axis](datum[`_${axis}`] - errors) ];
-  },
+  const stringMap = {
+    x: Data.createStringMap(props, "x"),
+    y: Data.createStringMap(props, "y")
+  };
 
-  formatErrorData(dataset, props) {
-    if (!dataset || Data.getLength(dataset) < 1) {
+  const formattedData = dataset.reduce((dataArr, datum, index) => {
+    datum = Data.parseDatum(datum);
+
+    const evaluatedX = accessor.x(datum);
+    const evaluatedY = accessor.y(datum);
+    const _x = evaluatedX !== undefined ? evaluatedX : index;
+    const _y = evaluatedY !== undefined ? evaluatedY : datum;
+    const errorX = replaceNegatives(accessor.errorX(datum));
+    const errorY = replaceNegatives(accessor.errorY(datum));
+
+    dataArr.push(
+      assign(
+        {},
+        datum,
+        { _x, _y, errorX, errorY },
+        // map string data to numeric values, and add names
+        typeof _x === "string" ? { _x: stringMap.x[_x], x: _x } : {},
+        typeof _y === "string" ? { _y: stringMap.y[_y], y: _y } : {}
+      )
+    );
+
+    return dataArr;
+  }, []);
+
+  return sortData(formattedData, props.sortKey, props.sortOrder);
+};
+
+const getErrorData = (props) => {
+  if (props.data) {
+    if (Data.getLength(props.data) < 1) {
       return [];
     }
-    const accessor = {
-      x: Helpers.createAccessor(props.x !== undefined ? props.x : "x"),
-      y: Helpers.createAccessor(props.y !== undefined ? props.y : "y"),
-      errorX: Helpers.createAccessor(props.errorX !== undefined ? props.errorX : "errorX"),
-      errorY: Helpers.createAccessor(props.errorY !== undefined ? props.errorY : "errorY")
-    };
 
-    const replaceNegatives = (errors) => {
-      // check if the value is negative, if it is set to 0
-      const replaceNeg = (val) => !val || val < 0 ? 0 : val;
-      return isArray(errors) ? errors.map((err) => replaceNeg(err)) : replaceNeg(errors);
-    };
-
-    const stringMap = {
-      x: Data.createStringMap(props, "x"),
-      y: Data.createStringMap(props, "y")
-    };
-
-    const formattedData = dataset.reduce((dataArr, datum, index) => {
-      datum = Data.parseDatum(datum);
-
-      const evaluatedX = accessor.x(datum);
-      const evaluatedY = accessor.y(datum);
-      const _x = evaluatedX !== undefined ? evaluatedX : index;
-      const _y = evaluatedY !== undefined ? evaluatedY : datum;
-      const errorX = replaceNegatives(accessor.errorX(datum));
-      const errorY = replaceNegatives(accessor.errorY(datum));
-
-      dataArr.push(
-        assign(
-          {},
-          datum,
-          { _x, _y, errorX, errorY },
-          // map string data to numeric values, and add names
-          typeof _x === "string" ? { _x: stringMap.x[_x], x: _x } : {},
-          typeof _y === "string" ? { _y: stringMap.y[_y], y: _y } : {}
-        )
-      );
-
-      return dataArr;
-    }, []);
-
-    return this.sortData(formattedData, props.sortKey, props.sortOrder);
-  },
-
-  sortData(dataset, sortKey, sortOrder = "ascending") {
-    if (!sortKey) {
-      return dataset;
-    }
-
-    if (sortKey === "x" || sortKey === "y") {
-      sortKey = `_${sortKey}`;
-    }
-
-    const sortedData = sortBy(dataset, sortKey);
-
-    if (sortOrder === "descending") {
-      return sortedData.reverse();
-    }
-
-    return sortedData;
-  },
-
-  getDomain(props, axis) {
-    const propsDomain = Domain.getDomainFromProps(props, axis);
-    if (propsDomain) {
-      return Domain.padDomain(propsDomain, props, axis);
-    }
-    const categoryDomain = Domain.getDomainFromCategories(props, axis);
-    if (categoryDomain) {
-      return Domain.padDomain(categoryDomain, props, axis);
-    }
-    const dataset = this.getErrorData(props);
-
-    if (dataset.length < 1) {
-      return Scale.getBaseScale(props, axis).domain();
-    }
-
-    const domain = this.getDomainFromData(props, axis, dataset);
-    return Domain.cleanDomain(Domain.padDomain(domain, props, axis), props);
-  },
-
-  getDomainFromData(props, axis, dataset) {
-    const currentAxis = Helpers.getCurrentAxis(axis, props.horizontal);
-    let error;
-    if (currentAxis === "x") {
-      error = "errorX";
-    } else if (currentAxis === "y") {
-      error = "errorY";
-    }
-    const axisData = flatten(dataset).map((datum) => datum[`_${currentAxis}`]);
-    const errorData = flatten(flatten(dataset).map((datum) => {
-      let errorMax;
-      let errorMin;
-      if (isArray(datum[error])) {
-        errorMax = datum[error][0] + datum[`_${currentAxis}`];
-        errorMin = datum[`_${currentAxis}`] - datum[error][1];
-      } else {
-        errorMax = datum[error] + datum[`_${currentAxis}`];
-        errorMin = datum[`_${currentAxis}`] - datum[error];
-      }
-      return [errorMax, errorMin];
-    }));
-
-    const allData = axisData.concat(errorData);
-    const min = Math.min(...allData);
-    const max = Math.max(...allData);
-    // TODO: is this the correct behavior, or should we just error. How do we
-    // handle charts with just one data point?
-    if (+min === +max) {
-      return Domain.getSinglePointDomain(max);
-    }
-    return [min, max];
-  },
-
-  getCalculatedValues(props) {
-    const defaultStyles = props.theme && props.theme.errorbar && props.theme.errorbar.style ?
-      props.theme.errorbar.style : {};
-    const style = Helpers.getStyles(props.style, defaultStyles) || {};
-    const dataWithErrors = assign(Data.getData(props), this.getErrorData(props));
-    const data = Data.addEventKeys(props, dataWithErrors);
-    const range = {
-      x: Helpers.getRange(props, "x"),
-      y: Helpers.getRange(props, "y")
-    };
-    const domain = {
-      x: this.getDomain(props, "x"),
-      y: this.getDomain(props, "y")
-    };
-    const scale = {
-      x: Scale.getBaseScale(props, "x").domain(domain.x).range(range.x),
-      y: Scale.getBaseScale(props, "y").domain(domain.y).range(range.y)
-    };
-    const origin = props.polar ? props.origin || Helpers.getPolarOrigin(props) : undefined;
-    return { domain, data, scale, style, origin };
-  },
-
-  getDataStyles(datum, style) {
-    const numKeys = keys(datum).filter((k) => isNaN(k));
-    const omitKeys = [
-      "x", "y", "_x", "_y", "name", "errorX", "errorY", "eventKey", "label"
-    ];
-    const stylesFromData = omit(datum, [...omitKeys, ...numKeys]);
-    return defaults({}, stylesFromData, style);
+    return formatErrorData(props.data, props);
+  } else {
+    const generatedData = (props.errorX || props.errorY) && Data.generateData(props);
+    return formatErrorData(generatedData, props);
   }
+};
+
+const getDomainFromData = (props, axis, dataset) => {
+  const currentAxis = Helpers.getCurrentAxis(axis, props.horizontal);
+  let error;
+  if (currentAxis === "x") {
+    error = "errorX";
+  } else if (currentAxis === "y") {
+    error = "errorY";
+  }
+  const axisData = flatten(dataset).map((datum) => datum[`_${currentAxis}`]);
+  const errorData = flatten(flatten(dataset).map((datum) => {
+    let errorMax;
+    let errorMin;
+    if (isArray(datum[error])) {
+      errorMax = datum[error][0] + datum[`_${currentAxis}`];
+      errorMin = datum[`_${currentAxis}`] - datum[error][1];
+    } else {
+      errorMax = datum[error] + datum[`_${currentAxis}`];
+      errorMin = datum[`_${currentAxis}`] - datum[error];
+    }
+    return [errorMax, errorMin];
+  }));
+
+  const allData = axisData.concat(errorData);
+  const min = Math.min(...allData);
+  const max = Math.max(...allData);
+  // TODO: is the correct behavior, or should we just error. How do we
+  // handle charts with just one data point?
+  if (+min === +max) {
+    return Domain.getSinglePointDomain(max);
+  }
+  return [min, max];
+};
+
+export const getDomain = (props, axis) => {
+  const propsDomain = Domain.getDomainFromProps(props, axis);
+  if (propsDomain) {
+    return Domain.padDomain(propsDomain, props, axis);
+  }
+  const categoryDomain = Domain.getDomainFromCategories(props, axis);
+  if (categoryDomain) {
+    return Domain.padDomain(categoryDomain, props, axis);
+  }
+  const dataset = getErrorData(props);
+
+  if (dataset.length < 1) {
+    return Scale.getBaseScale(props, axis).domain();
+  }
+
+  const domain = getDomainFromData(props, axis, dataset);
+  return Domain.cleanDomain(Domain.padDomain(domain, props, axis), props);
+};
+
+
+const getCalculatedValues = (props) => {
+  const defaultStyles = props.theme && props.theme.errorbar && props.theme.errorbar.style ?
+    props.theme.errorbar.style : {};
+  const style = Helpers.getStyles(props.style, defaultStyles) || {};
+  const dataWithErrors = assign(Data.getData(props), getErrorData(props));
+  const data = Data.addEventKeys(props, dataWithErrors);
+  const range = {
+    x: Helpers.getRange(props, "x"),
+    y: Helpers.getRange(props, "y")
+  };
+  const domain = {
+    x: getDomain(props, "x"),
+    y: getDomain(props, "y")
+  };
+  const scale = {
+    x: Scale.getBaseScale(props, "x").domain(domain.x).range(range.x),
+    y: Scale.getBaseScale(props, "y").domain(domain.y).range(range.y)
+  };
+  const origin = props.polar ? props.origin || Helpers.getPolarOrigin(props) : undefined;
+  return { domain, data, scale, style, origin };
+};
+
+const getLabelProps = (dataProps, text, style) => {
+  const { x, index, scale, errorY } = dataProps;
+  const error = errorY && Array.isArray(errorY) ? errorY[0] : errorY;
+  const y = error || dataProps.y;
+  const labelStyle = style.labels || {};
+  return {
+    style: labelStyle,
+    y: y - (labelStyle.padding || 0),
+    x,
+    text,
+    index,
+    scale,
+    datum: dataProps.datum,
+    data: dataProps.data,
+    textAnchor: labelStyle.textAnchor,
+    verticalAnchor: labelStyle.verticalAnchor || "end",
+    angle: labelStyle.angle
+  };
+};
+
+const getDataStyles = (datum, style) => {
+  const numKeys = keys(datum).filter((k) => isNaN(k));
+  const omitKeys = [
+    "x", "y", "_x", "_y", "name", "errorX", "errorY", "eventKey", "label"
+  ];
+  const stylesFromData = omit(datum, [...omitKeys, ...numKeys]);
+  return defaults({}, stylesFromData, style);
+};
+
+export const getBaseProps = (props, fallbackProps) => {
+  props = Helpers.modifyProps(props, fallbackProps, "errorbar");
+  const { data, style, scale, domain, origin } = getCalculatedValues(props, fallbackProps);
+  const { groupComponent, height, width, borderWidth, standalone, theme, polar, padding } = props;
+  const initialChildProps = { parent: {
+    domain, scale, data, height, width, standalone, theme, polar, origin,
+    padding, style: style.parent
+  } };
+
+  return data.reduce((childProps, datum, index) => {
+    const eventKey = datum.eventKey || index;
+    const x = scale.x(datum._x1 !== undefined ? datum._x1 : datum._x);
+    const y = scale.y(datum._y1 !== undefined ? datum._y1 : datum._y);
+
+    const dataProps = {
+      x, y, scale, datum, data, index, groupComponent, borderWidth,
+      style: getDataStyles(datum, style.data),
+      errorX: getErrors(datum, scale, "x"),
+      errorY: getErrors(datum, scale, "y")
+    };
+
+    childProps[eventKey] = {
+      data: dataProps
+    };
+    const text = LabelHelpers.getText(props, datum, index);
+    if (text !== undefined && text !== null || props.events || props.sharedEvents) {
+      childProps[eventKey].labels = getLabelProps(dataProps, text, style);
+    }
+
+    return childProps;
+  }, initialChildProps);
 };

--- a/src/components/victory-errorbar/victory-errorbar.js
+++ b/src/components/victory-errorbar/victory-errorbar.js
@@ -63,9 +63,9 @@ class VictoryErrorBar extends React.Component {
     theme: VictoryTheme.grayscale
   };
 
-  static getDomain = getDomain.bind(getDomain);
+  static getDomain = getDomain;
   static getData = Data.getData.bind(Data);
-  static getBaseProps = partialRight(getBaseProps.bind(getBaseProps), fallbackProps);
+  static getBaseProps = partialRight(getBaseProps, fallbackProps);
   static expectedComponents = [
     "dataComponent", "labelComponent", "groupComponent", "containerComponent"
   ];

--- a/src/components/victory-errorbar/victory-errorbar.js
+++ b/src/components/victory-errorbar/victory-errorbar.js
@@ -5,7 +5,7 @@ import {
   VictoryContainer, VictoryTheme, DefaultTransitions, ErrorBar, Data
 } from "victory-core";
 import { partialRight } from "lodash";
-import ErrorBarHelpers from "./helper-methods";
+import { getBaseProps, getDomain } from "./helper-methods";
 import { BaseProps, DataProps } from "../../helpers/common-props";
 
 const fallbackProps = {
@@ -63,10 +63,9 @@ class VictoryErrorBar extends React.Component {
     theme: VictoryTheme.grayscale
   };
 
-  static getDomain = ErrorBarHelpers.getDomain.bind(ErrorBarHelpers);
+  static getDomain = getDomain.bind(getDomain);
   static getData = Data.getData.bind(Data);
-  static getBaseProps = partialRight(
-    ErrorBarHelpers.getBaseProps.bind(ErrorBarHelpers), fallbackProps);
+  static getBaseProps = partialRight(getBaseProps.bind(getBaseProps), fallbackProps);
   static expectedComponents = [
     "dataComponent", "labelComponent", "groupComponent", "containerComponent"
   ];

--- a/src/components/victory-line/helper-methods.js
+++ b/src/components/victory-line/helper-methods.js
@@ -28,7 +28,7 @@ const getCalculatedValues = (props) => {
   return { domain, data, scale, style, origin };
 };
 
-export const getBaseProps = (props, fallbackProps) => {
+const getBaseProps = (props, fallbackProps) => {
   const modifiedProps = Helpers.modifyProps(props, fallbackProps, "line");
   props = assign({}, modifiedProps, getCalculatedValues(modifiedProps));
   const {
@@ -52,3 +52,5 @@ export const getBaseProps = (props, fallbackProps) => {
     return childProps;
   }, initialChildProps);
 };
+
+export { getBaseProps };

--- a/src/components/victory-line/helper-methods.js
+++ b/src/components/victory-line/helper-methods.js
@@ -1,56 +1,54 @@
 import { assign } from "lodash";
 import { Helpers, LabelHelpers, Data, Domain, Scale } from "victory-core";
 
-export default {
-  getBaseProps(props, fallbackProps) {
-    const modifiedProps = Helpers.modifyProps(props, fallbackProps, "line");
-    props = assign({}, modifiedProps, this.getCalculatedValues(modifiedProps));
-    const {
-      data, domain, events, groupComponent, height, interpolation, origin, padding, polar,
-      scale, sharedEvents, standalone, style, theme, width
-    } = props;
-    const initialChildProps = {
-      parent: {
-        style: style.parent, scale, data, height, width, domain, standalone, polar, origin, padding
-      },
-      all: { data:
-        { polar, origin, scale, data, interpolation, groupComponent, theme, style: style.data }
-      }
-    };
-    return data.reduce((childProps, datum, index) => {
-      const text = LabelHelpers.getText(props, datum, index);
-      if (text !== undefined && text !== null || events || sharedEvents) {
-        const eventKey = datum.eventKey || index;
-        childProps[eventKey] = { labels: LabelHelpers.getProps(props, index) };
-      }
-      return childProps;
-    }, initialChildProps);
-  },
+const getCalculatedValues = (props) => {
+  let data = Data.getData(props);
 
-  getCalculatedValues(props) {
-    let data = Data.getData(props);
-
-    if (data.length < 2) {
-      data = [];
-    }
-
-    const range = {
-      x: Helpers.getRange(props, "x"),
-      y: Helpers.getRange(props, "y")
-    };
-    const domain = {
-      x: Domain.getDomain(props, "x"),
-      y: Domain.getDomain(props, "y")
-    };
-    const scale = {
-      x: Scale.getBaseScale(props, "x").domain(domain.x).range(range.x),
-      y: Scale.getBaseScale(props, "y").domain(domain.y).range(range.y)
-    };
-    const origin = props.polar ? props.origin || Helpers.getPolarOrigin(props) : undefined;
-    const defaultStyles = props.theme && props.theme.line && props.theme.line.style ?
-      props.theme.line.style : {};
-    const style = Helpers.getStyles(props.style, defaultStyles);
-
-    return { domain, data, scale, style, origin };
+  if (data.length < 2) {
+    data = [];
   }
+
+  const range = {
+    x: Helpers.getRange(props, "x"),
+    y: Helpers.getRange(props, "y")
+  };
+  const domain = {
+    x: Domain.getDomain(props, "x"),
+    y: Domain.getDomain(props, "y")
+  };
+  const scale = {
+    x: Scale.getBaseScale(props, "x").domain(domain.x).range(range.x),
+    y: Scale.getBaseScale(props, "y").domain(domain.y).range(range.y)
+  };
+  const origin = props.polar ? props.origin || Helpers.getPolarOrigin(props) : undefined;
+  const defaultStyles = props.theme && props.theme.line && props.theme.line.style ?
+    props.theme.line.style : {};
+  const style = Helpers.getStyles(props.style, defaultStyles);
+
+  return { domain, data, scale, style, origin };
+};
+
+export const getBaseProps = (props, fallbackProps) => {
+  const modifiedProps = Helpers.modifyProps(props, fallbackProps, "line");
+  props = assign({}, modifiedProps, getCalculatedValues(modifiedProps));
+  const {
+    data, domain, events, groupComponent, height, interpolation, origin, padding, polar,
+    scale, sharedEvents, standalone, style, theme, width
+  } = props;
+  const initialChildProps = {
+    parent: {
+      style: style.parent, scale, data, height, width, domain, standalone, polar, origin, padding
+    },
+    all: { data:
+      { polar, origin, scale, data, interpolation, groupComponent, theme, style: style.data }
+    }
+  };
+  return data.reduce((childProps, datum, index) => {
+    const text = LabelHelpers.getText(props, datum, index);
+    if (text !== undefined && text !== null || events || sharedEvents) {
+      const eventKey = datum.eventKey || index;
+      childProps[eventKey] = { labels: LabelHelpers.getProps(props, index) };
+    }
+    return childProps;
+  }, initialChildProps);
 };

--- a/src/components/victory-line/victory-line.js
+++ b/src/components/victory-line/victory-line.js
@@ -58,8 +58,7 @@ class VictoryLine extends React.Component {
 
   static getDomain = Domain.getDomain.bind(Domain);
   static getData = Data.getData.bind(Data);
-  static getBaseProps = partialRight(getBaseProps.bind(getBaseProps),
-    fallbackProps);
+  static getBaseProps = partialRight(getBaseProps, fallbackProps);
   static expectedComponents = [
     "dataComponent", "labelComponent", "groupComponent", "containerComponent"
   ];

--- a/src/components/victory-line/victory-line.js
+++ b/src/components/victory-line/victory-line.js
@@ -1,7 +1,7 @@
 import { partialRight } from "lodash";
 import PropTypes from "prop-types";
 import React from "react";
-import LineHelpers from "./helper-methods";
+import { getBaseProps } from "./helper-methods";
 import {
   PropTypes as CustomPropTypes, Helpers, VictoryLabel, addEvents, VictoryContainer, VictoryTheme,
   DefaultTransitions, Curve, VictoryClipContainer, Data, Domain
@@ -58,7 +58,7 @@ class VictoryLine extends React.Component {
 
   static getDomain = Domain.getDomain.bind(Domain);
   static getData = Data.getData.bind(Data);
-  static getBaseProps = partialRight(LineHelpers.getBaseProps.bind(LineHelpers),
+  static getBaseProps = partialRight(getBaseProps.bind(getBaseProps),
     fallbackProps);
   static expectedComponents = [
     "dataComponent", "labelComponent", "groupComponent", "containerComponent"

--- a/src/components/victory-polar-axis/helper-methods.js
+++ b/src/components/victory-polar-axis/helper-methods.js
@@ -3,7 +3,7 @@ import Axis from "../../helpers/axis";
 import { Helpers, LabelHelpers, Scale, Domain, Collection } from "victory-core";
 
 // exposed for use by VictoryChart
-export const getAxis = (props, flipped) => {
+const getAxis = (props, flipped) => {
   const typicalAxis = props.dependentAxis ? "y" : "x";
   const invertedAxis = typicalAxis === "x" ? "y" : "x";
   return flipped ? invertedAxis : typicalAxis;
@@ -59,7 +59,7 @@ const getDomainFromTickValues = (props, axis) => {
 };
 
 // exposed for use by VictoryChart
-export const getDomain = (props, axis) => {
+const getDomain = (props, axis) => {
   const inherentAxis = getAxis(props);
   if (axis && axis !== inherentAxis) {
     return undefined;
@@ -114,7 +114,7 @@ const getRange = (props, axis) => {
 };
 
 // exposed for use by VictoryChart (necessary?)
-export const getScale = (props) => {
+const getScale = (props) => {
   const axis = getAxis(props);
   const scale = Scale.getBaseScale(props, axis);
   const domain = getDomain(props, axis) || scale.domain();
@@ -124,7 +124,7 @@ export const getScale = (props) => {
   return scale;
 };
 
-export const getStyles = (props, styleObject) => {
+const getStyles = (props, styleObject) => {
   const style = props.style || {};
   styleObject = styleObject || {};
   const parentStyleProps = { height: "auto", width: "100%" };
@@ -306,7 +306,7 @@ const getCalculatedValues = (props) => {
   };
 };
 
-export const getBaseProps = (props, fallbackProps) => {
+const getBaseProps = (props, fallbackProps) => {
   const role = getRole(props);
   props = modifyProps(props, fallbackProps, role);
   const calculatedValues = getCalculatedValues(props);
@@ -329,4 +329,11 @@ export const getBaseProps = (props, fallbackProps) => {
 
     return childProps;
   }, initialChildProps);
+};
+
+export { getDomain,
+  getAxis,
+  getScale,
+  getStyles,
+  getBaseProps
 };

--- a/src/components/victory-polar-axis/helper-methods.js
+++ b/src/components/victory-polar-axis/helper-methods.js
@@ -2,332 +2,331 @@ import { assign, uniqBy, defaults, defaultsDeep, isFunction } from "lodash";
 import Axis from "../../helpers/axis";
 import { Helpers, LabelHelpers, Scale, Domain, Collection } from "victory-core";
 
-export default {
-  getCalculatedValues(props) {
-    const defaultStyles = this.getStyleObject(props);
-    const style = this.getStyles(props, defaultStyles);
-    const padding = Helpers.getPadding(props);
-    const axis = this.getAxis(props);
-    const axisType = this.getAxisType(props);
-    const stringTicks = Helpers.stringTicks(props) ? props.tickValues : undefined;
-    const domain = this.getDomain(props, axis);
-    const range = this.getRange(props, axis);
-    const scale = this.getScale(props);
-    const initialTicks = Axis.getTicks(props, scale);
-    const ticks = axisType === "angular" ? this.filterTicks(initialTicks, scale) : initialTicks;
-    const tickFormat = Axis.getTickFormat(props, scale);
-    const radius = this.getRadius(props);
-    return {
-      axis, style, padding, stringTicks, axisType, scale, ticks, tickFormat, domain, range, radius
-    };
-  },
+// exposed for use by VictoryChart
+export const getAxis = (props, flipped) => {
+  const typicalAxis = props.dependentAxis ? "y" : "x";
+  const invertedAxis = typicalAxis === "x" ? "y" : "x";
+  return flipped ? invertedAxis : typicalAxis;
+};
 
-  evaluateProp(prop, data, index) {
-    return isFunction(prop) ? prop(data, index) : prop;
-  },
+const getPosition = (r, angle, axis) => {
+  return axis === "x" ? r * Math.cos(angle) : -r * Math.sin(angle);
+};
 
-  evaluateStyle(style, data, index) {
-    if (!style || !Object.keys(style).some((value) => isFunction(style[value]))) {
-      return style;
-    }
-    return Object.keys(style).reduce((prev, curr) => {
-      prev[curr] = this.evaluateProp(style[curr], data, index);
-      return prev;
-    }, {});
-  },
+const getAxisType = (props) => {
+  const typicalType = props.dependentAxis ? "radial" : "angular";
+  const invertedType = typicalType === "angular" ? "radial" : "angular";
+  return props.horizontal ? invertedType : typicalType;
+};
 
-  // exposed for use by VictoryChart
-  getDomain(props, axis) {
-    const inherentAxis = this.getAxis(props);
-    if (axis && axis !== inherentAxis) {
-      return undefined;
-    }
-    let domain;
-    if (Array.isArray(props.domain)) {
-      domain = props.domain;
-    } else if (props.domain && props.domain[inherentAxis]) {
-      domain = props.domain[inherentAxis];
-    } else if (Array.isArray(props.tickValues) && props.tickValues.length > 1) {
-      domain = this.getDomainFromTickValues(props, axis);
-    }
-    const paddedDomain = Domain.padDomain(domain, props, inherentAxis);
-    return domain ? Domain.cleanDomain(paddedDomain, props, inherentAxis) : undefined;
-  },
+const filterTicks = (ticks, scale) => {
+  const compareTicks = (t) => scale(t) % (2 * Math.PI);
+  return uniqBy(ticks, compareTicks);
+};
 
-  getDomainFromTickValues(props, axis) {
-    const { tickValues, startAngle = 0, endAngle = 360 } = props;
-    if (Helpers.stringTicks(props)) {
-      return [1, tickValues.length];
-    } else {
-      const ticks = tickValues.map((value) => +value);
-      const domain = [Collection.getMinValue(ticks), Collection.getMaxValue(ticks)];
-      return axis === "x" && Math.abs(startAngle - endAngle) === 360 ?
-        Domain.getSymmetricDomain(domain, ticks) : domain;
-    }
-  },
+const evaluateProp = (prop, data, index) => {
+  return isFunction(prop) ? prop(data, index) : prop;
+};
 
-  getRadius(props) {
-    const { left, right, top, bottom } = Helpers.getPadding(props);
-    const { width, height } = props;
-    return Math.min(width - left - right, height - top - bottom) / 2;
-  },
-
-  getRange(props, axis) {
-    // Return the range from props if one is given.
-    if (props.range && props.range[axis]) {
-      return props.range[axis];
-    } else if (props.range && Array.isArray(props.range)) {
-      return props.range;
-    }
-    const axisType = this.getAxisType(props);
-    if (axisType === "angular") {
-      const startAngle = Helpers.degreesToRadians(props.startAngle);
-      const endAngle = Helpers.degreesToRadians(props.endAngle);
-      return [startAngle, endAngle];
-    }
-    const radius = this.getRadius(props);
-    return [props.innerRadius || 0, radius];
-  },
-
-  // exposed for use by VictoryChart
-  getAxis(props, flipped) {
-    const typicalAxis = props.dependentAxis ? "y" : "x";
-    const invertedAxis = typicalAxis === "x" ? "y" : "x";
-    return flipped ? invertedAxis : typicalAxis;
-  },
-
-  getAxisType(props) {
-    const typicalType = props.dependentAxis ? "radial" : "angular";
-    const invertedType = typicalType === "angular" ? "radial" : "angular";
-    return props.horizontal ? invertedType : typicalType;
-  },
-
-  // exposed for use by VictoryChart (necessary?)
-  getScale(props) {
-    const axis = this.getAxis(props);
-    const scale = Scale.getBaseScale(props, axis);
-    const domain = this.getDomain(props, axis) || scale.domain();
-    const range = this.getRange(props, axis);
-    scale.range(range);
-    scale.domain(domain);
-    return scale;
-  },
-
-  getStyleObject(props) {
-    const { theme, dependentAxis } = props;
-    const generalAxisStyle = theme && theme.axis && theme.axis.style;
-    const axisType = dependentAxis ? "dependentAxis" : "independentAxis";
-    const specificAxisStyle = theme && theme[axisType] && theme[axisType].style;
-
-    return generalAxisStyle && specificAxisStyle
-      ? defaultsDeep({},
-          specificAxisStyle,
-          generalAxisStyle
-        )
-      : specificAxisStyle || generalAxisStyle;
-  },
-
-  getStyles(props, styleObject) {
-    const style = props.style || {};
-    styleObject = styleObject || {};
-    const parentStyleProps = { height: "auto", width: "100%" };
-    return {
-      parent: defaults(parentStyleProps, style.parent, styleObject.parent),
-      axis: defaults({}, style.axis, styleObject.axis),
-      axisLabel: defaults({}, style.axisLabel, styleObject.axisLabel),
-      grid: defaults({}, style.grid, styleObject.grid),
-      ticks: defaults({}, style.ticks, styleObject.ticks),
-      tickLabels: defaults({}, style.tickLabels, styleObject.tickLabels)
-    };
-  },
-
-  getAxisAngle(props) {
-    const { axisAngle, startAngle, axisValue, dependentAxis, scale } = props;
-    const otherAxis = this.getAxis(props) === "y" ? "x" : "y";
-    if (axisValue === undefined || !dependentAxis || scale[otherAxis] === undefined) {
-      return axisAngle || startAngle;
-    }
-    return Helpers.radiansToDegrees(scale.x(axisValue));
-  },
-
-  getTickProps(props, calculatedValues, tick, index) { //eslint-disable-line max-params
-    const { axisType, radius, scale, style, stringTicks } = calculatedValues;
-    const originalTick = stringTicks ? stringTicks[index] : tick;
-    const { tickStyle } = this.getEvaluatedStyles(style, originalTick, index);
-    const tickPadding = tickStyle.padding || 0;
-    const angularPadding = tickPadding; // TODO: do some geometry
-    const axisAngle = axisType === "radial" ? this.getAxisAngle(props, scale) : undefined;
-    return axisType === "angular" ?
-      {
-        index, datum: tick, style: tickStyle,
-        x1: radius * Math.cos(scale(tick)),
-        y1: -radius * Math.sin(scale(tick)),
-        x2: (radius + tickPadding) * Math.cos(scale(tick)),
-        y2: -(radius + tickPadding) * Math.sin(scale(tick))
-      } : {
-        style, index, datum: tick,
-        x1: (scale(tick) / 2) * Math.cos(axisAngle - angularPadding),
-        x2: (scale(tick) / 2) * Math.cos(axisAngle + angularPadding),
-        y1: -(scale(tick) / 2) * Math.sin(axisAngle - angularPadding),
-        y2: -(scale(tick) / 2) * Math.sin(axisAngle + angularPadding)
-      };
-  },
-
-  getTickLabelProps(props, calculatedValues, tick, index) { //eslint-disable-line max-params
-    const { axisType, radius, tickFormat, style, scale, ticks, stringTicks } = calculatedValues;
-    const originalTick = stringTicks ? stringTicks[index] : tick;
-    const { labelStyle } = this.getEvaluatedStyles(style, originalTick, index);
-    const { tickLabelComponent } = props;
-    const labelPlacement = tickLabelComponent.props && tickLabelComponent.props.labelPlacement ?
-      tickLabelComponent.props.labelPlacement : props.labelPlacement;
-    const tickPadding = labelStyle.padding || 0;
-    const angularPadding = 0; // TODO: do some geometry
-    const axisAngle = axisType === "radial" ? this.getAxisAngle(props, scale) : undefined;
-    const labelAngle = axisType === "angular" ?
-      Helpers.radiansToDegrees(scale(tick)) : axisAngle + angularPadding;
-    const textAngle = labelStyle.angle ||
-      LabelHelpers.getPolarAngle(assign({}, props, { labelPlacement }), labelAngle);
-    const labelRadius = axisType === "angular" ? radius + tickPadding : scale(tick);
-    const textAnchor = labelStyle.textAnchor ||
-      LabelHelpers.getPolarTextAnchor(assign({}, props, { labelPlacement }), labelAngle);
-    return {
-      index, datum: tick, style: labelStyle,
-      angle: textAngle,
-      textAnchor,
-      text: tickFormat(tick, index, ticks),
-      x: labelRadius * Math.cos(Helpers.degreesToRadians(labelAngle)),
-      y: -labelRadius * Math.sin(Helpers.degreesToRadians(labelAngle))
-    };
-  },
-
-  getGridProps(props, calculatedValues, tick, index) { //eslint-disable-line max-params
-    const { axisType, radius, style, scale, stringTicks } = calculatedValues;
-    const { startAngle, endAngle, innerRadius = 0 } = props;
-    const originalTick = stringTicks ? stringTicks[index] : tick;
-    const { gridStyle } = this.getEvaluatedStyles(style, originalTick, index);
-    const angle = scale(tick);
-    return axisType === "angular" ?
-      {
-        index, datum: tick, style: gridStyle,
-        x1: this.getPosition(radius, angle, "x"),
-        y1: this.getPosition(radius, angle, "y"),
-        x2: this.getPosition(innerRadius, angle, "x"),
-        y2: this.getPosition(innerRadius, angle, "y")
-      } : {
-        style: gridStyle, index, datum: tick,
-        cx: 0, cy: 0, r: scale(tick), startAngle, endAngle
-      };
-  },
-
-  getAxisLabelProps(props, calculatedValues) {
-    const { axisType, radius, style, scale } = calculatedValues;
-    const { axisLabelComponent } = props;
-    if (axisType !== "radial") {
-      return {};
-    }
-    const labelPlacement = axisLabelComponent.props && axisLabelComponent.props.labelPlacement ?
-      axisLabelComponent.props.labelPlacement : props.labelPlacement;
-    const labelStyle = style && style.axisLabel || {};
-    const axisAngle = axisType === "radial" ? this.getAxisAngle(props, scale) : undefined;
-    const textAngle = labelStyle.angle ||
-      LabelHelpers.getPolarAngle(assign({}, props, { labelPlacement }), axisAngle);
-    const labelRadius = radius + (labelStyle.padding || 0);
-    const textAnchor = labelStyle.textAnchor ||
-      LabelHelpers.getTextPolarAnchor(assign({}, props, { labelPlacement }), axisAngle);
-    const verticalAnchor = labelStyle.verticalAnchor ||
-      LabelHelpers.getPolarVerticalAnchor(assign({}, props, { labelPlacement }), axisAngle);
-    return {
-      style: labelStyle,
-      angle: textAngle,
-      textAnchor,
-      verticalAnchor,
-      text: props.label,
-      x: this.getPosition(labelRadius, Helpers.degreesToRadians(axisAngle), "x"),
-      y: this.getPosition(labelRadius, Helpers.degreesToRadians(axisAngle), "y")
-    };
-  },
-
-  getPosition(r, angle, axis) {
-    return axis === "x" ? r * Math.cos(angle) : -r * Math.sin(angle);
-  },
-
-  getAxisProps(modifiedProps, calculatedValues) {
-    const { style, axisType, radius, scale } = calculatedValues;
-    const { startAngle, endAngle, innerRadius = 0 } = modifiedProps;
-    const axisAngle = axisType === "radial" ?
-      Helpers.degreesToRadians(this.getAxisAngle(modifiedProps, scale)) : undefined;
-    return axisType === "radial" ?
-      {
-        style: style.axis,
-        x1: this.getPosition(innerRadius, axisAngle, "x"),
-        x2: this.getPosition(radius, axisAngle, "x"),
-        y1: this.getPosition(innerRadius, axisAngle, "y"),
-        y2: this.getPosition(radius, axisAngle, "y")
-      } : {
-        style: style.axis,
-        cx: 0, cy: 0, r: radius, startAngle, endAngle
-      };
-  },
-
-  getEvaluatedStyles(style, tick, index) {
-    return {
-      tickStyle: this.evaluateStyle(style.ticks, tick, index),
-      labelStyle: this.evaluateStyle(style.tickLabels, tick, index),
-      gridStyle: this.evaluateStyle(style.grid, tick, index)
-    };
-  },
-
-  getRole(props) {
-    if (props.dependentAxis) {
-      return props.theme && props.theme.dependentAxis
-        ? "dependentAxis"
-        : "axis";
-    }
-
-    return props.theme && props.theme.independentAxis
-      ? "independentAxis"
-      : "axis";
-  },
-
-  getShallowMergedThemeProps(props, role) {
-    const axisTheme = props.theme.axis || {};
-    return defaults({}, props.theme[role], axisTheme);
-  },
-
-  modifyProps(props, fallbackProps, role) {
-    if (role !== "axis") {
-      props.theme[role] = this.getShallowMergedThemeProps(props, role);
-    }
-    return Helpers.modifyProps(props, fallbackProps, role);
-  },
-
-  getBaseProps(props, fallbackProps) {
-    const role = this.getRole(props);
-    props = this.modifyProps(props, fallbackProps, role);
-    const calculatedValues = this.getCalculatedValues(props);
-    const { style, scale, ticks, domain } = calculatedValues;
-    const { width, height, standalone, theme } = props;
-    const axisProps = this.getAxisProps(props, calculatedValues);
-    const axisLabelProps = this.getAxisLabelProps(props, calculatedValues);
-    const initialChildProps = { parent:
-      { style: style.parent, ticks, scale, width, height, domain, standalone, theme }
-    };
-
-    return ticks.reduce((childProps, tick, index) => {
-      childProps[index] = {
-        axis: axisProps,
-        axisLabel: axisLabelProps,
-        ticks: this.getTickProps(props, calculatedValues, tick, index),
-        tickLabels: this.getTickLabelProps(props, calculatedValues, tick, index),
-        grid: this.getGridProps(props, calculatedValues, tick, index)
-      };
-
-      return childProps;
-    }, initialChildProps);
-  },
-
-  filterTicks(ticks, scale) {
-    const compareTicks = (t) => scale(t) % (2 * Math.PI);
-    return uniqBy(ticks, compareTicks);
+const evaluateStyle = (style, data, index) => {
+  if (!style || !Object.keys(style).some((value) => isFunction(style[value]))) {
+    return style;
   }
+  return Object.keys(style).reduce((prev, curr) => {
+    prev[curr] = evaluateProp(style[curr], data, index);
+    return prev;
+  }, {});
+};
+
+const getEvaluatedStyles = (style, tick, index) => {
+  return {
+    tickStyle: evaluateStyle(style.ticks, tick, index),
+    labelStyle: evaluateStyle(style.tickLabels, tick, index),
+    gridStyle: evaluateStyle(style.grid, tick, index)
+  };
+};
+
+const getDomainFromTickValues = (props, axis) => {
+  const { tickValues, startAngle = 0, endAngle = 360 } = props;
+  if (Helpers.stringTicks(props)) {
+    return [1, tickValues.length];
+  } else {
+    const ticks = tickValues.map((value) => +value);
+    const domain = [Collection.getMinValue(ticks), Collection.getMaxValue(ticks)];
+    return axis === "x" && Math.abs(startAngle - endAngle) === 360 ?
+      Domain.getSymmetricDomain(domain, ticks) : domain;
+  }
+};
+
+// exposed for use by VictoryChart
+export const getDomain = (props, axis) => {
+  const inherentAxis = getAxis(props);
+  if (axis && axis !== inherentAxis) {
+    return undefined;
+  }
+  let domain;
+  if (Array.isArray(props.domain)) {
+    domain = props.domain;
+  } else if (props.domain && props.domain[inherentAxis]) {
+    domain = props.domain[inherentAxis];
+  } else if (Array.isArray(props.tickValues) && props.tickValues.length > 1) {
+    domain = getDomainFromTickValues(props, axis);
+  }
+  const paddedDomain = Domain.padDomain(domain, props, inherentAxis);
+  return domain ? Domain.cleanDomain(paddedDomain, props, inherentAxis) : undefined;
+};
+
+const getStyleObject = (props) => {
+  const { theme, dependentAxis } = props;
+  const generalAxisStyle = theme && theme.axis && theme.axis.style;
+  const axisType = dependentAxis ? "dependentAxis" : "independentAxis";
+  const specificAxisStyle = theme && theme[axisType] && theme[axisType].style;
+
+  return generalAxisStyle && specificAxisStyle
+    ? defaultsDeep({},
+      specificAxisStyle,
+      generalAxisStyle
+    )
+    : specificAxisStyle || generalAxisStyle;
+};
+
+const getRadius = (props) => {
+  const { left, right, top, bottom } = Helpers.getPadding(props);
+  const { width, height } = props;
+  return Math.min(width - left - right, height - top - bottom) / 2;
+};
+
+const getRange = (props, axis) => {
+  // Return the range from props if one is given.
+  if (props.range && props.range[axis]) {
+    return props.range[axis];
+  } else if (props.range && Array.isArray(props.range)) {
+    return props.range;
+  }
+  const axisType = getAxisType(props);
+  if (axisType === "angular") {
+    const startAngle = Helpers.degreesToRadians(props.startAngle);
+    const endAngle = Helpers.degreesToRadians(props.endAngle);
+    return [startAngle, endAngle];
+  }
+  const radius = getRadius(props);
+  return [props.innerRadius || 0, radius];
+};
+
+// exposed for use by VictoryChart (necessary?)
+export const getScale = (props) => {
+  const axis = getAxis(props);
+  const scale = Scale.getBaseScale(props, axis);
+  const domain = getDomain(props, axis) || scale.domain();
+  const range = getRange(props, axis);
+  scale.range(range);
+  scale.domain(domain);
+  return scale;
+};
+
+export const getStyles = (props, styleObject) => {
+  const style = props.style || {};
+  styleObject = styleObject || {};
+  const parentStyleProps = { height: "auto", width: "100%" };
+  return {
+    parent: defaults(parentStyleProps, style.parent, styleObject.parent),
+    axis: defaults({}, style.axis, styleObject.axis),
+    axisLabel: defaults({}, style.axisLabel, styleObject.axisLabel),
+    grid: defaults({}, style.grid, styleObject.grid),
+    ticks: defaults({}, style.ticks, styleObject.ticks),
+    tickLabels: defaults({}, style.tickLabels, styleObject.tickLabels)
+  };
+};
+
+const getAxisAngle = (props) => {
+  const { axisAngle, startAngle, axisValue, dependentAxis, scale } = props;
+  const otherAxis = getAxis(props) === "y" ? "x" : "y";
+  if (axisValue === undefined || !dependentAxis || scale[otherAxis] === undefined) {
+    return axisAngle || startAngle;
+  }
+  return Helpers.radiansToDegrees(scale.x(axisValue));
+};
+
+const getTickProps = (props, calculatedValues, tick, index) => { //eslint-disable-line max-params
+  const { axisType, radius, scale, style, stringTicks } = calculatedValues;
+  const originalTick = stringTicks ? stringTicks[index] : tick;
+  const { tickStyle } = getEvaluatedStyles(style, originalTick, index);
+  const tickPadding = tickStyle.padding || 0;
+  const angularPadding = tickPadding; // TODO: do some geometry
+  const axisAngle = axisType === "radial" ? getAxisAngle(props, scale) : undefined;
+  return axisType === "angular" ?
+  {
+    index, datum: tick, style: tickStyle,
+    x1: radius * Math.cos(scale(tick)),
+    y1: -radius * Math.sin(scale(tick)),
+    x2: (radius + tickPadding) * Math.cos(scale(tick)),
+    y2: -(radius + tickPadding) * Math.sin(scale(tick))
+  } : {
+    style, index, datum: tick,
+    x1: (scale(tick) / 2) * Math.cos(axisAngle - angularPadding),
+    x2: (scale(tick) / 2) * Math.cos(axisAngle + angularPadding),
+    y1: -(scale(tick) / 2) * Math.sin(axisAngle - angularPadding),
+    y2: -(scale(tick) / 2) * Math.sin(axisAngle + angularPadding)
+  };
+};
+
+//eslint-disable-next-line max-params
+const getTickLabelProps = (props, calculatedValues, tick, index) => {
+  const { axisType, radius, tickFormat, style, scale, ticks, stringTicks } = calculatedValues;
+  const originalTick = stringTicks ? stringTicks[index] : tick;
+  const { labelStyle } = getEvaluatedStyles(style, originalTick, index);
+  const { tickLabelComponent } = props;
+  const labelPlacement = tickLabelComponent.props && tickLabelComponent.props.labelPlacement ?
+    tickLabelComponent.props.labelPlacement : props.labelPlacement;
+  const tickPadding = labelStyle.padding || 0;
+  const angularPadding = 0; // TODO: do some geometry
+  const axisAngle = axisType === "radial" ? getAxisAngle(props, scale) : undefined;
+  const labelAngle = axisType === "angular" ?
+    Helpers.radiansToDegrees(scale(tick)) : axisAngle + angularPadding;
+  const textAngle = labelStyle.angle ||
+    LabelHelpers.getPolarAngle(assign({}, props, { labelPlacement }), labelAngle);
+  const labelRadius = axisType === "angular" ? radius + tickPadding : scale(tick);
+  const textAnchor = labelStyle.textAnchor ||
+    LabelHelpers.getPolarTextAnchor(assign({}, props, { labelPlacement }), labelAngle);
+  return {
+    index, datum: tick, style: labelStyle,
+    angle: textAngle,
+    textAnchor,
+    text: tickFormat(tick, index, ticks),
+    x: labelRadius * Math.cos(Helpers.degreesToRadians(labelAngle)),
+    y: -labelRadius * Math.sin(Helpers.degreesToRadians(labelAngle))
+  };
+};
+
+const getGridProps = (props, calculatedValues, tick, index) => { //eslint-disable-line max-params
+  const { axisType, radius, style, scale, stringTicks } = calculatedValues;
+  const { startAngle, endAngle, innerRadius = 0 } = props;
+  const originalTick = stringTicks ? stringTicks[index] : tick;
+  const { gridStyle } = getEvaluatedStyles(style, originalTick, index);
+  const angle = scale(tick);
+  return axisType === "angular" ?
+  {
+    index, datum: tick, style: gridStyle,
+    x1: getPosition(radius, angle, "x"),
+    y1: getPosition(radius, angle, "y"),
+    x2: getPosition(innerRadius, angle, "x"),
+    y2: getPosition(innerRadius, angle, "y")
+  } : {
+    style: gridStyle, index, datum: tick,
+    cx: 0, cy: 0, r: scale(tick), startAngle, endAngle
+  };
+};
+
+const getAxisLabelProps = (props, calculatedValues) => {
+  const { axisType, radius, style, scale } = calculatedValues;
+  const { axisLabelComponent } = props;
+  if (axisType !== "radial") {
+    return {};
+  }
+  const labelPlacement = axisLabelComponent.props && axisLabelComponent.props.labelPlacement ?
+    axisLabelComponent.props.labelPlacement : props.labelPlacement;
+  const labelStyle = style && style.axisLabel || {};
+  const axisAngle = axisType === "radial" ? getAxisAngle(props, scale) : undefined;
+  const textAngle = labelStyle.angle ||
+    LabelHelpers.getPolarAngle(assign({}, props, { labelPlacement }), axisAngle);
+  const labelRadius = radius + (labelStyle.padding || 0);
+  const textAnchor = labelStyle.textAnchor ||
+    LabelHelpers.getTextPolarAnchor(assign({}, props, { labelPlacement }), axisAngle);
+  const verticalAnchor = labelStyle.verticalAnchor ||
+    LabelHelpers.getPolarVerticalAnchor(assign({}, props, { labelPlacement }), axisAngle);
+  return {
+    style: labelStyle,
+    angle: textAngle,
+    textAnchor,
+    verticalAnchor,
+    text: props.label,
+    x: getPosition(labelRadius, Helpers.degreesToRadians(axisAngle), "x"),
+    y: getPosition(labelRadius, Helpers.degreesToRadians(axisAngle), "y")
+  };
+};
+
+const getAxisProps = (modifiedProps, calculatedValues) => {
+  const { style, axisType, radius, scale } = calculatedValues;
+  const { startAngle, endAngle, innerRadius = 0 } = modifiedProps;
+  const axisAngle = axisType === "radial" ?
+    Helpers.degreesToRadians(getAxisAngle(modifiedProps, scale)) : undefined;
+  return axisType === "radial" ?
+  {
+    style: style.axis,
+    x1: getPosition(innerRadius, axisAngle, "x"),
+    x2: getPosition(radius, axisAngle, "x"),
+    y1: getPosition(innerRadius, axisAngle, "y"),
+    y2: getPosition(radius, axisAngle, "y")
+  } : {
+    style: style.axis,
+    cx: 0, cy: 0, r: radius, startAngle, endAngle
+  };
+};
+
+const getRole = (props) => {
+  if (props.dependentAxis) {
+    return props.theme && props.theme.dependentAxis
+      ? "dependentAxis"
+      : "axis";
+  }
+
+  return props.theme && props.theme.independentAxis
+    ? "independentAxis"
+    : "axis";
+};
+
+const getShallowMergedThemeProps = (props, role) => {
+  const axisTheme = props.theme.axis || {};
+  return defaults({}, props.theme[role], axisTheme);
+};
+
+const modifyProps = (props, fallbackProps, role) => {
+  if (role !== "axis") {
+    props.theme[role] = getShallowMergedThemeProps(props, role);
+  }
+  return Helpers.modifyProps(props, fallbackProps, role);
+};
+
+const getCalculatedValues = (props) => {
+  const defaultStyles = getStyleObject(props);
+  const style = getStyles(props, defaultStyles);
+  const padding = Helpers.getPadding(props);
+  const axis = getAxis(props);
+  const axisType = getAxisType(props);
+  const stringTicks = Helpers.stringTicks(props) ? props.tickValues : undefined;
+  const domain = getDomain(props, axis);
+  const range = getRange(props, axis);
+  const scale = getScale(props);
+  const initialTicks = Axis.getTicks(props, scale);
+  const ticks = axisType === "angular" ? filterTicks(initialTicks, scale) : initialTicks;
+  const tickFormat = Axis.getTickFormat(props, scale);
+  const radius = getRadius(props);
+  return {
+    axis, style, padding, stringTicks, axisType, scale, ticks, tickFormat, domain, range, radius
+  };
+};
+
+export const getBaseProps = (props, fallbackProps) => {
+  const role = getRole(props);
+  props = modifyProps(props, fallbackProps, role);
+  const calculatedValues = getCalculatedValues(props);
+  const { style, scale, ticks, domain } = calculatedValues;
+  const { width, height, standalone, theme } = props;
+  const axisProps = getAxisProps(props, calculatedValues);
+  const axisLabelProps = getAxisLabelProps(props, calculatedValues);
+  const initialChildProps = { parent:
+    { style: style.parent, ticks, scale, width, height, domain, standalone, theme }
+  };
+
+  return ticks.reduce((childProps, tick, index) => {
+    childProps[index] = {
+      axis: axisProps,
+      axisLabel: axisLabelProps,
+      ticks: getTickProps(props, calculatedValues, tick, index),
+      tickLabels: getTickLabelProps(props, calculatedValues, tick, index),
+      grid: getGridProps(props, calculatedValues, tick, index)
+    };
+
+    return childProps;
+  }, initialChildProps);
 };

--- a/src/components/victory-polar-axis/victory-polar-axis.js
+++ b/src/components/victory-polar-axis/victory-polar-axis.js
@@ -105,11 +105,11 @@ class VictoryPolarAxis extends React.Component {
     tickLabelComponent: <VictoryLabel/>
   };
 
-  static getDomain = getDomain.bind(getDomain);
-  static getAxis = getAxis.bind(getAxis);
-  static getScale = getScale.bind(getScale);
-  static getStyles = partialRight(getStyles.bind(getStyles), fallbackProps.style);
-  static getBaseProps = partialRight(getBaseProps.bind(getBaseProps), fallbackProps);
+  static getDomain = getDomain;
+  static getAxis = getAxis;
+  static getScale = getScale;
+  static getStyles = partialRight(getStyles, fallbackProps.style);
+  static getBaseProps = partialRight(getBaseProps, fallbackProps);
   static expectedComponents = [
     "axisComponent", "circularAxisComponent", "groupComponent", "containerComponent",
     "tickComponent", "tickLabelComponent", "gridComponent", "circularGridComponent"

--- a/src/components/victory-polar-axis/victory-polar-axis.js
+++ b/src/components/victory-polar-axis/victory-polar-axis.js
@@ -5,7 +5,7 @@ import {
   PropTypes as CustomPropTypes, Helpers, VictoryLabel,
   VictoryContainer, VictoryTheme, Grid, addEvents, Arc
 } from "victory-core";
-import AxisHelpers from "./helper-methods";
+import { getDomain, getAxis, getScale, getStyles, getBaseProps } from "./helper-methods";
 import { BaseProps } from "../../helpers/common-props";
 
 const fallbackProps = {
@@ -105,11 +105,11 @@ class VictoryPolarAxis extends React.Component {
     tickLabelComponent: <VictoryLabel/>
   };
 
-  static getDomain = AxisHelpers.getDomain.bind(AxisHelpers);
-  static getAxis = AxisHelpers.getAxis.bind(AxisHelpers);
-  static getScale = AxisHelpers.getScale.bind(AxisHelpers);
-  static getStyles = partialRight(AxisHelpers.getStyles.bind(AxisHelpers), fallbackProps.style);
-  static getBaseProps = partialRight(AxisHelpers.getBaseProps.bind(AxisHelpers), fallbackProps);
+  static getDomain = getDomain.bind(getDomain);
+  static getAxis = getAxis.bind(getAxis);
+  static getScale = getScale.bind(getScale);
+  static getStyles = partialRight(getStyles.bind(getStyles), fallbackProps.style);
+  static getBaseProps = partialRight(getBaseProps.bind(getBaseProps), fallbackProps);
   static expectedComponents = [
     "axisComponent", "circularAxisComponent", "groupComponent", "containerComponent",
     "tickComponent", "tickLabelComponent", "gridComponent", "circularGridComponent"

--- a/src/components/victory-voronoi/helper-methods.js
+++ b/src/components/victory-voronoi/helper-methods.js
@@ -2,82 +2,81 @@ import { assign, keys, omit, defaults, without, isNaN } from "lodash";
 import { Helpers, LabelHelpers, Scale, Domain, Data } from "victory-core";
 import { voronoi as d3Voronoi } from "d3-voronoi";
 
-export default {
-  getBaseProps(props, fallbackProps) {
-    const modifiedProps = Helpers.modifyProps(props, fallbackProps, "scatter");
-    props = assign({}, modifiedProps, this.getCalculatedValues(modifiedProps));
-    const {
-      data, domain, events, height, origin, padding, polar, polygons,
-      scale, sharedEvents, standalone, style, theme, width
-    } = props;
-    const initialChildProps = { parent: {
-      style: style.parent, scale, domain, data, standalone, height, width, theme,
-      origin, polar, padding
-    } };
+const getVoronoi = (props, range, scale) => {
+  const minRange = [Math.min(...range.x), Math.min(...range.y)];
+  const maxRange = [Math.max(...range.x), Math.max(...range.y)];
+  const angleAccessor = (d) => {
+    const x = scale.x(d._x1 !== undefined ? d._x1 : d._x);
+    return -1 * x + Math.PI / 2;
+  };
+  const xAccessor = (d) => scale.x(d._x1 !== undefined ? d._x1 : d._x);
+  return d3Voronoi()
+    .x((d) => props.polar ? angleAccessor(d) : xAccessor(d))
+    .y((d) => scale.y(d._y1 !== undefined ? d._y1 : d._y))
+    .extent([minRange, maxRange]);
+};
 
-    return data.reduce((childProps, datum, index) => {
-      const polygon = without(polygons[index], "data");
-      const eventKey = datum.eventKey;
-      const { x, y } = Helpers.scalePoint(props, datum);
-      const dataProps = {
-        x, y, datum, data, index, scale, polygon, origin,
-        size: props.size,
-        style: this.getDataStyles(datum, style.data)
-      };
+const getDataStyles = (datum, style) => {
+  const numKeys = keys(datum).filter((k) => isNaN(k));
+  const omitKeys = [
+    "x", "y", "_x", "_y", "eventKey", "label"
+  ];
+  const stylesFromData = omit(datum, [...omitKeys, ...numKeys]);
+  return defaults({}, stylesFromData, style);
+};
 
-      childProps[eventKey] = { data: dataProps };
-      const text = LabelHelpers.getText(props, datum, index);
-      if (text !== undefined && text !== null || events || sharedEvents) {
-        childProps[eventKey].labels = LabelHelpers.getProps(props, index);
-      }
 
-      return childProps;
-    }, initialChildProps);
-  },
+const getCalculatedValues = (props) => {
+  const defaultStyles = props.theme && props.theme.voronoi && props.theme.voronoi.style ?
+    props.theme.voronoi.style : {};
+  const style = Helpers.getStyles(props.style, defaultStyles);
+  const data = Data.getData(props);
+  const range = {
+    x: Helpers.getRange(props, "x"),
+    y: Helpers.getRange(props, "y")
+  };
+  const domain = {
+    x: Domain.getDomain(props, "x"),
+    y: Domain.getDomain(props, "y")
+  };
+  const scale = {
+    x: Scale.getBaseScale(props, "x").domain(domain.x).range(range.x),
+    y: Scale.getBaseScale(props, "y").domain(domain.y).range(range.y)
+  };
+  const voronoi = getVoronoi(props, range, scale);
+  const polygons = voronoi.polygons(data);
+  const origin = props.polar ? props.origin || Helpers.getPolarOrigin(props) : undefined;
+  return { domain, data, scale, style, polygons, origin };
+};
 
-  getCalculatedValues(props) {
-    const defaultStyles = props.theme && props.theme.voronoi && props.theme.voronoi.style ?
-      props.theme.voronoi.style : {};
-    const style = Helpers.getStyles(props.style, defaultStyles);
-    const data = Data.getData(props);
-    const range = {
-      x: Helpers.getRange(props, "x"),
-      y: Helpers.getRange(props, "y")
+export const getBaseProps = (props, fallbackProps) => {
+  const modifiedProps = Helpers.modifyProps(props, fallbackProps, "scatter");
+  props = assign({}, modifiedProps, getCalculatedValues(modifiedProps));
+  const {
+    data, domain, events, height, origin, padding, polar, polygons,
+    scale, sharedEvents, standalone, style, theme, width
+  } = props;
+  const initialChildProps = { parent: {
+    style: style.parent, scale, domain, data, standalone, height, width, theme,
+    origin, polar, padding
+  } };
+
+  return data.reduce((childProps, datum, index) => {
+    const polygon = without(polygons[index], "data");
+    const eventKey = datum.eventKey;
+    const { x, y } = Helpers.scalePoint(props, datum);
+    const dataProps = {
+      x, y, datum, data, index, scale, polygon, origin,
+      size: props.size,
+      style: getDataStyles(datum, style.data)
     };
-    const domain = {
-      x: Domain.getDomain(props, "x"),
-      y: Domain.getDomain(props, "y")
-    };
-    const scale = {
-      x: Scale.getBaseScale(props, "x").domain(domain.x).range(range.x),
-      y: Scale.getBaseScale(props, "y").domain(domain.y).range(range.y)
-    };
-    const voronoi = this.getVoronoi(props, range, scale);
-    const polygons = voronoi.polygons(data);
-    const origin = props.polar ? props.origin || Helpers.getPolarOrigin(props) : undefined;
-    return { domain, data, scale, style, polygons, origin };
-  },
 
-  getVoronoi(props, range, scale) {
-    const minRange = [Math.min(...range.x), Math.min(...range.y)];
-    const maxRange = [Math.max(...range.x), Math.max(...range.y)];
-    const angleAccessor = (d) => {
-      const x = scale.x(d._x1 !== undefined ? d._x1 : d._x);
-      return -1 * x + Math.PI / 2;
-    };
-    const xAccessor = (d) => scale.x(d._x1 !== undefined ? d._x1 : d._x);
-    return d3Voronoi()
-      .x((d) => props.polar ? angleAccessor(d) : xAccessor(d))
-      .y((d) => scale.y(d._y1 !== undefined ? d._y1 : d._y))
-      .extent([minRange, maxRange]);
-  },
+    childProps[eventKey] = { data: dataProps };
+    const text = LabelHelpers.getText(props, datum, index);
+    if (text !== undefined && text !== null || events || sharedEvents) {
+      childProps[eventKey].labels = LabelHelpers.getProps(props, index);
+    }
 
-  getDataStyles(datum, style) {
-    const numKeys = keys(datum).filter((k) => isNaN(k));
-    const omitKeys = [
-      "x", "y", "_x", "_y", "eventKey", "label"
-    ];
-    const stylesFromData = omit(datum, [...omitKeys, ...numKeys]);
-    return defaults({}, stylesFromData, style);
-  }
+    return childProps;
+  }, initialChildProps);
 };

--- a/src/components/victory-voronoi/helper-methods.js
+++ b/src/components/victory-voronoi/helper-methods.js
@@ -49,7 +49,7 @@ const getCalculatedValues = (props) => {
   return { domain, data, scale, style, polygons, origin };
 };
 
-export const getBaseProps = (props, fallbackProps) => {
+const getBaseProps = (props, fallbackProps) => {
   const modifiedProps = Helpers.modifyProps(props, fallbackProps, "scatter");
   props = assign({}, modifiedProps, getCalculatedValues(modifiedProps));
   const {
@@ -80,3 +80,5 @@ export const getBaseProps = (props, fallbackProps) => {
     return childProps;
   }, initialChildProps);
 };
+
+export { getBaseProps };

--- a/src/components/victory-voronoi/victory-voronoi.js
+++ b/src/components/victory-voronoi/victory-voronoi.js
@@ -4,7 +4,7 @@ import {
   PropTypes as CustomPropTypes, Helpers, VictoryLabel, addEvents,
   VictoryContainer, VictoryTheme, DefaultTransitions, Voronoi, Data, Domain
 } from "victory-core";
-import VoronoiHelpers from "./helper-methods";
+import { getBaseProps } from "./helper-methods";
 import { BaseProps, DataProps } from "../../helpers/common-props";
 
 const fallbackProps = {
@@ -42,8 +42,7 @@ class VictoryVoronoi extends React.Component {
 
   static getDomain = Domain.getDomain.bind(Domain);
   static getData = Data.getData.bind(Data);
-  static getBaseProps = partialRight(
-    VoronoiHelpers.getBaseProps.bind(VoronoiHelpers), fallbackProps);
+  static getBaseProps = partialRight(getBaseProps.bind(getBaseProps), fallbackProps);
   static expectedComponents = [
     "dataComponent", "labelComponent", "groupComponent", "containerComponent"
   ];

--- a/src/components/victory-voronoi/victory-voronoi.js
+++ b/src/components/victory-voronoi/victory-voronoi.js
@@ -42,7 +42,7 @@ class VictoryVoronoi extends React.Component {
 
   static getDomain = Domain.getDomain.bind(Domain);
   static getData = Data.getData.bind(Data);
-  static getBaseProps = partialRight(getBaseProps.bind(getBaseProps), fallbackProps);
+  static getBaseProps = partialRight(getBaseProps, fallbackProps);
   static expectedComponents = [
     "dataComponent", "labelComponent", "groupComponent", "containerComponent"
   ];

--- a/test/client/spec/components/victory-area/helper-methods.spec.js
+++ b/test/client/spec/components/victory-area/helper-methods.spec.js
@@ -1,7 +1,7 @@
 /* eslint no-unused-expressions: 0 */
 /* eslint-disable max-nested-callbacks */
 /* global sinon */
-import AreaHelpers from "src/components/victory-area/helper-methods";
+import { getDataWithBaseline } from "src/components/victory-area/helper-methods";
 import { Data } from "victory-core";
 
 describe("victory-area/helper-methods", () => {
@@ -34,7 +34,7 @@ describe("victory-area/helper-methods", () => {
 
     it("should return the minimum if yOffset is not present", () => {
       const props = { data };
-      const result = AreaHelpers.getDataWithBaseline(props, scale(defaultDomain));
+      const result = getDataWithBaseline(props, scale(defaultDomain));
       const expectedResult = [
         { _y0: 0, _y1: 1, _x: 1, _y: 1 }, { _y0: 0, _y1: 1, _x: 2, _y: 1 }
       ];
@@ -43,7 +43,7 @@ describe("victory-area/helper-methods", () => {
 
     it("should return the domain minimum when it is greater than zero", () => {
       const props = { data };
-      const result = AreaHelpers.getDataWithBaseline(props, scale(nonZeroDomain));
+      const result = getDataWithBaseline(props, scale(nonZeroDomain));
       const expectedResult = [
         { _y0: 1, _y1: 1, _x: 1, _y: 1 }, { _y0: 1, _y1: 1, _x: 2, _y: 1 }
       ];
@@ -52,7 +52,7 @@ describe("victory-area/helper-methods", () => {
 
     it("should return zero when the domain minimum is negative", () => {
       const props = { data };
-      const result = AreaHelpers.getDataWithBaseline(props, scale(negativeDomain));
+      const result = getDataWithBaseline(props, scale(negativeDomain));
       const expectedResult = [
         { _y0: 0, _y1: 1, _x: 1, _y: 1 }, { _y0: 0, _y1: 1, _x: 2, _y: 1 }
       ];
@@ -61,7 +61,7 @@ describe("victory-area/helper-methods", () => {
 
     it("should return yOffset if present", () => {
       const props = { data: stackedData };
-      const result = AreaHelpers.getDataWithBaseline(props, scale(defaultDomain));
+      const result = getDataWithBaseline(props, scale(defaultDomain));
       const expectedResult = stackedData;
       expect(result).to.eql(expectedResult);
     });

--- a/test/client/spec/components/victory-candlestick/helper-methods.spec.js
+++ b/test/client/spec/components/victory-candlestick/helper-methods.spec.js
@@ -1,6 +1,6 @@
 /* eslint no-unused-expressions: 0 */
 /* eslint max-nested-callbacks: 0 */
-import Helpers from "src/components/victory-candlestick/helper-methods";
+import { getData, getDomain } from "src/components/victory-candlestick/helper-methods";
 import { range } from "lodash";
 import { fromJS } from "immutable";
 
@@ -19,7 +19,7 @@ const getDataTest = {
       const dataSet = createData([{ x: 5, open: 10, close: 20, high: 25, low: 5 }]);
 
       it("returns an object with an array of y values", () => {
-        const dataResult = Helpers.getData({ data: dataSet, x: "x", open: "open",
+        const dataResult = getData({ data: dataSet, x: "x", open: "open",
         close: "close", high: "high", low: "low" });
         expect(dataResult[0]._y).to.eql([10, 20, 25, 5]);
       });
@@ -29,7 +29,7 @@ const getDataTest = {
           range(5).map((i) => ({ x: i, open: i, close: i, high: i, low: i })).reverse()
         );
 
-        const dataResult = Helpers.getData({ data, x: "x", open: "open",
+        const dataResult = getData({ data, x: "x", open: "open",
         close: "close", high: "high", low: "low", sortKey: "x" });
 
         expect(dataResult.map((datum) => datum.x)).to.eql([0, 1, 2, 3, 4]);
@@ -43,13 +43,13 @@ const getDataTest = {
       ]);
 
       it("returns a domain array for the x axis", () => {
-        const domainXResult = Helpers.getDomain({ data: dataSet, x: "x", open: "open",
+        const domainXResult = getDomain({ data: dataSet, x: "x", open: "open",
         close: "close", high: "high", low: "low" }, "x");
         expect(domainXResult).to.eql([5, 10]);
       });
 
       it("returns a domain array for the y axis", () => {
-        const domainYResult = Helpers.getDomain({ data: dataSet, open: "open",
+        const domainYResult = getDomain({ data: dataSet, open: "open",
         close: "close", high: "high", low: "low" }, "y");
         expect(domainYResult).to.eql([5, 30]);
       });

--- a/test/client/spec/components/victory-chart/helper-methods.spec.js
+++ b/test/client/spec/components/victory-chart/helper-methods.spec.js
@@ -1,6 +1,8 @@
 /* global sinon */
 /* eslint-disable no-unused-expressions,react/no-multi-comp */
-import Helpers from "src/components/victory-chart/helper-methods";
+import {
+  getChildComponents, getDataComponents, getDomain, createStringMap
+} from "src/components/victory-chart/helper-methods";
 import React from "react";
 import { VictoryAxis, VictoryLine, VictoryBar } from "src/index";
 import { Log, Data } from "victory-core";
@@ -29,7 +31,7 @@ describe("victory-chart/helpers-methods", () => {
 
     it("returns a pair of default axes when no children are given", () => {
       const children = [];
-      const result = Helpers.getChildComponents({ children }, defaultAxes);
+      const result = getChildComponents({ children }, defaultAxes);
       expect(result).to.have.length(2);
       expect(result).to.deep.include.members([defaultAxes.independent, defaultAxes.dependent]);
     });
@@ -37,7 +39,7 @@ describe("victory-chart/helpers-methods", () => {
     it("adds default axes when none of the children are axis components", () => {
       const line = getVictoryLine({});
       const children = [line];
-      const result = Helpers.getChildComponents({ children }, defaultAxes);
+      const result = getChildComponents({ children }, defaultAxes);
       expect(result).to.have.length(3);
       expect(result).to.deep.include.members([
         defaultAxes.independent, defaultAxes.dependent
@@ -47,7 +49,7 @@ describe("victory-chart/helpers-methods", () => {
     it("does not add default axes if axis any axis components exist in children", () => {
       const axis = getVictoryAxis({});
       const children = [axis];
-      const result = Helpers.getChildComponents({ children }, defaultAxes);
+      const result = getChildComponents({ children }, defaultAxes);
       expect(result).to.have.length(1);
       expect(result[0].props).to.eql(axis.props);
     });
@@ -57,7 +59,7 @@ describe("victory-chart/helpers-methods", () => {
         getVictoryAxis({ orientation: "top" }),
         getVictoryAxis({ orientation: "right" })
       ];
-      const result = Helpers.getChildComponents({ children }, defaultAxes);
+      const result = getChildComponents({ children }, defaultAxes);
       expect(result).to.have.length(1);
       expect(result[0].props).to.eql(children[0].props);
     });
@@ -70,7 +72,7 @@ describe("victory-chart/helpers-methods", () => {
     const childComponents = [bar, line, axis];
 
     it("returns data components but not axis components", () => {
-      const componentResult = Helpers.getDataComponents(childComponents);
+      const componentResult = getDataComponents(childComponents);
       expect(componentResult).to.have.members([bar, line]);
       expect(componentResult).not.to.have.members([axis]);
     });
@@ -94,7 +96,7 @@ describe("victory-chart/helpers-methods", () => {
 
     it("calculates a domain from props", () => {
       const props = { domain: { x: [1, 2], y: [2, 3] } };
-      const domainResultX = Helpers.getDomain(props, "x", childComponents);
+      const domainResultX = getDomain(props, "x", childComponents);
       expect(Wrapper.getDomain).calledWith(props, "x", childComponents).and.returned([1, 2]);
       expect(victoryLine.type.getDomain).notCalled;
       expect(domainResultX).to.eql([1, 2]);
@@ -103,7 +105,7 @@ describe("victory-chart/helpers-methods", () => {
     it("calculates a domain from child components", () => {
       const props = {};
       const polarProps = { polar: undefined, startAngle: undefined, endAngle: undefined };
-      const domainResultX = Helpers.getDomain(props, "x", childComponents);
+      const domainResultX = getDomain(props, "x", childComponents);
       expect(Wrapper.getDomain).calledWith(props, "x", childComponents);
       expect(victoryLine.type.getDomain).calledWith(assign({}, victoryLine.props, polarProps));
       expect(domainResultX).to.eql(victoryLine.props.domain);
@@ -128,7 +130,7 @@ describe("victory-chart/helpers-methods", () => {
       const props = {};
       const axisComponent = getVictoryAxis({ tickValues: ["a", "b", "c"] });
       const childComponents = [axisComponent];
-      const stringResult = Helpers.createStringMap(props, "x", childComponents);
+      const stringResult = createStringMap(props, "x", childComponents);
       expect(Wrapper.getStringsFromChildren).calledWith(props, "x", childComponents)
         .and.returned(["a", "b", "c"]);
       expect(Data.getStringsFromAxes).calledWith(axisComponent.props, "x")
@@ -145,7 +147,7 @@ describe("victory-chart/helpers-methods", () => {
       const axisComponent = getVictoryAxis({ tickValues: ["c", "d"] });
       const lineComponent = getVictoryLine({ data: [{ x: "a", y: 1 }, { x: "b", y: 1 }] });
       const childComponents = [axisComponent, lineComponent];
-      const stringResult = Helpers.createStringMap(props, "x", childComponents);
+      const stringResult = createStringMap(props, "x", childComponents);
       expect(Wrapper.getStringsFromChildren).calledWith(props, "x", childComponents)
         .and.returned(["a", "b", "c", "d"]);
       expect(Data.getStringsFromAxes).calledWith(axisComponent.props, "x")


### PR DESCRIPTION
Issue: [#650](https://github.com/FormidableLabs/victory/issues/650).
See [#168](https://github.com/FormidableLabs/victory-pie/pull/168) for a very similar PR on the Victory-Pie project.

- Export all methods individually as named exports, instead of export all helpers as a default export in the form of an object
- Reorder the method definitions to counter eslint's no-use-before-define errors. This makes the diff look mighty weird, so it might be easier to look at the individual commits' diff

We could not find a clean way to convert classes that were tested using sinon.stub() so we did not refactor them