### PR TITLE
check on labels prop before computing base props for labels

### DIFF
--- a/demo/components/victory-boxplot-demo.js
+++ b/demo/components/victory-boxplot-demo.js
@@ -76,6 +76,7 @@ export default class App extends React.Component {
         <VictoryChart style={chartStyle} domain={{ x: [0, 20], y: [0, 3] }}>
           <VictoryBoxPlot
             minLabels maxLabels
+            q1Labels={() => ""}
             whiskerWidth={50}
             data={[{ y: 1, x: [5, 10, 9, 2] }, { y: 2, x: [1, 15, 6, 8] }]}
             boxWidth={20}

--- a/src/components/victory-area/helper-methods.js
+++ b/src/components/victory-area/helper-methods.js
@@ -44,7 +44,7 @@ const getBaseProps = (props, fallbackProps) => {
   props = assign({}, modifiedProps, getCalculatedValues(modifiedProps));
   const {
     data, domain, events, groupComponent, height, interpolation, origin, padding, polar,
-    scale, sharedEvents, standalone, style, theme, width
+    scale, sharedEvents, standalone, style, theme, width, labels
   } = props;
   const initialChildProps = {
     parent: {
@@ -57,7 +57,7 @@ const getBaseProps = (props, fallbackProps) => {
   };
   return data.reduce((childProps, datum, index) => {
     const text = LabelHelpers.getText(props, datum, index);
-    if (text !== undefined && text !== null || events || sharedEvents) {
+    if (text !== undefined && text !== null || (labels && events || sharedEvents)) {
       const eventKey = datum.eventKey || index;
       childProps[eventKey] = { labels: LabelHelpers.getProps(props, index) };
     }

--- a/src/components/victory-bar/helper-methods.js
+++ b/src/components/victory-bar/helper-methods.js
@@ -44,7 +44,7 @@ const getBaseProps = (props, fallbackProps) => {
   props = assign({}, modifiedProps, getCalculatedValues(modifiedProps));
   const {
     alignment, barRatio, cornerRadius, data, domain, events, height, horizontal, origin, padding,
-    polar, scale, sharedEvents, standalone, style, theme, width
+    polar, scale, sharedEvents, standalone, style, theme, width, labels
   } = props;
   const initialChildProps = { parent: {
     domain, scale, width, height, data, standalone,
@@ -65,7 +65,7 @@ const getBaseProps = (props, fallbackProps) => {
     };
 
     const text = LabelHelpers.getText(props, datum, index);
-    if (text !== undefined && text !== null || events || sharedEvents) {
+    if (text !== undefined && text !== null || (labels && events || sharedEvents)) {
       childProps[eventKey].labels = LabelHelpers.getProps(props, index);
     }
     return childProps;

--- a/src/components/victory-boxplot/helper-methods.js
+++ b/src/components/victory-boxplot/helper-methods.js
@@ -367,7 +367,11 @@ const getBaseProps = (props, fallbackProps) => {
 
     TYPES.forEach((type) => {
       const labelText = getText(dataProps, type);
-      if (labelText !== null && typeof labelText !== undefined || !events || !sharedEvents) {
+      const labelProp = props.labels || props[`${type}Labels`];
+      if (
+        labelText !== null && typeof labelText !== undefined ||
+        labelProp && (events || sharedEvents)
+      ) {
         const target = `${type}Labels`;
         acc[eventKey][target] = getLabelProps(dataProps, labelText, type);
       }

--- a/src/components/victory-boxplot/helper-methods.js
+++ b/src/components/victory-boxplot/helper-methods.js
@@ -347,7 +347,7 @@ const getBaseProps = (props, fallbackProps) => {
   const boxScale = horizontal ? scale.x : scale.y;
 
   return data.reduce((acc, datum, index) => {
-    const eventKey = typeof datum.eventKey !== undefined ? datum.eventKey : index;
+    const eventKey = typeof datum.eventKey !== "undefined" ? datum.eventKey : index;
     const positions = {
       x: scale.x(datum._x),
       y: scale.y(datum._y),
@@ -369,7 +369,7 @@ const getBaseProps = (props, fallbackProps) => {
       const labelText = getText(dataProps, type);
       const labelProp = props.labels || props[`${type}Labels`];
       if (
-        labelText !== null && typeof labelText !== undefined ||
+        labelText !== null && typeof labelText !== "undefined" ||
         labelProp && (events || sharedEvents)
       ) {
         const target = `${type}Labels`;

--- a/src/components/victory-candlestick/helper-methods.js
+++ b/src/components/victory-candlestick/helper-methods.js
@@ -150,7 +150,7 @@ const getBaseProps = (props, fallbackProps) => { // eslint-disable-line max-stat
   const { data, style, scale, domain, origin } = calculatedValues;
   const {
     groupComponent, width, height, padding, standalone,
-    theme, polar, wickStrokeWidth
+    theme, polar, wickStrokeWidth, labels, events, sharedEvents
   } = props;
   const initialChildProps = { parent: {
     domain, scale, width, height, data, standalone, theme, polar, origin,
@@ -175,7 +175,7 @@ const getBaseProps = (props, fallbackProps) => { // eslint-disable-line max-stat
       data: dataProps
     };
     const text = LabelHelpers.getText(props, datum, index);
-    if (text !== undefined && text !== null || props.events || props.sharedEvents) {
+    if (text !== undefined && text !== null || (labels && events || sharedEvents)) {
       childProps[eventKey].labels = getLabelProps(dataProps, text, style);
     }
 

--- a/src/components/victory-errorbar/helper-methods.js
+++ b/src/components/victory-errorbar/helper-methods.js
@@ -203,7 +203,10 @@ const getDataStyles = (datum, style) => {
 const getBaseProps = (props, fallbackProps) => {
   props = Helpers.modifyProps(props, fallbackProps, "errorbar");
   const { data, style, scale, domain, origin } = getCalculatedValues(props, fallbackProps);
-  const { groupComponent, height, width, borderWidth, standalone, theme, polar, padding } = props;
+  const {
+    groupComponent, height, width, borderWidth, standalone, theme, polar, padding,
+    labels, events, sharedEvents
+  } = props;
   const initialChildProps = { parent: {
     domain, scale, data, height, width, standalone, theme, polar, origin,
     padding, style: style.parent
@@ -225,7 +228,7 @@ const getBaseProps = (props, fallbackProps) => {
       data: dataProps
     };
     const text = LabelHelpers.getText(props, datum, index);
-    if (text !== undefined && text !== null || props.events || props.sharedEvents) {
+    if (text !== undefined && text !== null || (labels && events || sharedEvents)) {
       childProps[eventKey].labels = getLabelProps(dataProps, text, style);
     }
 

--- a/src/components/victory-line/helper-methods.js
+++ b/src/components/victory-line/helper-methods.js
@@ -33,7 +33,7 @@ const getBaseProps = (props, fallbackProps) => {
   props = assign({}, modifiedProps, getCalculatedValues(modifiedProps));
   const {
     data, domain, events, groupComponent, height, interpolation, origin, padding, polar,
-    scale, sharedEvents, standalone, style, theme, width
+    scale, sharedEvents, standalone, style, theme, width, labels
   } = props;
   const initialChildProps = {
     parent: {
@@ -45,7 +45,7 @@ const getBaseProps = (props, fallbackProps) => {
   };
   return data.reduce((childProps, datum, index) => {
     const text = LabelHelpers.getText(props, datum, index);
-    if (text !== undefined && text !== null || events || sharedEvents) {
+    if (text !== undefined && text !== null || (labels && events || sharedEvents)) {
       const eventKey = datum.eventKey || index;
       childProps[eventKey] = { labels: LabelHelpers.getProps(props, index) };
     }

--- a/src/components/victory-scatter/helper-methods.js
+++ b/src/components/victory-scatter/helper-methods.js
@@ -7,7 +7,7 @@ export default {
     props = assign({}, modifiedProps, this.getCalculatedValues(modifiedProps));
     const {
       data, domain, events, height, origin, padding, polar, scale,
-      sharedEvents, standalone, style, theme, width
+      sharedEvents, standalone, style, theme, width, labels
     } = props;
     const initialChildProps = { parent: {
       style: style.parent, scale, domain, data, height, width, standalone, theme,
@@ -26,7 +26,7 @@ export default {
 
       childProps[eventKey] = { data: dataProps };
       const text = LabelHelpers.getText(props, datum, index);
-      if (text !== undefined && text !== null || events || sharedEvents) {
+      if (text !== undefined && text !== null || (labels && events || sharedEvents)) {
         childProps[eventKey].labels = LabelHelpers.getProps(props, index);
       }
 

--- a/src/components/victory-voronoi/helper-methods.js
+++ b/src/components/victory-voronoi/helper-methods.js
@@ -49,7 +49,7 @@ const getBaseProps = (props, fallbackProps) => {
   props = assign({}, modifiedProps, getCalculatedValues(modifiedProps));
   const {
     data, domain, events, height, origin, padding, polar, polygons,
-    scale, sharedEvents, standalone, style, theme, width
+    scale, sharedEvents, standalone, style, theme, width, labels
   } = props;
   const initialChildProps = { parent: {
     style: style.parent, scale, domain, data, standalone, height, width, theme,
@@ -68,7 +68,7 @@ const getBaseProps = (props, fallbackProps) => {
 
     childProps[eventKey] = { data: dataProps };
     const text = LabelHelpers.getText(props, datum, index);
-    if (text !== undefined && text !== null || events || sharedEvents) {
+    if (text !== undefined && text !== null || (labels && events || sharedEvents)) {
       childProps[eventKey].labels = LabelHelpers.getProps(props, index);
     }
 


### PR DESCRIPTION
cc/ @chrisbolin 

This PR checks on the existence of a `labels` prop (or corresponding prop) rather than calculating base props for labels any time there are events. This will be a breaking change for some small number of users, but the upgrade path is simple. Those impacted will just need to add `labels={() => null}` or similar.