### PR TITLE
Update changelog and victory core dep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,48 @@
 # VictoryChart Changelog
 
+## 26.0.0 (2018-04-21)
+
+**Breaking Changes**
+
+-[587](https://github.com/FormidableLabs/victory-chart/pull/587) Disable styles on data
+
+This change deprecates Victory's ability to automatically pick up style attributes from the data object. This change will improve performance, but will be a breaking change for many users. Fortunately the upgrade path is simple:
+
+If your data object looks like
+```
+data={[
+  { x: 1, y: 1, fill: "red", opacity: 0.2 },
+  ...
+]}
+```
+Add the following functional styles:
+```
+style={{ data:  { fill: (d) => d.fill, opacity: (d) => d.opacity } }}
+```
+and everything will work as before.
+
+-[584](https://github.com/FormidableLabs/victory-chart/pull/584) Check for labels prop before computing baseProps for labels
+
+Base props for labels will no longer be pre-calculated unless a labels prop exists. This change improves performance, but it will be a breaking change for users who were using events for adding labels to elements that did not already have them using an event mutation like:
+
+```
+events={[{
+  target: "data",
+  eventHandlers: {
+    onClick: () => {
+      return [{ target: "labels", mutation: () => ({ text: "clicked" }) }];
+    }
+  }
+}]}
+```
+If you are using this pattern, you can make labels work as expected by adding a dummy labels prop like: `labels={() => null}`
+
+Note: This change _does not_ affect tooltips, which exist, but are invisible until they receive the `active` prop
+
+Other changes
+-[589](https://github.com/FormidableLabs/victory-chart/pull/589) Audit lodash methods
+-[583](https://github.com/FormidableLabs/victory-chart/pull/583) Perf improvement for `VictorySelectionContainer`
+
 ## 25.2.5 (2018-04-17)
 
 - [583](https://github.com/FormidableLabs/victory-chart/pull/583) Perf improvements for `VictorySelectionContainer` and general perf improvements from `victory-core@21.1.12`

--- a/package-lock.json
+++ b/package-lock.json
@@ -14354,9 +14354,9 @@
       }
     },
     "victory-core": {
-      "version": "21.1.12",
-      "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-21.1.12.tgz",
-      "integrity": "sha512-GnUfYAJSZDtEwp+GUi5Oj1abIyWsENEht31a40QZCk0up7Lm2lQqabsDylhcRVwl5M+g3UK/yX6Gep5YpCdSEg==",
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-22.0.0.tgz",
+      "integrity": "sha512-M2dWN4MEFi+UyQcc9rb2ad2UXg982QjPj+GyCT81/o66N2NYwrkokcZN+SumChzUq5ZFMmcuX+f1IUWpyN9FPw==",
       "requires": {
         "d3-ease": "1.0.3",
         "d3-interpolate": "1.1.6",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "d3-voronoi": "^1.1.2",
     "lodash": "^4.17.5",
     "react-fast-compare": "^1.0.0",
-    "victory-core": "^21.1.12"
+    "victory-core": "^22.0.0"
   },
   "devDependencies": {
     "@storybook/addon-options": "^3.1.2",


### PR DESCRIPTION
**Breaking Changes**

-[587](https://github.com/FormidableLabs/victory-chart/pull/587) Disable styles on data

This change deprecates Victory's ability to automatically pick up style attributes from the data object. This change will improve performance, but will be a breaking change for many users. Fortunately the upgrade path is simple:

If your data object looks like
```
data={[
  { x: 1, y: 1, fill: "red", opacity: 0.2 },
  ...
]}
```
Add the following functional styles:
```
style={{ data:  { fill: (d) => d.fill, opacity: (d) => d.opacity } }}
```
and everything will work as before.

-[584](https://github.com/FormidableLabs/victory-chart/pull/584) Check for labels prop before computing baseProps for labels

Base props for labels will no longer be pre-calculated unless a labels prop exists. This change improves performance, but it will be a breaking change for users who were using events for adding labels to elements that did not already have them using an event mutation like:

```
events={[{
  target: "data",
  eventHandlers: {
    onClick: () => {
      return [{ target: "labels", mutation: () => ({ text: "clicked" }) }];
    }
  }
}]}
```
If you are using this pattern, you can make labels work as expected by adding a dummy labels prop like: `labels={() => null}`

Note: This change _does not_ affect tooltips, which exist, but are invisible until they receive the `active` prop

Other changes
-[589](https://github.com/FormidableLabs/victory-chart/pull/589) Audit lodash methods
-[583](https://github.com/FormidableLabs/victory-chart/pull/583) Perf improvement for `VictorySelectionContainer`