### PR TITLE
Add guard to VictoryStack's addLayoutData

### DIFF
--- a/src/components/victory-stack/victory-stack.js
+++ b/src/components/victory-stack/victory-stack.js
@@ -120,6 +120,9 @@ export default class VictoryStack extends React.Component {
 
   /* eslint-disable max-params, no-nested-ternary */
   addLayoutData(props, calculatedProps, datasets, index) {
+    if (!datasets[index]) {
+      return [];
+    }
     const xOffset = props.xOffset || 0;
     return datasets[index].map((datum) => {
       const yOffset = Wrapper.getY0(datum, index, calculatedProps) || 0;


### PR DESCRIPTION
Closes FormidableLabs/victory#1000

This does not address underlying issue of the index from `childComponents` being used to access `datasets` when `childComponents.length` does not equal `datasets.length`. 