### PR TITLE
Feature/allow draw

### DIFF
--- a/demo/components/victory-brush-container-demo.js
+++ b/demo/components/victory-brush-container-demo.js
@@ -100,7 +100,7 @@ class App extends React.Component {
             height={400}
             padding={{ top: 100, bottom: 50, left: 50, right: 50 }}
             containerComponent={
-              <VictoryBrushContainer brushDomain={{ x: [2, 4], y: [-2, 2] }} allowResize={false}/>
+              <VictoryBrushContainer brushDomain={{ x: [2, 4], y: [-2, 2] }} allowDraw={false}/>
             }
           >
             <VictoryLegend x={120} y={20}

--- a/src/components/addons/victory-brush-line.js
+++ b/src/components/addons/victory-brush-line.js
@@ -97,6 +97,7 @@ const fallbackProps = {
 export default class VictoryBrushLine extends React.Component {
   static propTypes = {
     allowDrag: PropTypes.bool,
+    allowDraw: PropTypes.bool,
     allowResize: PropTypes.bool,
     brushAreaComponent: PropTypes.element,
     brushAreaStyle: PropTypes.object,
@@ -125,6 +126,7 @@ export default class VictoryBrushLine extends React.Component {
 
   static defaultProps = {
     allowDrag: true,
+    allowDraw: true,
     allowResize: true,
     brushAreaComponent: <Box/>,
     brushComponent: <Box/>,
@@ -159,7 +161,9 @@ export default class VictoryBrushLine extends React.Component {
         },
         onMouseDown: (evt, targetProps) => {
           evt.preventDefault();
-          const { allowResize, allowDrag, dimension, activeBrushes, brushDomain } = targetProps;
+          const {
+            allowResize, allowDrag, allowDraw, dimension, activeBrushes, brushDomain
+          } = targetProps;
 
           // Don't trigger events for static brushes
           if (!allowResize && !allowDrag) {
@@ -194,7 +198,7 @@ export default class VictoryBrushLine extends React.Component {
           } else {
             // if the event occurs outside the region, or if the whole domain is selected,
             // start a new selection
-            return allowResize ? [{
+            return allowDraw ? [{
               mutation: () => ({
                 isSelecting: allowResize,
                 brushDomain: null,

--- a/src/components/containers/brush-helpers.js
+++ b/src/components/containers/brush-helpers.js
@@ -174,7 +174,7 @@ const Helpers = {
     } else {
       // if the event occurs outside the region, or if the whole domain is selected,
       // start a new selection
-      return allowResize && allowDraw ? [{
+      return allowDraw ? [{
         target: "parent",
         mutation: () => ({
           isSelecting: allowResize, domainBox, fullDomainBox,

--- a/src/components/containers/brush-helpers.js
+++ b/src/components/containers/brush-helpers.js
@@ -123,7 +123,7 @@ const Helpers = {
   onMouseDown(evt, targetProps) { // eslint-disable-line max-statements
     evt.preventDefault();
     const {
-      brushDimension, handleWidth, cachedBrushDomain, domain, allowResize, allowDrag
+      brushDimension, handleWidth, cachedBrushDomain, domain, allowResize, allowDrag, allowDraw
     } = targetProps;
 
     // Don't trigger events for static brushes
@@ -174,7 +174,7 @@ const Helpers = {
     } else {
       // if the event occurs outside the region, or if the whole domain is selected,
       // start a new selection
-      return allowResize ? [{
+      return allowResize && allowDraw ? [{
         target: "parent",
         mutation: () => ({
           isSelecting: allowResize, domainBox, fullDomainBox,

--- a/src/components/containers/victory-brush-container.js
+++ b/src/components/containers/victory-brush-container.js
@@ -10,6 +10,7 @@ export const brushContainerMixin = (base) => class VictoryBrushContainer extends
   static propTypes = {
     ...VictoryContainer.propTypes,
     allowDrag: PropTypes.bool,
+    allowDraw: PropTypes.bool,
     allowResize: PropTypes.bool,
     brushComponent: PropTypes.element,
     brushDimension: PropTypes.oneOf(["x", "y"]),
@@ -28,6 +29,7 @@ export const brushContainerMixin = (base) => class VictoryBrushContainer extends
   static defaultProps = {
     ...VictoryContainer.defaultProps,
     allowDrag: true,
+    allowDraw: true,
     allowResize: true,
     brushComponent: <rect/>,
     brushStyle: {


### PR DESCRIPTION
Adds an `allowDraw` prop for more granular brush control.

Closes https://github.com/FormidableLabs/victory/issues/1010